### PR TITLE
Issue #80: Use receiveAsync() to aggregate messages into shared queue for partitioned consumer

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -125,9 +125,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     private final ScheduledExecutorService inactivityMonitor;
     private final ScheduledExecutorService messageExpiryMonitor;
 
-    private final ExecutorService lookupIoExecutor = new ThreadPoolExecutor(1, 16, 0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<Runnable>(), new DefaultThreadFactory("pulsar-lookup"));
-
     private DistributedIdGenerator producerNameGenerator;
 
     private final static String producerNameGeneratorPath = "/counters/producer-name";
@@ -385,11 +382,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                             pulsar.getConfiguration().getBrokerClientAuthenticationParameters());
                 }
                 if (configuration.isUseTls() && !data.getServiceUrlTls().isEmpty()) {
-                    return new PulsarClientImpl(data.getServiceUrlTls(), configuration, this.workerGroup,
-                            this.lookupIoExecutor);
+                    return new PulsarClientImpl(data.getServiceUrlTls(), configuration, this.workerGroup);
                 } else {
-                    return new PulsarClientImpl(data.getServiceUrl(), configuration, this.workerGroup,
-                            this.lookupIoExecutor);
+                    return new PulsarClientImpl(data.getServiceUrl(), configuration, this.workerGroup);
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -29,7 +29,6 @@ import com.yahoo.pulsar.client.api.PulsarClientException;
 import com.yahoo.pulsar.client.impl.BinaryProtoLookupService.LookupDataResult;
 import com.yahoo.pulsar.common.api.Commands;
 import com.yahoo.pulsar.common.api.PulsarHandler;
-import com.yahoo.pulsar.common.api.proto.PulsarApi.ServerError;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandCloseProducer;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConnected;
@@ -197,7 +196,7 @@ public class ClientCnx extends PulsarHandler {
             log.warn("{} Received unknown request id from server: {}", ctx.channel(), success.getRequestId());
         }
     }
-    
+
     @Override
     protected void handleLookupResponse(CommandLookupTopicResponse lookupResult) {
         log.info("Received Broker lookup response: {}", lookupResult.getResponse());
@@ -225,7 +224,7 @@ public class ClientCnx extends PulsarHandler {
             log.warn("{} Received unknown request id from server: {}", ctx.channel(), lookupResult.getRequestId());
         }
     }
-    
+
     @Override
     protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse lookupResult) {
         log.info("Received Broker Partition response: {}", lookupResult.getPartitions());
@@ -262,7 +261,7 @@ public class ClientCnx extends PulsarHandler {
             long sequenceId = sendError.getSequenceId();
             producers.get(producerId).recoverChecksumError(this, sequenceId);
         } else {
-            ctx.close();    
+            ctx.close();
         }
     }
 
@@ -307,7 +306,7 @@ public class ClientCnx extends PulsarHandler {
             log.warn("Consumer with id {} not found while closing consumer ", consumerId);
         }
     }
-    
+
     @Override
     protected boolean isHandshakeCompleted() {
         return state == State.Ready;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -47,10 +47,12 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
     protected final ExecutorService listenerExecutor;
     final BlockingQueue<Message> incomingMessages;
     protected final ConcurrentLinkedQueue<CompletableFuture<Message>> pendingReceives;
+    protected final int maxReceiverQueueSize;
 
     protected ConsumerBase(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
-            ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture, boolean useGrowableQueue) {
+            ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
         super(client, topic);
+        this.maxReceiverQueueSize = conf.getReceiverQueueSize();
         this.subscription = subscription;
         this.conf = conf;
         this.consumerName = conf.getConsumerName() == null
@@ -59,11 +61,10 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
         this.listener = conf.getMessageListener();
         if (conf.getReceiverQueueSize() <= 1) {
             this.incomingMessages = Queues.newArrayBlockingQueue(1);
-        } else if (useGrowableQueue) {
-            this.incomingMessages = new GrowableArrayBlockingQueue<>();
         } else {
-            this.incomingMessages = Queues.newArrayBlockingQueue(conf.getReceiverQueueSize());
+            this.incomingMessages = new GrowableArrayBlockingQueue<>();
         }
+
         this.listenerExecutor = listenerExecutor;
         this.pendingReceives = Queues.newConcurrentLinkedQueue();
     }

--- a/pulsar-testclient/src/main/java/com/yahoo/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/com/yahoo/pulsar/testclient/PerformanceConsumer.java
@@ -179,8 +179,7 @@ public class PerformanceConsumer {
         if (isNotBlank(arguments.authPluginClassName)) {
             clientConf.setAuthentication(arguments.authPluginClassName, arguments.authParams);
         }
-        PulsarClient pulsarClient = new PulsarClientImpl(arguments.serviceURL, clientConf, eventLoopGroup,
-                Executors.newFixedThreadPool(16));
+        PulsarClient pulsarClient = new PulsarClientImpl(arguments.serviceURL, clientConf, eventLoopGroup);
 
         List<Future<Consumer>> futures = Lists.newArrayList();
         ConsumerConfiguration consumerConfig = new ConsumerConfiguration();

--- a/pulsar-testclient/src/main/java/com/yahoo/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/com/yahoo/pulsar/testclient/PerformanceProducer.java
@@ -211,8 +211,7 @@ public class PerformanceProducer {
             clientConf.setAuthentication(arguments.authPluginClassName, arguments.authParams);
         }
 
-        PulsarClient client = new PulsarClientImpl(arguments.serviceURL, clientConf, eventLoopGroup,
-                Executors.newFixedThreadPool(16));
+        PulsarClient client = new PulsarClientImpl(arguments.serviceURL, clientConf, eventLoopGroup);
 
         ProducerConfiguration producerConf = new ProducerConfiguration();
         producerConf.setSendTimeout(0, TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation

Context can be found in #80. This is a slightly different approach from #83, using `receiveAsync()` and pausing and resuming reads depending on the shared queue utilization.
