### PR TITLE
Fix #91 intermittent test failure PulsarClientToolTest.testInitialzation

### DIFF
--- a/pulsar-client-tools/src/test/java/com/yahoo/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools/src/test/java/com/yahoo/pulsar/client/cli/PulsarClientToolTest.java
@@ -62,7 +62,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
             try {
                 pulsarClientToolConsumer = new PulsarClientTool(properties);
                 String[] args = { "consume", "-t", "Exclusive", "-s", "sub-name", "-n",
-                        Integer.toString(numberOfMessages), "--hex", "-r", "10", topicName };
+                        Integer.toString(numberOfMessages), "--hex", "-r", "30", topicName };
                 Assert.assertEquals(pulsarClientToolConsumer.run(args), 0);
                 future.complete(null);
             } catch (Throwable t) {


### PR DESCRIPTION
### Motivation

Fix one of the intermittent test failure

### Modifications

Increase consumer rate limit to avoid:
```
Caused by: java.lang.AssertionError: expected [0] but found [-1]
    at org.testng.Assert.fail(Assert.java:94)
    at org.testng.Assert.failNotEquals(Assert.java:494)
    at org.testng.Assert.assertEquals(Assert.java:123)
    at org.testng.Assert.assertEquals(Assert.java:370)
    at org.testng.Assert.assertEquals(Assert.java:380)
    at com.yahoo.pulsar.client.cli.PulsarClientToolTest.lambda$0(PulsarClientToolTest.java:66)
```



