### PR TITLE
Fix: Reset message-header index while verify checksum-strip at Reconnection

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
@@ -791,9 +791,10 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
 
                 log.info("[{}] [{}] Re-Sending {} messages to server", topic, producerName, messagesToResend);
 
+                final boolean stripChecksum = cnx.getRemoteEndpointProtocolVersion() < brokerChecksumSupportedVersion();
                 for (OpSendMsg op : pendingMessages) {
                     
-                    if (cnx.getRemoteEndpointProtocolVersion() < brokerChecksumSupportedVersion()) {
+                    if (stripChecksum) {
                         stripChecksum(op);
                     }
                     op.cmd.retain();
@@ -827,10 +828,8 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         DoubleByteBuf msg = getDoubleByteBuf(op.cmd);
         if (msg != null) {
             ByteBuf headerFrame = msg.getFirst();
-            ByteBuf payloadFrame = msg.getSecond();
             msg.markReaderIndex();
             headerFrame.markReaderIndex();
-            payloadFrame.markReaderIndex();
             try {
                 headerFrame.skipBytes(4); // skip [total-size]
                 int cmdSize = (int) headerFrame.readUnsignedInt();
@@ -839,6 +838,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                 headerFrame.skipBytes(cmdSize);
 
                 if (!hasChecksum(headerFrame)) {
+                	headerFrame.resetReaderIndex();
                     return;
                 }
 


### PR DESCRIPTION
### Motivation

At reconnection: before resending messages, producer verifies broker-version and removes checksum and modifies prepared message if requires. If message is not modified then message-header index is not reset correctly which can corrupt the message.

This problem would only happen in a mixed environment with 1.15 and 1.14 clients.

### Modifications

Reset message-header index while stripping checksum.

### Result

It will not corrupt message while resending message on reconnection.