### PR TITLE
Fix: broken websocket test and proxy-producer error handling

### DIFF
--- a/docs/WebSocket.md
+++ b/docs/WebSocket.md
@@ -95,10 +95,19 @@ http://{serviceUrl}:8080/ws/producer/persistent/{property}/{cluster}/{namespace}
 
 ##### Acknowledgement from server
 
+###### Success response
 ```json
 {
    "result": "ok",
    "messageId": "CAAQAw==",
+   "context": "1"
+ }
+```
+###### Failure response
+```json
+ {
+   "result": "send-error:3",
+   "errorMsg": "Failed to de-serialize from JSON",
    "context": "1"
  }
 ```
@@ -172,6 +181,8 @@ following error codes:
 |     4      | Failed to serialize to JSON      |
 |     5      | Failed to authenticate client    |
 |     6      | Client is not authorized         |
+|     7      | Invalid payload encoding         |
+|     8      | Unknown error			        |
 
 Application is responsible to re-establish a new WebSocket session after
 a backoff period.

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/AdminResource.java
@@ -237,7 +237,7 @@ public abstract class AdminResource extends PulsarWebResource {
         }
     }
 
-    public ObjectMapper jsonMapper() {
+    public static ObjectMapper jsonMapper() {
         return ObjectMapperFactory.getThreadLocal();
     }
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -20,50 +20,60 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.net.URI;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.test.PortManager;
+import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Sets;
 import com.yahoo.pulsar.broker.ServiceConfiguration;
-import com.yahoo.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import com.yahoo.pulsar.client.api.ProducerConsumerBase;
 import com.yahoo.pulsar.websocket.WebSocketService;
+import com.yahoo.pulsar.websocket.service.ProxyServer;
+import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
-public class ProxyAuthenticationTest extends MockedPulsarServiceBaseTest {
+public class ProxyAuthenticationTest extends ProducerConsumerBase {
     protected String methodName;
-    private static final int TEST_PORT = PortManager.nextFreePort();
+    private static final int TEST_PORT = 6080;
     private static final String CONSUME_URI = "ws://localhost:" + TEST_PORT
-            + "/consume/persistent/my-property/cluster1/my-ns/my-topic/my-sub";
+            + "/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
     private static final String PRODUCE_URI = "ws://localhost:" + TEST_PORT
-            + "/produce/persistent/my-property/cluster1/my-ns/my-topic/";
+            + "/ws/producer/persistent/my-property/use/my-ns/my-topic/";
+    private ProxyServer proxyServer;
     private WebSocketService service;
 
     @BeforeClass
     public void setup() throws Exception {
         super.internalSetup();
+        super.producerBaseSetup();
 
         ServiceConfiguration config = new ServiceConfiguration();
         config.setWebServicePort(TEST_PORT);
+        config.setClusterName("use");
         config.setAuthenticationEnabled(true);
         config.setAuthenticationProviders(
                 Sets.newHashSet("com.yahoo.pulsar.websocket.proxy.MockAuthenticationProvider"));
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
-        service.start();
+        proxyServer = new ProxyServer(config);
+        WebSocketServiceStarter.start(proxyServer, service);
         log.info("Proxy Server Started");
     }
 
-    @Override
+    @AfterClass
     protected void cleanup() throws Exception {
         super.internalCleanup();
         service.close();
+        proxyServer.stop();
         log.info("Finished Cleaning Up Test setup");
 
     }
@@ -81,16 +91,20 @@ public class ProxyAuthenticationTest extends MockedPulsarServiceBaseTest {
         try {
             consumeClient.start();
             ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
-            consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
-            log.info("Connecting to : %s%n", consumeUri);
+            Future<Session> consumerFuture = consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
+            log.info("Connecting to : {}", consumeUri);
 
             ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
             produceClient.start();
-            produceClient.connect(produceSocket, produceUri, produceRequest);
+            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
+            // let it connect
+            Thread.sleep(1000);
+            Assert.assertTrue(consumerFuture.get().isOpen());
+            Assert.assertTrue(producerFuture.get().isOpen());
 
             consumeSocket.awaitClose(1, TimeUnit.SECONDS);
             produceSocket.awaitClose(1, TimeUnit.SECONDS);
-
+            Assert.assertTrue(produceSocket.getBuffer().size() > 0);
             Assert.assertEquals(produceSocket.getBuffer(), consumeSocket.getBuffer());
         } catch (Throwable t) {
             log.error(t.getMessage());

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -19,49 +19,58 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.net.URI;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.pulsar.broker.ServiceConfiguration;
-import com.yahoo.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import com.yahoo.pulsar.client.api.ProducerConsumerBase;
 import com.yahoo.pulsar.websocket.WebSocketService;
+import com.yahoo.pulsar.websocket.service.ProxyServer;
+import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
-public class ProxyPublishConsumeTest extends MockedPulsarServiceBaseTest {
+public class ProxyPublishConsumeTest extends ProducerConsumerBase {
     protected String methodName;
-    private static final String CONSUME_URI = "ws://localhost:6080/ws/consumer/persistent/my-property/cluster1/my-ns/my-topic/my-sub";
-    private static final String PRODUCE_URI = "ws://localhost:6080/ws/producer/persistent/my-property/cluster1/my-ns/my-topic/";
+    private static final String CONSUME_URI = "ws://localhost:6080/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
+    private static final String PRODUCE_URI = "ws://localhost:6080/ws/producer/persistent/my-property/use/my-ns/my-topic/";
     private static final int TEST_PORT = 6080;
+    private ProxyServer proxyServer;
     private WebSocketService service;
 
     @BeforeClass
     public void setup() throws Exception {
         super.internalSetup();
+        super.producerBaseSetup();
 
         ServiceConfiguration config = new ServiceConfiguration();
         config.setWebServicePort(TEST_PORT);
+        config.setClusterName("use");
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
-        service.start();
+        proxyServer = new ProxyServer(config);
+        WebSocketServiceStarter.start(proxyServer, service);
         log.info("Proxy Server Started");
     }
 
-    @Override
+    @AfterClass
     protected void cleanup() throws Exception {
         super.internalCleanup();
         service.close();
+        proxyServer.stop();
         log.info("Finished Cleaning Up Test setup");
-
     }
 
     @Test
-    public void socketTest() throws InterruptedException {
+    public void socketTest() throws Exception {
         URI consumeUri = URI.create(CONSUME_URI);
         URI produceUri = URI.create(PRODUCE_URI);
 
@@ -73,19 +82,21 @@ public class ProxyPublishConsumeTest extends MockedPulsarServiceBaseTest {
         try {
             consumeClient.start();
             ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
-            consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
-            log.info("Connecting to : %s%n", consumeUri);
+            Future<Session> consumerFuture = consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
+            log.info("Connecting to : {}", consumeUri);
 
             ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
             produceClient.start();
-            produceClient.connect(produceSocket, produceUri, produceRequest);
-
+            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
+            // let it connect
+            Thread.sleep(1000);
+            Assert.assertTrue(consumerFuture.get().isOpen());
+            Assert.assertTrue(producerFuture.get().isOpen());
+            
             consumeSocket.awaitClose(1, TimeUnit.SECONDS);
             produceSocket.awaitClose(1, TimeUnit.SECONDS);
-
+            Assert.assertTrue(produceSocket.getBuffer().size() > 0);
             Assert.assertEquals(produceSocket.getBuffer(), consumeSocket.getBuffer());
-        } catch (Throwable t) {
-            log.error(t.getMessage());
         } finally {
             try {
                 consumeClient.stop();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManager;
@@ -29,34 +30,39 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.pulsar.broker.ServiceConfiguration;
-import com.yahoo.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import com.yahoo.pulsar.client.api.ProducerConsumerBase;
 import com.yahoo.pulsar.websocket.WebSocketService;
+import com.yahoo.pulsar.websocket.service.ProxyServer;
+import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
-public class ProxyPublishConsumeTls extends MockedPulsarServiceBaseTest {
+public class ProxyPublishConsumeTls extends ProducerConsumerBase {
     protected String methodName;
-    private static final String CONSUME_URI = "wss://localhost:6090/ws/consumer/persistent/my-property/cluster1/my-ns/my-topic/my-sub";
-    private static final String PRODUCE_URI = "wss://localhost:6090/ws/producer/persistent/my-property/cluster1/my-ns/my-topic/";
+    private static final String CONSUME_URI = "wss://localhost:6090/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
+    private static final String PRODUCE_URI = "wss://localhost:6090/ws/producer/persistent/my-property/use/my-ns/my-topic/";
     private static final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
     private static final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
     private static final int TEST_PORT = 6080;
     private static final int TLS_TEST_PORT = 6090;
-
+    private ProxyServer proxyServer;
     private WebSocketService service;
 
     @BeforeClass
     public void setup() throws Exception {
         super.internalSetup();
+        super.producerBaseSetup();
 
         ServiceConfiguration config = new ServiceConfiguration();
         config.setWebServicePort(TEST_PORT);
@@ -64,18 +70,19 @@ public class ProxyPublishConsumeTls extends MockedPulsarServiceBaseTest {
         config.setTlsEnabled(true);
         config.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
         config.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
-
+        config.setClusterName("use");
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
-        service.start();
-
+        proxyServer = new ProxyServer(config);
+        WebSocketServiceStarter.start(proxyServer, service);
         log.info("Proxy Server Started");
     }
 
-    @Override
+    @AfterClass
     protected void cleanup() throws Exception {
         super.internalCleanup();
         service.close();
+        proxyServer.stop();
         log.info("Finished Cleaning Up Test setup");
 
     }
@@ -101,16 +108,20 @@ public class ProxyPublishConsumeTls extends MockedPulsarServiceBaseTest {
         try {
             consumeClient.start();
             ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
-            consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
-            log.info("Connecting to : %s%n", consumeUri);
+            Future<Session> consumerFuture = consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
+            log.info("Connecting to : {}", consumeUri);
 
             ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
             produceClient.start();
-            produceClient.connect(produceSocket, produceUri, produceRequest);
+            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
+            // let it connect
+            Thread.sleep(1000);
+            Assert.assertTrue(consumerFuture.get().isOpen());
+            Assert.assertTrue(producerFuture.get().isOpen());
 
             consumeSocket.awaitClose(1, TimeUnit.SECONDS);
             produceSocket.awaitClose(1, TimeUnit.SECONDS);
-
+            Assert.assertTrue(produceSocket.getBuffer().size() > 0);
             Assert.assertEquals(produceSocket.getBuffer(), consumeSocket.getBuffer());
         } catch (Throwable t) {
             log.error(t.getMessage());

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/SimpleConsumerSocket.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/SimpleConsumerSocket.java
@@ -50,14 +50,14 @@ public class SimpleConsumerSocket {
 
     @OnWebSocketClose
     public void onClose(int statusCode, String reason) {
-        log.info("Connection closed: %d - %s%n", statusCode, reason);
+        log.info("Connection closed: {} - {}", statusCode, reason);
         this.session = null;
         this.closeLatch.countDown();
     }
 
     @OnWebSocketConnect
     public void onConnect(Session session) throws InterruptedException {
-        log.info("Got connect: %s%n", session);
+        log.info("Got connect: {}", session);
         this.session = session;
         log.debug("Got connected: {}", session);
     }

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketError.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketError.java
@@ -28,7 +28,9 @@ public enum WebSocketError {
     FailedToDeserializeFromJSON(3, "Failed to de-serialize from JSON"), //
     FailedToSerializeToJSON(4, "Failed to serialize to JSON"), //
     AuthenticationError(5, "Failed to authenticate client"), //
-    NotAuthorizedError(6, "Client is not authorized"); //
+    NotAuthorizedError(6, "Client is not authorized"), //
+    PayloadEncodingError(7, "Invalid payload encoding"), //
+    UnknownError(8, "Unknown error"); //
 
     private final int code;
     private final String description;

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/data/ProducerAck.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/data/ProducerAck.java
@@ -17,16 +17,27 @@ package com.yahoo.pulsar.websocket.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static com.google.common.base.Joiner.on;
+import com.yahoo.pulsar.websocket.WebSocketError;
 
 @JsonInclude(Include.NON_NULL)
 public class ProducerAck {
     public String result;
+    public String errorMsg;
     public String messageId;
     public String context;
 
-    public ProducerAck(String result, String messageId, String context) {
-        this.result = result;
+    public ProducerAck(String messageId, String context) {
+        this.result = "ok";
         this.messageId = messageId;
         this.context = context;
     }
+
+    public ProducerAck(WebSocketError error, String errorMsg, String messageId, String context) {
+        this.result = on(':').join("send-error", error.getCode());
+        this.errorMsg = errorMsg;
+        this.messageId = messageId;
+        this.context = context;
+    }
+
 }

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketServiceStarter.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketServiceStarter.java
@@ -27,30 +27,28 @@ import com.yahoo.pulsar.websocket.WebSocketProducerServlet;
 import com.yahoo.pulsar.websocket.WebSocketService;
 
 public class WebSocketServiceStarter {
+
     public static void main(String args[]) throws Exception {
         checkArgument(args.length == 1, "Need to specify a configuration file");
-
         try {
             // load config file and start proxy service
             String configFile = args[0];
             log.info("Loading configuration from {}", configFile);
             ServiceConfiguration config = ServiceConfigurationLoader.create(configFile);
             ProxyServer proxyServer = new ProxyServer(config);
-
             WebSocketService service = new WebSocketService(config);
-
-            proxyServer.addWebSocketServlet(WebSocketProducerServlet.SERVLET_PATH,
-                    new WebSocketProducerServlet(service));
-            proxyServer.addWebSocketServlet(WebSocketConsumerServlet.SERVLET_PATH,
-                    new WebSocketConsumerServlet(service));
-
-            proxyServer.start();
-
-            service.start();
+            start(proxyServer, service);
         } catch (Exception e) {
             log.error("Failed to start WebSocket service", e);
             Runtime.getRuntime().halt(1);
         }
+    }
+
+    public static void start(ProxyServer proxyServer, WebSocketService service) throws Exception {
+        proxyServer.addWebSocketServlet(WebSocketProducerServlet.SERVLET_PATH, new WebSocketProducerServlet(service));
+        proxyServer.addWebSocketServlet(WebSocketConsumerServlet.SERVLET_PATH, new WebSocketConsumerServlet(service));
+        proxyServer.start();
+        service.start();
     }
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketServiceStarter.class);


### PR DESCRIPTION
### Motivation

- Web-socket unit-test cases are broken and not validating functionalities correctly
- Websocket proxy-producer was missing few validation/error-handling in msg-produce scenario

### Modifications

- Fixed: all web-socket unit-testcases
- Fixed: websocket-proxy-producer validation/error handling

### Result

No functional change

