### PR TITLE
Revise null check of ServiceConfigureUtils

### DIFF
--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfigurationUtils.java
@@ -21,12 +21,14 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 public class ServiceConfigurationUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceConfigurationUtils.class);
 
     public static String getDefaultOrConfiguredAddress(String configuredAddress) {
-        if ( configuredAddress == null ) {
+        if (isBlank(configuredAddress)) {
             return unsafeLocalhostResolve();
         }
         return configuredAddress;


### PR DESCRIPTION
### Motivation

getDefaultOrConfiguredAddress method in ServiceConfigurationUtils class returns blank string when configuredAddress is blank.

### Modifications

The method had only null check.
I changed it to blank check.

### Result

The method returns localhost address when configuredAddress is blank.
