### PR TITLE
Async authorization check while creation of producer/consumer

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
@@ -381,7 +381,7 @@ public class ServerCnxTest {
     @Test(timeOut = 30000)
     public void testProducerCommandWithAuthorizationPositive() throws Exception {
         AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
-        doReturn(true).when(authorizationManager).canProduce(Mockito.any(), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationManager).canProduceAsync(Mockito.any(), Mockito.any());
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         resetChannel();
@@ -409,7 +409,7 @@ public class ServerCnxTest {
         ConfigurationCacheService configCacheService = mock(ConfigurationCacheService.class);
         doReturn(configCacheService).when(pulsar).getConfigurationCache();
         doReturn(zkDataCache).when(configCacheService).policiesCache();
-        doThrow(new NoNodeException()).when(zkDataCache).get(matches(".*nonexistent.*"));
+        doReturn(CompletableFuture.completedFuture(Optional.empty())).when(zkDataCache).getAsync(matches(".*nonexistent.*"));
 
         AuthorizationManager authorizationManager = spy(new AuthorizationManager(svcConfig, configCacheService));
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
@@ -440,7 +440,7 @@ public class ServerCnxTest {
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
         doReturn(false).when(authorizationManager).isSuperUser(Mockito.anyString());
-        doReturn(true).when(authorizationManager).checkPermission(any(DestinationName.class), Mockito.anyString(),
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationManager).checkPermission(any(DestinationName.class), Mockito.anyString(),
                 any(AuthAction.class));
 
         resetChannel();
@@ -493,7 +493,7 @@ public class ServerCnxTest {
 
     public void testProducerCommandWithAuthorizationNegative() throws Exception {
         AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
-        doReturn(false).when(authorizationManager).canProduce(Mockito.any(), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationManager).canProduceAsync(Mockito.any(), Mockito.any());
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
@@ -1022,7 +1022,7 @@ public class ServerCnxTest {
     @Test(timeOut = 30000)
     public void testSubscribeCommandWithAuthorizationPositive() throws Exception {
         AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
-        doReturn(true).when(authorizationManager).canConsume(Mockito.any(), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(true)).when(authorizationManager).canConsumeAsync(Mockito.any(), Mockito.any());
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
@@ -1042,7 +1042,7 @@ public class ServerCnxTest {
     @Test(timeOut = 30000)
     public void testSubscribeCommandWithAuthorizationNegative() throws Exception {
         AuthorizationManager authorizationManager = mock(AuthorizationManager.class);
-        doReturn(false).when(authorizationManager).canConsume(Mockito.any(), Mockito.any());
+        doReturn(CompletableFuture.completedFuture(false)).when(authorizationManager).canConsumeAsync(Mockito.any(), Mockito.any());
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -24,6 +24,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -177,8 +178,8 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     }
 
     @Override
-    protected boolean isAuthorized(String authRole) {
-        return service.getAuthorizationManager().canConsume(DestinationName.get(topic), authRole);
+    protected CompletableFuture<Boolean> isAuthorized(String authRole) {
+        return service.getAuthorizationManager().canConsumeAsync(DestinationName.get(topic), authRole);
     }
 
     private static String extractSubscription(HttpServletRequest request) {

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
@@ -17,6 +17,7 @@ package com.yahoo.pulsar.websocket;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletRequest;
@@ -118,8 +119,8 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         });
     }
 
-    protected boolean isAuthorized(String authRole) {
-        return service.getAuthorizationManager().canProduce(DestinationName.get(topic), authRole);
+    protected CompletableFuture<Boolean> isAuthorized(String authRole) {
+        return service.getAuthorizationManager().canProduceAsync(DestinationName.get(topic), authRole);
     }
 
     private ProducerConfiguration getProducerConfiguration() {


### PR DESCRIPTION
### Motivation

While creating producer/consumer at broker: broker performs sync authorization check (sync zk-policies checks) on client-connection which blocks broker-io threads.

### Modifications

Made async-authorization check while creating producer/consumer at broker and websocket server.

### Result

No functional change and it will avoid i/o thread blocking while creating producer/consumer.

