### PR TITLE
Fix: complete MessageReplay immediately if there is no entry to replay which will not block further reads as current Replay is finished

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -803,6 +803,14 @@ public class ManagedCursorImpl implements ManagedCursor {
         return result.entries;
     }
 
+    /**
+     * Async replays given positions: 
+     * a. before reading it filters out already-acked messages 
+     * b. reads remaining entries async and gives it to given ReadEntriesCallback
+     * c. returns all already-acked messages which are not replayed so, those messages can be removed by
+     * caller(Dispatcher)'s replay-list and it won't try to replay it again
+     * 
+     */
     @Override
     public Set<? extends Position> asyncReplayEntries(final Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx) {
         List<Entry> entries = Lists.newArrayListWithExpectedSize(positions.size());

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <groupId>com.yahoo.pulsar</groupId>
   <artifactId>pulsar</artifactId>
 
-  <version>1.15.1</version>
+  <version>1.15.2-SNAPSHOT</version>
 
   <name>Pulsar</name>
   <description>Pulsar is a distributed pub-sub messaging platform with a very

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>pulsar-broker-common</artifactId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -173,6 +173,12 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
                         ReadType.Replay);
                 // clear already acked positions from replay bucket
                 messagesToReplay.removeAll(deletedMessages);
+                // if all the entries are acked-entries and cleared up from messagesToReplay, try to read
+                // next entries as readCompletedEntries-callback was never called 
+                if ((messagesToReplayNow.size() - deletedMessages.size()) == 0) {
+                    havePendingReplayRead = false;
+                    readMoreEntries();
+                }
             } else if (!havePendingRead) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule read of {} messages for {} consumers", name, messagesToRead,

--- a/pulsar-checksum/pom.xml
+++ b/pulsar-checksum/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>com.yahoo.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
-		<version>1.15.1</version>
+		<version>1.15.2-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-storm/pom.xml
+++ b/pulsar-storm/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.yahoo.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
-		<version>1.15.1</version>
+		<version>1.15.2-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.1</version>
+    <version>1.15.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
### Motivation

While doing messageReplay: if all the replay-entries are already acked then Dispatcher was not replaying any entry and also was not receiving a ```ReadEntriesCallback``` which keeps ```messagesToReplay``` in pending state and further reads couldn't read next entries.

### Modifications

If all the replay-entries are already acked 
- Dispatcher should remove it from ```messagesToReplay``` bucket
- mark ```messagesToReplay``` flag complete
- continue to do next readMoreEntries

### Result

Dispatcher will immediately mark ```messagesToReplay``` flag complete incase of all invalid-entries for replay and continue reading more messages and consumer will not be blocked while receiving messages.