### PR TITLE
In managed ledger BK test, wait for background ledger roll-over to complete before shutting down

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -273,6 +273,9 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
             future.get();
         }
 
+        // Since in this test we roll-over the cursor ledger every 10 entries acknowledged, the background roll back
+        // might still be happening when the futures are completed.
+        Thread.sleep(1000);
         factory.shutdown();
     }
 


### PR DESCRIPTION
### Motivation

Described in #16: Intermittent test failure in ManagedLedgerBkTest.testConcurrentMarkDelete, 
the cursor is completing the roll-over after the futures are already completed.