### PR TITLE
Status file path should not be required in configuration

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -75,7 +75,7 @@ clientLibraryVersionCheckAllowUnversioned=true
 
 # Path for the file used to determine the rotation status for the broker when responding
 # to service discovery health checks
-statusFilePath=/usr/local/apache/htdocs
+statusFilePath=
 
 ### --- Authentication --- ###
 

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -77,7 +77,6 @@ public class ServiceConfiguration {
     private boolean clientLibraryVersionCheckAllowUnversioned = true;
     // Path for the file used to determine the rotation status for the broker
     // when responding to service discovery health checks
-    @FieldContext(required = true)
     private String statusFilePath;
 
     /***** --- TLS --- ****/


### PR DESCRIPTION
### Motivation

Status file for external health-check monitoring should not be required in configuration.

### Modifications

Remove the requirement for the field to be set in broker.conf

