### PR TITLE
specify require dependencies for python example

### DIFF
--- a/docs/WebSocket.md
+++ b/docs/WebSocket.md
@@ -179,6 +179,7 @@ a backoff period.
 ## Examples
 
 ### Python
+in this example you need to install `websocket-client` package , you can install it using `pip install websocket-client` or download it from [Pypi page](https://pypi.python.org/pypi/websocket-client) .
 
 #### Python producer
 


### PR DESCRIPTION
the python example require websocket-client to be installed .