### PR TITLE
Fix msg-acknowledge counter at client-stats

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerStats.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerStats.java
@@ -47,7 +47,6 @@ public class ConsumerStats implements Serializable {
     private final LongAdder numReceiveFailed;
     private final LongAdder numAcksSent;
     private final LongAdder numAcksFailed;
-    private final LongAdder numAcksTracker;
     private final LongAdder totalMsgsReceived;
     private final LongAdder totalBytesReceived;
     private final LongAdder totalReceiveFailed;
@@ -64,7 +63,6 @@ public class ConsumerStats implements Serializable {
         numReceiveFailed = null;
         numAcksSent = null;
         numAcksFailed = null;
-        numAcksTracker = null;
         totalMsgsReceived = null;
         totalBytesReceived = null;
         totalReceiveFailed = null;
@@ -82,7 +80,6 @@ public class ConsumerStats implements Serializable {
         numReceiveFailed = new LongAdder();
         numAcksSent = new LongAdder();
         numAcksFailed = new LongAdder();
-        numAcksTracker = new LongAdder();
         totalMsgsReceived = new LongAdder();
         totalBytesReceived = new LongAdder();
         totalReceiveFailed = new LongAdder();
@@ -156,10 +153,6 @@ public class ConsumerStats implements Serializable {
         }
     }
 
-    void incrementNumAcksSent() {
-        numAcksSent.increment();
-    }
-
     void incrementNumAcksSent(long numAcks) {
         numAcksSent.add(numAcks);
     }
@@ -174,18 +167,6 @@ public class ConsumerStats implements Serializable {
 
     Timeout getStatTimeout() {
         return statTimeout;
-    }
-
-    void resetNumAckTracker() {
-        numAcksTracker.reset();
-    }
-
-    void incrementNumAcksTracker(final int numMessages) {
-        numAcksTracker.add(numMessages);
-    }
-
-    long getNumAcksTrackerSumThenReset() {
-        return numAcksTracker.sumThenReset();
     }
 
     void reset() {

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerStatsDisabled.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerStatsDisabled.java
@@ -31,11 +31,6 @@ public class ConsumerStatsDisabled extends ConsumerStats {
     }
 
     @Override
-    void incrementNumAcksSent() {
-        // Do nothing
-    }
-
-    @Override
     void incrementNumAcksSent(long numAcks) {
         // Do nothing
     }
@@ -43,22 +38,6 @@ public class ConsumerStatsDisabled extends ConsumerStats {
     @Override
     void incrementNumAcksFailed() {
         // Do nothing
-    }
-
-    @Override
-    void resetNumAckTracker() {
-        // Do nothing
-    }
-
-    @Override
-    void incrementNumAcksTracker(final int numMessages) {
-        // Do nothing
-    }
-
-    @Override
-    long getNumAcksTrackerSumThenReset() {
-        // Do nothing
-        return -1;
     }
 
 }


### PR DESCRIPTION
### Motivation

Corrected calculation for Client-Stats msg-acknowledgement counter.
- Right now, we increment msg-ack counter when we [receive](https://github.com/yahoo/pulsar/blob/master/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java#L641) message from broker
- and on next [acknowledgement](https://github.com/yahoo/pulsar/blob/master/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java#L399) on that consumer, we aggregate above captured number of received-message and set as a ack-message count. and this gives incorrect msg-ack count.

### Modifications

- For non-batch message: increment count when actually send acknowledgement to broker
- For batch message: increment count with number of msg in batch when ack received for all messages in the batch

### Result

It calculates correct msg-ack count.
