### PR TITLE
While closing-topic: remove producer from set in separate thread than same set-iterator thread

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Producer.java
@@ -328,8 +328,10 @@ public class Producer {
     public CompletableFuture<Void> disconnect() {
         if (!closeFuture.isDone()) {
             log.info("Disconnecting producer: {}", this);
-            cnx.closeProducer(this);
-            closeNow();
+            cnx.ctx().executor().execute(() -> {
+                cnx.closeProducer(this);
+                closeNow();
+            });
         }
         return closeFuture;
     }


### PR DESCRIPTION
### Motivation

While closing [topic](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java#L512): Closing-topic thread iterates over ```producers``` typeof  ```ConcurrentOpenHashSet``` and try to remove element from same Set and in the same thread, which may cause deadlock. So, we need to remove producer-element from Set in different thread.

### Modifications

Remove closed-producer from Set in different thread.

### Result

It will avoid possible deadlock on ```ConcurrentOpenHashSet``` while closing topic.

