### PR TITLE
Non blocking partitioned Consumers

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
@@ -41,6 +41,8 @@ public class ConsumerConfiguration implements Serializable {
 
     private MessageListener messageListener;
 
+    private ReceiveListener receiveListener;
+
     private int receiverQueueSize = 1000;
 
     private String consumerName = null;
@@ -90,6 +92,26 @@ public class ConsumerConfiguration implements Serializable {
     public ConsumerConfiguration setSubscriptionType(SubscriptionType subscriptionType) {
         checkNotNull(subscriptionType);
         this.subscriptionType = subscriptionType;
+        return this;
+    }
+
+    /**
+     * @return the configured {@link ReceiveListener} for the consumer
+     */
+    public ReceiveListener getReceiveListener() {
+        return this.receiveListener;
+    }
+
+    /**
+     * Sets a {@link ReceiveListener} for the consumer, that notifies when a message
+     * is ready to be received.
+     *
+     * @param receiveListener
+     *            the listener object
+     */
+    public ConsumerConfiguration setReceiveListener(ReceiveListener receiveListener) {
+        checkNotNull(receiveListener);
+        this.receiveListener = receiveListener;
         return this;
     }
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ReceiveListener.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ReceiveListener.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.client.api;
+
+import java.io.Serializable;
+
+/**
+ * A listener that will be called in order for every message received.
+ *
+ *
+ */
+public interface ReceiveListener extends Serializable {
+    /**
+     * This method is called whenever a new message is received.
+     * 
+     * This method will only be called once for each message, unless either application or broker crashes.
+     *
+     * Application is responsible of handling any exception that could be thrown while processing.
+     *
+     * @param consumer
+     *            the consumer that received a message
+     */
+    void received(Consumer consumer);
+}


### PR DESCRIPTION
### Motivation

As discussed in [#80](https://github.com/yahoo/pulsar/issues/80), current `PartitionedConsumerImpl` behavior es to block `listenerExecutor` when no space is left on the queue.

I've made a first approach at solving this issue, I wanted you to review it and see if this is a good approach or if you can figure out a better way of solving this.
### Modifications

I've modified `PartitionedConsumerImpl` to behave more like `ConsumerImpl`, it keeps track of the amount of space in the queue and tries to fill the queue when a certain threshold has been surpassed, or when `ConsumerImpl` notifies that messages have been received.
I've added a new `ReceiveListener` to `ConsumerImpl` that, unlike `MessageListener`, does not remove messages from the queue, but only notifies that it has new messages.
This Listener is used by the new `PartitionedConsumerImpl` to try to fill it's queue by pulling messages in a round-robin fashion from `ConsumerImpl`s starting from the notifying consumer.
`PartitionedConsumerImpl` also keeps track of when a receive is already running as to not swarm `listenerExecutor` with tasks that will probably do nothing.
### Result

`PartitionedConsumerImpl` should no longer block `listenerExecutor`.

_Comment: I'm not particularly sure about the `AtomicBoolean` flag to keep track if a receive is running, I guess, there could be a case when receive is finishing, not looping anymore and we cannot schedule another run because it has not yet disabled the flag._

Cheers!
