### PR TITLE
Add unack-message threshold to restrict consumer for receiving messages without acknowledging-msg up to the threshold

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -97,6 +97,11 @@ tlsTrustCertsFilePath=
 # Accept untrusted TLS certificate from client
 tlsAllowInsecureConnection=false
 
+# Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
+# messages to consumer once, this limit reaches until consumer starts acknowledging messages back. 
+# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction 
+maxUnackedMessagesPerConsumer=50000
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -70,6 +70,11 @@ clientLibraryVersionCheckAllowUnversioned=true
 # to service discovery health checks
 statusFilePath=/usr/local/apache/htdocs
 
+# Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
+# messages to consumer once, this limit reaches until consumer starts acknowledging messages back
+# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
+maxUnackedMessagesPerConsumer=50000
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -81,6 +81,10 @@ public class ServiceConfiguration {
     // Path for the file used to determine the rotation status for the broker
     // when responding to service discovery health checks
     private String statusFilePath;
+    // Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
+    // messages to consumer once, this limit reaches until consumer starts acknowledging messages back
+    // Using a value of 0, is disabling unackedMessage-limit check and consumer can receive messages without any restriction
+    private int maxUnackedMessagesPerConsumer = 50000;
 
     /***** --- TLS --- ****/
     // Enable TLS
@@ -403,6 +407,14 @@ public class ServiceConfiguration {
 
     public void setStatusFilePath(String statusFilePath) {
         this.statusFilePath = statusFilePath;
+    }
+    
+    public int getMaxUnackedMessagesPerConsumer() {
+        return maxUnackedMessagesPerConsumer;
+    }
+
+    public void setMaxUnackedMessagesPerConsumer(int maxUnackedMessagesPerConsumer) {
+        this.maxUnackedMessagesPerConsumer = maxUnackedMessagesPerConsumer;
     }
 
     public boolean isTlsEnabled() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -328,8 +328,9 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                 try {
                     PersistentSubscription subscription = subscriptions.computeIfAbsent(subscriptionName,
                             name -> new PersistentSubscription(PersistentTopic.this, cursor));
-
-                    Consumer consumer = new Consumer(subscription, subType, consumerId, consumerName, cnx,
+                    
+                    Consumer consumer = new Consumer(subscription, subType, consumerId, consumerName,
+                            brokerService.pulsar().getConfiguration().getMaxUnackedMessagesPerConsumer(), cnx,
                             cnx.getRole());
                     subscription.addConsumer(consumer);
                     if (!cnx.isActive()) {
@@ -835,6 +836,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                     destStatsStream.writePair("address", consumerStats.address);
                     destStatsStream.writePair("consumerName", consumerStats.consumerName);
                     destStatsStream.writePair("availablePermits", consumerStats.availablePermits);
+                    destStatsStream.writePair("unackedMessages", consumerStats.unackedMessages);
                     destStatsStream.writePair("connectedSince", consumerStats.connectedSince);
                     destStatsStream.writePair("msgRateOut", consumerStats.msgRateOut);
                     destStatsStream.writePair("msgThroughputOut", consumerStats.msgThroughputOut);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -192,7 +192,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 2. Add consumer
         Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, "Cons1"/* consumer name */,
-                serverCnx, "myrole-1");
+                50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertTrue(consumers.get(0).consumerName() == consumer1.consumerName());
@@ -209,7 +209,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 5. Add another consumer which does not change active consumer
         Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, "Cons2"/* consumer name */,
-                serverCnx, "myrole-1");
+                50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer1.consumerName());
@@ -217,7 +217,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 6. Add a consumer which changes active consumer
         Consumer consumer0 = new Consumer(sub, SubType.Exclusive, 0 /* consumer id */, "Cons0"/* consumer name */,
-                serverCnx, "myrole-1");
+                50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer0);
         consumers = pdfc.getConsumers();
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer0.consumerName());

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicTest.java
@@ -372,7 +372,7 @@ public class PersistentTopicTest {
 
         // 1. simple add consumer
         Consumer consumer = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, "Cons1"/* consumer name */,
-                serverCnx, "myrole-1");
+                50000, serverCnx, "myrole-1");
         sub.addConsumer(consumer);
         assertTrue(sub.getDispatcher().isConsumerConnected());
 
@@ -402,7 +402,7 @@ public class PersistentTopicTest {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentSubscription sub = new PersistentSubscription(topic, cursorMock);
         Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, "Cons1"/* consumer name */,
-                serverCnx, "myrole-1");
+                50000, serverCnx, "myrole-1");
         sub.addConsumer(consumer1);
 
         doAnswer(new Answer<Object>() {
@@ -424,7 +424,7 @@ public class PersistentTopicTest {
         try {
             Thread.sleep(10); /* delay to ensure that the ubsubscribe gets executed first */
             Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, "Cons2"/* consumer name */,
-                    serverCnx, "myrole-1");
+                    50000, serverCnx, "myrole-1");
         } catch (BrokerServiceException e) {
             assertTrue(e instanceof BrokerServiceException.SubscriptionFencedException);
         }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -54,6 +55,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.yahoo.pulsar.broker.service.persistent.PersistentTopic;
 import com.yahoo.pulsar.client.impl.ConsumerImpl;
+import com.yahoo.pulsar.client.util.FutureUtil;
 import com.yahoo.pulsar.common.api.PulsarDecoder;
 
 public class SimpleProducerConsumerTest extends ProducerConsumerBase {
@@ -957,4 +959,542 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             });
         }
     }
+    
+    /**
+     * Verify: Consumer stops receiving msg when reach unack-msg limit and 
+     * starts receiving once acks messages
+     * 1. Produce X (600) messages 
+     * 2. Consumer has receive size (10) and receive message without acknowledging
+     * 3. Consumer will stop receiving message after unAckThreshold = 500
+     * 4. Consumer acks messages and starts consuming remanining messages
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerBlockingWithUnAckedMessages() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
+        try {
+            final int unAckedMessagesBufferSize = 500;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 600;
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+            assertEquals(messages.size(), unAckedMessagesBufferSize);
+
+            // start acknowledging messages
+            messages.forEach(m -> {
+                try {
+                    consumer.acknowledge(m);
+                } catch (PulsarClientException e) {
+                    fail("ack failed", e);
+                }
+            });
+
+            // try to consume remaining messages
+            int remainingMessages = totalProducedMsgs - messages.size();
+            for (int i = 0; i < remainingMessages; i++) {
+                msg = consumer.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    log.info("Received message: " + new String(msg.getData()));
+                }
+            }
+
+            // total received-messages should match to produced messages
+            assertEquals(totalProducedMsgs, messages.size());
+            producer.close();
+            consumer.close();
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+    
+    /**
+     * Verify: iteration of 
+     * a. message receive w/o acking 
+     * b. stop receiving msg
+     * c. ack msgs
+     * d. started receiving msgs 
+     * 
+     * 1. Produce total X (1500) messages
+     * 2. Consumer consumes messages without acking until stop receiving 
+     * from broker due to reaching ack-threshold (500)
+     * 3. Consumer acks messages after stop getting messages 
+     * 4. Consumer again tries to consume messages
+     * 5. Consumer should be able to complete consuming all 1500 messages in 3 iteration (1500/500)
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerBlockingWithUnAckedMessagesMultipleIteration() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
+        try {
+            final int unAckedMessagesBufferSize = 500;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 1500;
+
+            // receiver consumes messages in iteration after acknowledging broker
+            final int totalReceiveIteration = totalProducedMsgs / unAckedMessagesBufferSize;
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            int totalReceivedMessages = 0;
+            // (2) Receive Messages
+            for (int j = 0; j < totalReceiveIteration; j++) {
+
+                Message msg = null;
+                List<Message> messages = Lists.newArrayList();
+                for (int i = 0; i < totalProducedMsgs; i++) {
+                    msg = consumer.receive(1, TimeUnit.SECONDS);
+                    if (msg != null) {
+                        messages.add(msg);
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+                // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+                assertEquals(messages.size(), unAckedMessagesBufferSize);
+
+                // start acknowledging messages
+                messages.forEach(m -> {
+                    try {
+                        consumer.acknowledge(m);
+                    } catch (PulsarClientException e) {
+                        fail("ack failed", e);
+                    }
+                });
+                totalReceivedMessages += messages.size();
+            }
+
+            // total received-messages should match to produced messages
+            assertEquals(totalReceivedMessages, totalProducedMsgs);
+            producer.close();
+            consumer.close();
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+    
+    
+    /**
+     * Verify: Consumer1 which doesn't send ack will not impact Consumer2 which sends ack for consumed message.
+     * 
+     * 
+     * @param batchMessageDelayMs
+     * @throws Exception
+     */
+    @Test
+    public void testMutlipleSharedConsumerBlockingWithUnAckedMessages() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
+        try {
+            final int maxUnackedMessages = 20;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 100;
+            int totalReceiveMessages = 0;
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+            Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+            
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            
+            // (2) Consumer1: consume without ack:
+            // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMessages++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+            assertEquals(messages.size(), maxUnackedMessages);
+
+            // (3.1) Consumer2 will start consuming messages without ack: it should stop after maxUnackedMessages
+            messages.clear();
+            for (int i = 0; i < totalProducedMsgs - maxUnackedMessages; i++) {
+                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMessages++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            assertEquals(messages.size(), maxUnackedMessages);
+            // (3.2) ack for all maxUnackedMessages
+            messages.forEach(m -> {
+                try {
+                    consumer2.acknowledge(m);
+                } catch (PulsarClientException e) {
+                    fail("shouldn't have failed ", e);
+                }
+            });
+
+            // (4) Consumer2 consumer and ack: so it should consume all remaining messages
+            messages.clear();
+            for (int i = 0; i < totalProducedMsgs - (2 * maxUnackedMessages); i++) {
+                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMessages++;
+                    consumer2.acknowledge(msg);
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+
+            // verify total-consumer messages = total-produce messages
+            assertEquals(totalProducedMsgs, totalReceiveMessages);
+            producer.close();
+            consumer1.close();
+            consumer2.close();
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+    
+    @Test
+    public void testUnackBlockRedeliverMessages() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
+        int totalReceiveMsg = 0;
+        try {
+            final int unAckedMessagesBufferSize = 10;
+            final int receiverQueueSize = 20;
+            final int totalProducedMsgs = 100;
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMsg++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+
+            consumer.redeliverUnacknowledgedMessages();
+
+            Thread.sleep(1000);
+            int alreadyConsumedMessages = messages.size();
+            messages.clear();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    consumer.acknowledge(msg);
+                    totalReceiveMsg++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+
+            // total received-messages should match to produced messages
+            assertEquals(totalProducedMsgs + alreadyConsumedMessages, totalReceiveMsg);
+            producer.close();
+            consumer.close();
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+    
+    @Test(dataProvider = "batch")
+    public void testUnackedBlockAtBatch(int batchMessageDelayMs) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
+        try {
+            final int maxUnackedMessages = 20;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 100;
+            int totalReceiveMessages = 0;
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+            
+            if (batchMessageDelayMs != 0) {
+                producerConf.setBatchingEnabled(true);
+                producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+                producerConf.setBatchingMaxMessages(5);
+            }
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                futures.add(producer.sendAsync(message.getBytes()));
+            }
+
+            FutureUtil.waitForAll(futures).get();
+            
+            // (2) Consumer1: consume without ack:
+            // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMessages++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            // should be blocked due to unack-msgs and should not consume all msgs
+            assertNotEquals(messages.size(), totalProducedMsgs);
+            // ack for all maxUnackedMessages
+            messages.forEach(m -> {
+                try {
+                    consumer1.acknowledge(m);
+                } catch (PulsarClientException e) {
+                    fail("shouldn't have failed ", e);
+                }
+            });
+
+            // (3) Consumer consumes and ack: so it should consume all remaining messages
+            messages.clear();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMessages++;
+                    consumer1.acknowledge(msg);
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            // verify total-consumer messages = total-produce messages
+            assertEquals(totalProducedMsgs, totalReceiveMessages);
+            producer.close();
+            consumer1.close();
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+    
+    /**
+     * Verify: Consumer2 sends ack of Consumer1 and consumer1 should be unblock if it is blocked due to unack-messages
+     * 
+     * 
+     * @param batchMessageDelayMs
+     * @throws Exception
+     */
+    @Test
+    public void testBlockUnackConsumerAckByDifferentConsumer() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerConsumer();
+        try {
+            final int maxUnackedMessages = 20;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 100;
+            int totalReceiveMessages = 0;
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+            Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+            
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            
+            // (2) Consumer1: consume without ack:
+            // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    messages.add(msg);
+                    totalReceiveMessages++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            
+            assertEquals(messages.size(), maxUnackedMessages); //consumer1
+            
+            // (3) ack for all UnackedMessages from consumer2
+            messages.forEach(m -> {
+                try {
+                    consumer2.acknowledge(m);
+                } catch (PulsarClientException e) {
+                    fail("shouldn't have failed ", e);
+                }
+            });
+
+            // (4) consumer1 will consumer remaining msgs and consumer2 will ack those messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer1.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    totalReceiveMessages++;
+                    consumer2.acknowledge(msg);
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer2.receive(1, TimeUnit.SECONDS);
+                if (msg != null) {
+                    totalReceiveMessages++;
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+            
+            // verify total-consumer messages = total-produce messages
+            assertEquals(totalProducedMsgs, totalReceiveMessages);
+            producer.close();
+            consumer1.close();
+            consumer2.close();
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+
+
 }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/ConsumerStats.java
@@ -31,6 +31,9 @@ public class ConsumerStats {
 
     /** Number of available message permits for the consumer */
     public int availablePermits;
+    
+    /** Number of unacknowledged messages for the consumer */
+    public int unackedMessages;
 
     /** Address of this consumer */
     public String address;
@@ -43,6 +46,7 @@ public class ConsumerStats {
         this.msgRateOut += stats.msgRateOut;
         this.msgThroughputOut += stats.msgThroughputOut;
         this.availablePermits += stats.availablePermits;
+        this.unackedMessages += stats.unackedMessages;
         return this;
     }
 }


### PR DESCRIPTION
### Motivation

If consumer keep tries to receive messages without acknowledging to broker then broker won't know last-deleted/received message entry. and if broker/consumer crashes/restarts in between then next time broker needs to send all the messages again as client didn't ack those messages.

### Modifications

- introduced configurable threshold ```maxUnackedMessagesPerConsumer``` limit till which consumer can consume messages without sending ack
- once consumer reaches this ```maxUnackedMessagesPerConsumer``` limit, broker stops sending further messages until consumer sends acknowledgement for ```maxUnackedMessagesPerConsumer/2``` messages.

### Result

- broker can block consumer if consumer doesn't send ack for ```maxUnackedMessagesPerConsumer``` number of messages.
