### PR TITLE
Add admin-interface(REST/CLI) to expire messages for a topic

### DIFF
--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
@@ -586,6 +586,58 @@ public interface PersistentTopics {
     CompletableFuture<Void> skipMessagesAsync(String destination, String subName, long numMessages);
 
     /**
+     * Expire all messages older than given N (expireTimeInSeconds) seconds for a given subscription
+     * 
+     * @param destination
+     *            Destination name
+     * @param subName
+     *            Subscription name
+     * @param expireTimeInSeconds
+     *            Expire messages older than time in seconds
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    public void expireMessages(String destination, String subscriptionName, long expireTimeInSeconds) throws PulsarAdminException;
+    
+    /**
+     * Expire all messages older than given N (expireTimeInSeconds) seconds for a given subscription asynchronously
+     * 
+     * @param destination
+     *            Destination name
+     * @param subName
+     *            Subscription name
+     * @param expireTimeInSeconds
+     *            Expire messages older than time in seconds
+     * @return
+     */
+    public CompletableFuture<Void> expireMessagesAsync(String destination, String subscriptionName, long expireTimeInSeconds);
+
+    /**
+     * Expire all messages older than given N (expireTimeInSeconds) seconds for all subscriptions of the
+     * persistent-topic
+     * 
+     * @param destination
+     *            Destination name
+     * @param expireTimeInSeconds
+     *            Expire messages older than time in seconds
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    public void expireMessagesForAllSubscriptions(String destination, long expireTimeInSeconds) throws PulsarAdminException;
+    
+
+    /**
+     * Expire all messages older than given N (expireTimeInSeconds) seconds for all subscriptions of the
+     * persistent-topic asynchronously
+     * 
+     * @param destination
+     *            Destination name
+     * @param expireTimeInSeconds
+     *            Expire messages older than time in seconds
+     */
+    public CompletableFuture<Void> expireMessagesForAllSubscriptionsAsync(String destination, long expireTimeInSeconds);
+    
+    /**
      * Peek messages from a topic subscription
      *
      * @param destination

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
@@ -386,7 +386,7 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
             throw new PulsarAdminException(e.getCause());
         }
     }
-
+    
     @Override
     public CompletableFuture<Void> skipMessagesAsync(String destination, String subName, long numMessages) {
         DestinationName ds = validateTopic(destination);
@@ -394,6 +394,49 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
         return asyncPostRequest(
                 persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("subscription")
                         .path(encodedSubName).path("skip").path(String.valueOf(numMessages)),
+                Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+    
+    @Override
+    public void expireMessages(String destination, String subName, long expireTimeInSeconds) throws PulsarAdminException {
+        try {
+            expireMessagesAsync(destination, subName, expireTimeInSeconds).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+    
+    @Override
+    public CompletableFuture<Void> expireMessagesAsync(String destination, String subName, long expireTimeInSeconds) {
+        DestinationName ds = validateTopic(destination);
+        String encodedSubName = Codec.encode(subName);
+        return asyncPostRequest(
+                persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("subscription")
+                        .path(encodedSubName).path("expireMessages").path(String.valueOf(expireTimeInSeconds)),
+                Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+    
+    @Override
+    public void expireMessagesForAllSubscriptions(String destination, long expireTimeInSeconds) throws PulsarAdminException {
+        try {
+            expireMessagesForAllSubscriptionsAsync(destination, expireTimeInSeconds).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+    
+    @Override
+    public CompletableFuture<Void> expireMessagesForAllSubscriptionsAsync(String destination, long expireTimeInSeconds) {
+        DestinationName ds = validateTopic(destination);
+        return asyncPostRequest(
+                persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("all_subscription")
+                        .path("expireMessages").path(String.valueOf(expireTimeInSeconds)),
                 Entity.entity("", MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
@@ -52,6 +52,8 @@ public class CmdPersistentTopics extends CmdBase {
         jcommander.addCommand("partitioned-stats", new GetPartitionedStats());
         jcommander.addCommand("skip", new Skip());
         jcommander.addCommand("skip-all", new SkipAll());
+        jcommander.addCommand("expire-messages", new ExpireMessages());
+        jcommander.addCommand("expire-messages-all-subscriptions", new ExpireMessagesForAllSubscriptions());
         jcommander.addCommand("create-partitioned-topic", new CreatePartitionedCmd());
         jcommander.addCommand("get-partitioned-topic-metadata", new GetPartitionedTopicMetadataCmd());
         jcommander.addCommand("delete-partitioned-topic", new DeletePartitionedCmd());
@@ -293,6 +295,40 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             persistentTopics.skipMessages(persistentTopic, subName, numMessages);
+        }
+    }
+    
+    @Parameters(commandDescription = "Expire messages for the subscription")
+    private class ExpireMessages extends CliCommand {
+        @Parameter(description = "persistent://property/cluster/namespace/destination", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-s",
+                "--subscription" }, description = "Subscription to be skip messages on", required = true)
+        private String subName;
+
+        @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
+        private long expireTimeInSeconds;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            persistentTopics.expireMessages(persistentTopic, subName, expireTimeInSeconds);
+        }
+    }
+    
+    @Parameters(commandDescription = "Expire messages for all subscriptions")
+    private class ExpireMessagesForAllSubscriptions extends CliCommand {
+        @Parameter(description = "persistent://property/cluster/namespace/destination", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-t", "--expireTime" }, description = "Expire messages older than time in seconds", required = true)
+        private long expireTimeInSeconds;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            persistentTopics.expireMessagesForAllSubscriptions(persistentTopic, expireTimeInSeconds);
         }
     }
 

--- a/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -358,6 +358,12 @@ public class PulsarAdminToolTest {
 
         topics.run(split("skip persistent://myprop/clust/ns1/ds1 -s sub1 -n 100"));
         verify(mockTopics).skipMessages("persistent://myprop/clust/ns1/ds1", "sub1", 100);
+        
+        topics.run(split("expire-messages persistent://myprop/clust/ns1/ds1 -s sub1 -t 100"));
+        verify(mockTopics).expireMessages("persistent://myprop/clust/ns1/ds1", "sub1", 100);
+        
+        topics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 100"));
+        verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1", 100);
 
         topics.run(split("create-partitioned-topic persistent://myprop/clust/ns1/ds1 --partitions 32"));
         verify(mockTopics).createPartitionedTopic("persistent://myprop/clust/ns1/ds1", 32);


### PR DESCRIPTION
### Motivation

In some case, we need a cleanup interface which allows to expire all messages for a topic which are older than specific duration. So, we need Admin api that allows to expire messages for a specific subscription or on all subscriptions of a topic.

### Modifications

Introduce a interface (REST-api/ Admin-CLI) that allows to expire messages on a specific subscription or on all subscriptions of a given topic.

### Result

Provide a new api to expire messages for a topic and no functional changes in other components.