### PR TITLE
Allow reset of global topic subscription

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -847,9 +847,6 @@ public class PersistentTopics extends AdminResource {
             try {
                 PersistentSubscription sub = topic.getPersistentSubscription(subName);
                 checkNotNull(sub);
-                if (dn.isGlobal()) {
-                    throw new NotAllowedException("reset cursor not supported for global topic");
-                }
                 sub.resetCursor(timestamp).get();
                 log.info("[{}][{}] reset cursor on subscription {} to time {}", clientAppId(), dn, subName, timestamp);
             } catch (Exception e) {

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
@@ -446,9 +446,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
     }
 
     @Test(enabled = true)
-    public void testResetCursorFails() throws Exception {
+    public void testResetCursorNotFail() throws Exception {
 
-        log.info("--- Starting ReplicatorTest::testResetCursorFails ---");
+        log.info("--- Starting ReplicatorTest::testResetCursorNotFail ---");
 
         // This test is to verify that reset cursor fails on global topic
         SortedSet<String> testDests = new TreeSet<String>();
@@ -488,12 +488,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 fail(String.format("replication test failed with %s exception", e.getMessage()));
             }
         }
-        try {
-            admin1.persistentTopics().resetCursor(testDests.first(), "sub-id", System.currentTimeMillis());
-            fail("should have gotten not allowed exception");
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof PulsarAdminException.NotAllowedException, e.getMessage());
-        }
+        admin1.persistentTopics().resetCursor(testDests.first(), "sub-id", System.currentTimeMillis());
     }
 
     @Test(enabled = true)


### PR DESCRIPTION
### Motivation

As stated by @merlimat on [#73](https://github.com/yahoo/pulsar/issues/73), there doesn't seem to be a reason not to allow resetting a subscription on a global topic since subscriptions are cluster-local.

### Modifications

Removed validation.

### Result

Subscriptions on global topic are now allowed to be reset
