### PR TITLE
Add numMessagesInQueue and getAvailablePermits for PartitionedConsumer

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -291,6 +291,10 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
 
     abstract public boolean isConnected();
 
+    abstract public int getAvailablePermits();
+
+    abstract public int numMessagesInQueue();
+
     public CompletableFuture<Consumer> subscribeFuture() {
         return subscribeFuture;
     }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
@@ -858,10 +858,12 @@ public class ConsumerImpl extends ConsumerBase {
         return partitionIndex;
     }
 
+    @Override
     public int getAvailablePermits() {
         return availablePermits.get();
     }
 
+    @Override
     public int numMessagesInQueue() {
         return incomingMessages.size();
     }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -399,6 +399,16 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     }
 
     @Override
+    public int getAvailablePermits() {
+        return consumers.stream().mapToInt(ConsumerImpl::getAvailablePermits).sum();
+    }
+
+    @Override
+    public int numMessagesInQueue() {
+        return consumers.stream().mapToInt(ConsumerImpl::numMessagesInQueue).sum();
+    }
+
+    @Override
     public synchronized ConsumerStats getStats() {
         if (stats == null) {
             return null;


### PR DESCRIPTION
### Motivation

Allow a partitioned consumer to get the available messages to consume

### Modifications

Added `numMessagesInQueue` and `getAvailablePermits` for `PartitionedConsumer`

### Result

A Partitioned consumer can now get the amount of messages it has to consume.