### PR TITLE
Reduce Dispatcher-totalPermits by number of messages delivered in batch

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -199,7 +199,7 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
                 readMoreEntries(currentConsumer);
             }
         } else {
-            currentConsumer.sendMessages(entries).addListener(future -> {
+            currentConsumer.sendMessages(entries).getLeft().addListener(future -> {
                 if (future.isSuccess()) {
                     // Schedule a new read batch operation only after the previous batch has been written to the socket
                     synchronized (PersistentDispatcherSingleActiveConsumer.this) {


### PR DESCRIPTION
### Motivation

[Dispatcher](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L69).totalPermits and [Consumer](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java#L66).messagePermits count must be consistent else it may block client-consumer while fetching messages. Right now, it is inconsistent in case of Batch-message with shared-subscription consumer usecase.

### Modifications

Maintain permits-counter in [Dispatcher](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L69) and [Consumer](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java#L66) by reducing total number of messages sent in a given batch-message rather just considering 1 message per batch-message in Dispatcher.

### Result

It will maintain Dispatcher and Consumer permits-counter and that can prevent possible consumer-message blocking.

