### PR TITLE
GPG keys need to imported just once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
 
 # Reconstruct the gpg keys to sign the artifacts
 before_deploy:
-  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch
-  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch
+  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch || true
+  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch || true
 
 deploy:
   -


### PR DESCRIPTION
### Motivation

During release process, there are 2 deploy phases, once for Sonatype and one for GitHub releases upload. The `before_deploy` script is current being executed twice and fails the 2nd time.

### Modifications

Import the GPG keys just once in the `before_script` phase.

### Result

Releases tar.gz files will be automatically uploaded to github.

