### PR TITLE
Update async-http-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@ flexible messaging model and an intuitive client API.</description>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.ning</groupId>
+        <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
-        <version>1.9.38</version>
+        <version>2.0.19</version>
       </dependency>
 
       <dependency>

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
@@ -329,7 +329,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             consumer.close();
             fail("TLS connection should fail");
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("Connection refused"));
+            assertTrue(e.getMessage().contains("ConnectException"));
         } finally {
             pulsarClient.close();
         }

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -95,7 +95,7 @@
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>
-                  <include>com.ning:async-http-client</include>
+                  <include>org.asynchttpclient:async-http-client</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.code.gson:gson</include>
@@ -110,8 +110,8 @@
                   <shadedPattern>pulsar-admin-shade.org.apache.commons</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.ning</pattern>
-                  <shadedPattern>pulsar-admin-shade.com.ning</shadedPattern>
+                  <pattern>org.asynchttpclient</pattern>
+                  <shadedPattern>com.yahoo.pulsar.shade.org.asynchttpclient</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.google</pattern>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -61,7 +61,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.ning</groupId>
+			<groupId>org.asynchttpclient</groupId>
 			<artifactId>async-http-client</artifactId>
 		</dependency>
 		<dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ning</groupId>
+      <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
     </dependency>
 
@@ -111,7 +111,7 @@
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>
-                  <include>com.ning:async-http-client</include>
+                  <include>org.asynchttpclient:async-http-client</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.code.gson:gson</include>
@@ -139,8 +139,8 @@
                   <shadedPattern>com.yahoo.pulsar.shade.org.apache.commons</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.ning</pattern>
-                  <shadedPattern>com.yahoo.pulsar.shade.com.ning</shadedPattern>
+                  <pattern>org.asynchttpclient</pattern>
+                  <shadedPattern>com.yahoo.pulsar.shade.org.asynchttpclient</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.google</pattern>
@@ -153,10 +153,6 @@
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
                   <shadedPattern>com.yahoo.pulsar.shade.com.fasterxml.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.jboss.netty</pattern>
-                  <shadedPattern>com.yahoo.pulsar.shade.org.jboss.netty</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerStats.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerStats.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.ning.http.client.providers.netty.chmv8.LongAdder;
 import com.yahoo.pulsar.client.api.ConsumerConfiguration;
 import com.yahoo.pulsar.client.api.Message;
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerStats.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerStats.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.ning.http.client.providers.netty.chmv8.LongAdder;
 import com.yahoo.pulsar.client.api.ProducerConfiguration;
 import com.yahoo.sketches.quantiles.DoublesSketch;
 

--- a/pulsar-storm/pom.xml
+++ b/pulsar-storm/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ning</groupId>
+      <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
### Motivation

Pulsar is using async-http-client version 1.9.x which uses Netty 3. Besides this being slower. it creates a whole pool of threads for usage only of the http client.

### Modifications

I've updated async-http-client to version 2.0 which uses Netty 4 and so can reuse the same event loop as the client.

### Result

Less threads in use!

I don't know if this could bring some unforeseen changes, though.
