### PR TITLE
synchronized should be used for final map consumers other than method parameter consumer.

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
@@ -418,7 +418,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     void cleanupConsumer(ConsumerBase consumer) {
-        synchronized (consumer) {
+        synchronized (consumers) {
             consumers.remove(consumer);
         }
     }


### PR DESCRIPTION
### Motivation

synchronized should be used for final map `consumers` other than method parameter `consumer`.

### Modifications

```
-        synchronized (consumer) {
+        synchronized (consumers) {
```

### Result

`synchronized` works correctly.