### PR TITLE
Increment permits when redelivering messages from incomingMessages

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -16,6 +16,7 @@
 package com.yahoo.pulsar.client.impl;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -316,5 +317,5 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
      * the connected consumers. This is a non blocking call and doesn't throw an exception. In case the connection
      * breaks, the messages are redelivered after reconnect.
      */
-    protected abstract void redeliverUnacknowledgedMessages(List<MessageIdImpl> messageIds);
+    protected abstract void redeliverUnacknowledgedMessages(Set<MessageIdImpl> messageIds);
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -18,7 +18,9 @@ package com.yahoo.pulsar.client.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -387,9 +389,9 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     }
 
     @Override
-    public void redeliverUnacknowledgedMessages(List<MessageIdImpl> messageIds) {
+    public void redeliverUnacknowledgedMessages(Set<MessageIdImpl> messageIds) {
         for (ConsumerImpl c : consumers) {
-            List<MessageIdImpl> consumerMessageIds = new ArrayList<>();
+            Set<MessageIdImpl> consumerMessageIds = new HashSet<>();
             messageIds.removeIf(messageId -> {
                 if (messageId.getPartitionIndex() == c.getPartitionIndex()) {
                     consumerMessageIds.add(messageId);

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/UnAckedMessageTracker.java
@@ -17,7 +17,9 @@ package com.yahoo.pulsar.client.impl;
 
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -88,7 +90,7 @@ public class UnAckedMessageTracker implements Closeable {
             public void run(Timeout t) throws Exception {
                 if (isAckTimeout()) {
                     log.warn("[{}] {} messages have timed-out", consumerBase, oldOpenSet.size());
-                    List<MessageIdImpl> messageIds = new ArrayList<>();
+                    Set<MessageIdImpl> messageIds = new HashSet<>();
                     oldOpenSet.forEach(messageIds::add);
                     oldOpenSet.clear();
                     consumerBase.redeliverUnacknowledgedMessages(messageIds);


### PR DESCRIPTION
### Motivation

Issue [#100](https://github.com/yahoo/pulsar/issues/100)

### Modifications

- Converted `redeliverUnacknowledgedMessages(List<MessageIdImpl> messageIds)` to receive a `Set` to allow for fast lookup.
- Make `redeliverUnacknowledgedMessages(Set<MessageIdImpl> messageIds)` iterate, remove and count messages which are expired and still belong to the queue. Increase available permits by the amount of messages removed from the queue.
__I'm not particularly certain about this, removing messages from a `BlockingQueue` is not recommended, but I don't really see a better way without changing much.__

- Reset `unAckedMessageTracker` timer for messages that are retreived from the queue. Conceptually `ackTimeout` should be the maximum amount of time a consumer should be processing a message without acknowledging it, currently, the consumer has `ackTimeout - timeInQueue`, but the time the message is in the queue cannot be controlled, and a consumer could be handed a messsage which only has a few milliseconds remaining. We should reset the timer when pulling a message.


