### PR TITLE
add queue refill threshold configurable by consumer

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
@@ -47,6 +47,8 @@ public class ConsumerConfiguration implements Serializable {
 
     private long ackTimeoutMillis = 0;
 
+    private double receiverQueueRefillThreshold = 0.5;
+
     /**
      * @return the configured timeout in milliseconds for unacked messages.
      */
@@ -170,5 +172,24 @@ public class ConsumerConfiguration implements Serializable {
         checkArgument(consumerName != null && !consumerName.equals(""));
         this.consumerName = consumerName;
         return this;
+    }
+
+    /**
+     * Set receiver threshold for available permits.
+     * @param receiverQueueRefillThreshold
+     * @return
+     */
+    public ConsumerConfiguration setReceiverQueueRefillThreshold(double receiverQueueRefillThreshold) {
+        checkArgument(receiverQueueRefillThreshold >= 0.10 && receiverQueueRefillThreshold <= 0.99,
+                "Receiver Queue Threshold should be greater or equal than 0.10 and smaller or equal than 0.99");
+        this.receiverQueueRefillThreshold = receiverQueueRefillThreshold;
+        return this;
+    }
+
+    /**
+     * @return the configured threshold for available permits.
+     */
+    public double getReceiverQueueRefillThreshold() {
+        return this.receiverQueueRefillThreshold;
     }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
@@ -101,7 +101,7 @@ public class ConsumerImpl extends ConsumerBase {
         this.availablePermits = new AtomicInteger(0);
         this.subscribeTimeout = System.currentTimeMillis() + client.getConfiguration().getOperationTimeoutMs();
         this.partitionIndex = partitionIndex;
-        this.receiverQueueRefillThreshold = conf.getReceiverQueueSize() / 2;
+        this.receiverQueueRefillThreshold = (int)(conf.getReceiverQueueSize() * conf.getReceiverQueueRefillThreshold());
         this.codecProvider = new CompressionCodecProvider();
         batchMessageAckTracker = new ConcurrentSkipListMap<>();
         if (client.getConfiguration().getStatsIntervalSeconds() > 0) {


### PR DESCRIPTION
### Motivation

Be able to have consumers with different types of receiver queue threshold.

### Modifications

New configuration option for consumer.

### Result

Consumers can have different receiver queue threshold.

