### PR TITLE
Prevent message-replay of already acknowledged messages

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -369,8 +369,10 @@ public interface ManagedCursor {
      *            callback object returning the list of entries
      * @param ctx
      *            opaque context
+     * @return skipped positions 
+     *              set of positions which are already deleted/acknowledged and skipped while replaying them
      */
-    public void asyncReplayEntries(Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx);
+    public Set<? extends Position> asyncReplayEntries(Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx);
 
     /**
      * Close the cursor and releases the associated resources.

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 @Test
 public class ManagedCursorContainerTest {
@@ -184,7 +185,8 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void asyncReplayEntries(Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx) {
+        public Set<? extends Position> asyncReplayEntries(Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx) {
+            return Sets.newConcurrentHashSet();
         }
 
         @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2072,10 +2072,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         c1.markDelete(p2);
 
         try {
-            c1.replayEntries(positions);
-            fail("Should fail");
+            // as mark-delete is at position: p2 it should read entry : p3
+            assertEquals(1, c1.replayEntries(positions).size());
         } catch (ManagedLedgerException e) {
-            // ok
+            fail("Should have not failed");
         }
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.TooManyRequestsException;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,7 +166,10 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
                 }
 
                 havePendingReplayRead = true;
-                cursor.asyncReplayEntries(messagesToReplayNow, this, ReadType.Replay);
+                Set<? extends Position> deletedMessages = cursor.asyncReplayEntries(messagesToReplayNow, this,
+                        ReadType.Replay);
+                // clear already acked positions from replay bucket
+                messagesToReplay.removeAll(deletedMessages);
             } else if (!havePendingRead) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule read of {} messages for {} consumers", name, messagesToRead,


### PR DESCRIPTION
### Motivation

In Race condition of: (1) message-redelivery-request and (2) ack-message: broker tries to replay already acked messages which results into invalid entry while replaying it and it keeps retrying reading of same entry. 
Right now, It happens only when consumer has already consumed all publish messages and broker receives redelivery of unack message request.

### Modifications

- filter out already acked messages before replaying it.
- remove already acked message from messageReplay bucket

### Result

Broker will ignore already acked message while replaying it.

