### PR TITLE
Replace Collections.sort(list) with list.sort() to support earlier jdk-version than jdk-1.8.0_20

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheDefaultEvictionPolicy.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheDefaultEvictionPolicy.java
@@ -44,7 +44,7 @@ public class EntryCacheDefaultEvictionPolicy implements EntryCacheEvictionPolicy
         checkArgument(sizeToFree > 0);
         checkArgument(!caches.isEmpty());
 
-        Collections.sort(caches, reverseOrder());
+        caches.sort(reverseOrder());
 
         long totalSize = 0;
         for (EntryCache cache : caches) {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/AdminResource.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -207,7 +206,7 @@ public abstract class AdminResource extends PulsarWebResource {
             }
         }
 
-        Collections.sort(namespaces);
+        namespaces.sort(null);
         return namespaces;
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Namespaces.java
@@ -132,7 +132,7 @@ public class Namespaces extends AdminResource {
             throw new RestException(e);
         }
 
-        Collections.sort(namespaces);
+        namespaces.sort(null);
         return namespaces;
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -147,7 +147,7 @@ public class PersistentTopics extends AdminResource {
             throw new RestException(e);
         }
 
-        Collections.sort(destinations);
+        destinations.sort(null);
         return destinations;
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Properties.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Properties.java
@@ -58,7 +58,7 @@ public class Properties extends AdminResource {
 
         try {
             List<String> properties = globalZk().getChildren(path("policies"), false);
-            Collections.sort(properties);
+            properties.sort(null);
             return properties;
         } catch (Exception e) {
             log.error("[{}] Failed to get properties list", clientAppId(), e);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/NamespaceService.java
@@ -668,7 +668,7 @@ public class NamespaceService {
             // NoNode means there are no persistent topics for this namespace
         }
 
-        Collections.sort(destinations);
+        destinations.sort(null);
         return destinations;
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -72,7 +72,7 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
     private void pickAndScheduleActiveConsumer() {
         checkArgument(!consumers.isEmpty());
 
-        Collections.sort(consumers, (c1, c2) -> c1.consumerName().compareTo(c2.consumerName()));
+        consumers.sort((c1, c2) -> c1.consumerName().compareTo(c2.consumerName()));
 
         int index = partitionIndex % consumers.size();
         Consumer prevConsumer = activeConsumer.getAndSet(consumers.get(index));

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/NamespacesTest.java
@@ -198,12 +198,12 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     public void testGetNamespaces() throws Exception {
         List<String> expectedList = Lists.newArrayList(this.testLocalNamespaces.get(0).toString(),
                 this.testLocalNamespaces.get(1).toString());
-        Collections.sort(expectedList);
+        expectedList.sort(null);
         assertEquals(namespaces.getNamespacesForCluster(this.testProperty, this.testLocalCluster), expectedList);
         expectedList = Lists.newArrayList(this.testLocalNamespaces.get(0).toString(),
                 this.testLocalNamespaces.get(1).toString(), this.testLocalNamespaces.get(2).toString(),
                 this.testGlobalNamespaces.get(0).toString());
-        Collections.sort(expectedList);
+        expectedList.sort(null);
         assertEquals(namespaces.getPropertyNamespaces(this.testProperty), expectedList);
 
         try {
@@ -620,7 +620,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         namespaces.deleteNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName(), false);
         List<String> nsList = Lists.newArrayList(this.testLocalNamespaces.get(1).toString(),
                 this.testLocalNamespaces.get(2).toString());
-        Collections.sort(nsList);
+        nsList.sort(null);
         assertEquals(namespaces.getPropertyNamespaces(this.testProperty), nsList);
 
         testNs = this.testLocalNamespaces.get(1);

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentLongHashMapTest.java
@@ -253,21 +253,21 @@ public class ConcurrentLongHashMapTest {
         map.put(2, "two");
 
         List<Long> keys = map.keys();
-        Collections.sort(keys);
+        keys.sort(null);
         assertEquals(keys, Lists.newArrayList(0l, 1l, 2l));
 
         List<String> values = map.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList("one", "two", "zero"));
 
         map.put(1, "uno");
 
         keys = map.keys();
-        Collections.sort(keys);
+        keys.sort(null);
         assertEquals(keys, Lists.newArrayList(0l, 1l, 2l));
 
         values = map.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList("two", "uno", "zero"));
 
         map.clear();

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentOpenHashMapTest.java
@@ -239,21 +239,21 @@ public class ConcurrentOpenHashMapTest {
         map.put(2l, "two");
 
         List<Long> keys = map.keys();
-        Collections.sort(keys);
+        keys.sort(null);
         assertEquals(keys, Lists.newArrayList(0l, 1l, 2l));
 
         List<String> values = map.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList("one", "two", "zero"));
 
         map.put(1l, "uno");
 
         keys = map.keys();
-        Collections.sort(keys);
+        keys.sort(null);
         assertEquals(keys, Lists.newArrayList(0l, 1l, 2l));
 
         values = map.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList("two", "uno", "zero"));
 
         map.clear();

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentOpenHashSetTest.java
@@ -226,7 +226,7 @@ public class ConcurrentOpenHashSetTest {
         set.add(2l);
 
         List<Long> values = set.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList(0l, 1l, 2l));
 
         set.clear();
@@ -244,14 +244,14 @@ public class ConcurrentOpenHashSetTest {
         set.add(7);
 
         List<Integer> values = set.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList(0, 1, 3, 6, 7));
 
         int numOfItemsDeleted = set.removeIf(i -> i < 5);
         assertEquals(numOfItemsDeleted, 3);
         assertEquals(set.size(), values.size() - numOfItemsDeleted);
         values = set.values();
-        Collections.sort(values);
+        values.sort(null);
         assertEquals(values, Lists.newArrayList(6, 7));
     }
 


### PR DESCRIPTION
### Motivation

jdk version before 1.8.0_20 calls set() on iterator while performing ```Collections.sort()``` which throws ```UnsupportedOperationException```. So, replacing ```Collections.sort()``` with ```list.sort()```

### Modifications
Replacing ```Collections.sort()``` with ```list.sort()```

### Result
It will fix ```java.lang.UnsupportedOperationException``` while sorting list.
