### PR TITLE
Correct an invalid null check

### DIFF
--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/client/cli/PulsarClientTool.java
@@ -16,6 +16,7 @@
 package com.yahoo.pulsar.client.cli;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.FileInputStream;
 import java.net.MalformedURLException;
@@ -90,7 +91,7 @@ public class PulsarClientTool {
 
     public int run(String[] args) {
         try {
-            if (this.serviceURL == null && this.serviceURL.isEmpty()) {
+            if (isBlank(this.serviceURL)) {
                 commandParser.usage();
                 return -1;
             }


### PR DESCRIPTION
### Motivation

The condition is simply wrong. It checks if serviceURL IS null, and then use it.
It causes NPE if serviceUrl is not specified in a config file.

### Modifications

Correct the condition to check if the variable is blank.

### Result

pulsar-client shows the usage without NPE.
