### PR TITLE
Partitioned numMessagesInQueue should count it's incoming messages

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -405,7 +405,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     @Override
     public int numMessagesInQueue() {
-        return consumers.stream().mapToInt(ConsumerImpl::numMessagesInQueue).sum();
+        return incomingMessages.size() + consumers.stream().mapToInt(ConsumerImpl::numMessagesInQueue).sum();
     }
 
     @Override


### PR DESCRIPTION
It seems to me that Partitioned Consumer should count it's own incoming messages plus the incoming messages of all its internal consumers.

