### PR TITLE
At closing consumer: make pendingRead false when no consumer is connected to SingleDispatcher

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -123,7 +123,8 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
             return;
         }
 
-        if (havePendingRead && cursor.cancelPendingReadRequest()) {
+        // if no consumer is available then clear-out pendingRead and let it read when it connects next time
+        if ((consumers.isEmpty()) || (havePendingRead && cursor.cancelPendingReadRequest())) {
             havePendingRead = false;
         }
 


### PR DESCRIPTION
### Motivation

In case of ```Exclusive``` consumer is disconnecting and if it doesn't flip ```havePendingRead=false``` at  [PersistentDispatcherSingleActiveConsumer](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L126), then on next reconnection consumer will not receive new messages and it will be blocked.
So, we should make ```havePendingRead=false``` at the time of disconnect-consumer if there is no consumer available 
- next time when new consumer will connect it will anyway read more entires  without considering pendingRead
- however, in case of ```Exclusive``` subscription: if ```havePendingRead=true``` and ```cursor.cancelPendingReadRequest()=false (which will be the case if there is no pendingReadOp present at ManagedCursor)```, ```havePendingRead``` will be always true and next time when new consumer will connect, it might get blocked at [pickAndScheduleActiveConsumer](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L126) while addConsumer() and at [consumerFlow](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L224)

### Modifications

Always clear pendingRead at Exclusive consumer disconnect.

### Result

Avoid possibility of exclusive consumer blocking.

