### PR TITLE
Fix incremental checksum computation for crc

### DIFF
--- a/pulsar-checksum/src/main/circe/include/int_types.h
+++ b/pulsar-checksum/src/main/circe/include/int_types.h
@@ -15,7 +15,7 @@
  ******************************************************************************/
 #include <stddef.h> // size_t
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1600 // stdint.h added in MSVC 2010
 
 typedef __int8 int8_t;
 typedef __int16 int16_t;
@@ -26,11 +26,17 @@ typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;
 
-# define SIZE_T_FORMAT "%Iu"
-
 #else
 
 # include <stdint.h>
+
+#endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1900 // MSVC 2015
+
+# define SIZE_T_FORMAT "%Iu"
+
+#else
 
 # define SIZE_T_FORMAT "%zu"
 

--- a/pulsar-checksum/src/main/java/com/scurrilous/circe/crc/ReflectedIntCrc.java
+++ b/pulsar-checksum/src/main/java/com/scurrilous/circe/crc/ReflectedIntCrc.java
@@ -36,8 +36,12 @@ final class ReflectedIntCrc extends AbstractIntCrc {
     }
 
     @Override
+    protected int initial() {
+        return reflect(super.initial());
+    }
+
+    @Override
     protected int resumeRaw(int crc, byte[] input, int index, int length) {
-        crc = reflect(crc);
         for (int i = 0; i < length; ++i)
             crc = table[(crc ^ input[index + i]) & 0xff] ^ (crc >>> 8);
         return crc;

--- a/pulsar-checksum/src/main/java/com/yahoo/pulsar/checksum/utils/Crc32cChecksum.java
+++ b/pulsar-checksum/src/main/java/com/yahoo/pulsar/checksum/utils/Crc32cChecksum.java
@@ -46,12 +46,25 @@ public class Crc32cChecksum {
      */
     public static int computeChecksum(ByteBuf payload) {
         if (payload.hasMemoryAddress() && (CRC32C_HASH instanceof Sse42Crc32C)) {
-            return CRC32C_HASH.calculate(payload.memoryAddress(), payload.readableBytes());
+            return CRC32C_HASH.calculate(payload.memoryAddress() + payload.readerIndex(), payload.readableBytes());
         } else if (payload.hasArray()) {
             return CRC32C_HASH.calculate(payload.array(), payload.arrayOffset() + payload.readerIndex(),
                     payload.readableBytes());
         } else {
             return CRC32C_HASH.calculate(payload.nioBuffer());
+        }
+    }
+    
+    
+    public static int resumeChecksum(int previousChecksum, ByteBuf payload) {
+        if (payload.hasMemoryAddress() && (CRC32C_HASH instanceof Sse42Crc32C)) {
+            return CRC32C_HASH.resume(previousChecksum, payload.memoryAddress() + payload.readerIndex(),
+                    payload.readableBytes());
+        } else if (payload.hasArray()) {
+            return CRC32C_HASH.resume(previousChecksum, payload.array(), payload.arrayOffset() + payload.readerIndex(),
+                    payload.readableBytes());
+        } else {
+            return CRC32C_HASH.resume(previousChecksum, payload.nioBuffer());
         }
     }
 

--- a/pulsar-checksum/src/test/java/com/scurrilous/circe/crc/CRCTest.java
+++ b/pulsar-checksum/src/test/java/com/scurrilous/circe/crc/CRCTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 import org.testng.annotations.Test;
 
 import com.scurrilous.circe.HashProvider;
+import com.scurrilous.circe.IncrementalIntHash;
 import com.scurrilous.circe.params.CrcParameters;
 
 /**
@@ -159,5 +160,21 @@ public class CRCTest {
     @Test
     public void testCRC64_XZ() {
         assertEquals(0x995dc9bbdf1939faL, PROVIDER.getIncrementalLong(CRC64_XZ).calculate(DIGITS));
+    }
+    
+    @Test
+    public void testCRC32CIncremental() {
+        // reflected
+        testIncremental(PROVIDER.getIncrementalInt(CRC32C));
+    }
+
+    private void testIncremental(IncrementalIntHash hash) {
+        final String data = "data";
+        final String combined = data + data;
+
+        final int dataChecksum = hash.calculate(data.getBytes(ASCII));
+        final int combinedChecksum = hash.calculate(combined.getBytes(ASCII));
+        final int incrementalChecksum = hash.resume(dataChecksum, data.getBytes(ASCII));
+        assertEquals(combinedChecksum, incrementalChecksum);
     }
 }


### PR DESCRIPTION
### Motivation

Crc32C java implementation was not giving correct result for incremental computation.

### Modifications

Fix checksum crc32c checksum computation. Author has also provided fix on it.

### Result

Crc32c checksum gives correct result for incremental checksum computation.

