### PR TITLE
Ensure importing of GPG keys in travis build doesn't get stuck on confirmation prompt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
 
 # Reconstruct the gpg keys to sign the artifacts
 before_deploy:
-  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
-  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch
+  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch
 
 deploy:
   -


### PR DESCRIPTION
### Motivation

We need GPG keys to automatically sign artifacts to push on Maven Central. Importing the keys is currently blocking the build, since it ask for manual confirmation
