### PR TITLE
Fix: Discovery-lookup returns correct PartitionMetadataResponse on partition-lookup

### DIFF
--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
@@ -377,10 +377,28 @@ public class Commands {
         return res;
     }
 
+    public static ByteBuf newPartitionMetadataResponse(String brokerServiceUrl, String brokerServiceUrlTls,
+            long requestId) {
+        CommandPartitionedTopicMetadataResponse.Builder partitionMetadataResponseBuilder = CommandPartitionedTopicMetadataResponse
+                .newBuilder();
+        partitionMetadataResponseBuilder.setBrokerServiceUrl(brokerServiceUrl);
+        partitionMetadataResponseBuilder.setBrokerServiceUrlTls(brokerServiceUrlTls);
+        partitionMetadataResponseBuilder.setResponse(CommandPartitionedTopicMetadataResponse.LookupType.Redirect);
+        partitionMetadataResponseBuilder.setRequestId(requestId);
+
+        CommandPartitionedTopicMetadataResponse partitionMetadataResponse = partitionMetadataResponseBuilder.build();
+        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.PARTITIONED_METADATA_RESPONSE)
+                .setPartitionMetadataResponse(partitionMetadataResponse));
+        partitionMetadataResponseBuilder.recycle();
+        partitionMetadataResponse.recycle();
+        return res;
+    }
+    
     public static ByteBuf newPartitionMetadataResponse(int partitions, long requestId) {
         CommandPartitionedTopicMetadataResponse.Builder partitionMetadataResponseBuilder = CommandPartitionedTopicMetadataResponse
                 .newBuilder();
         partitionMetadataResponseBuilder.setPartitions(partitions);
+        partitionMetadataResponseBuilder.setResponse(CommandPartitionedTopicMetadataResponse.LookupType.Success);
         partitionMetadataResponseBuilder.setRequestId(requestId);
 
         CommandPartitionedTopicMetadataResponse partitionMetadataResponse = partitionMetadataResponseBuilder.build();


### PR DESCRIPTION
### Motivation

Discovery-service-lookup using Binary-protocol was returning generic ```LookupTopicResponse``` rather specific and correct ```PartitionMetadataResponse``` for any ```PartitionMetadataRequest```.  

### Modifications

Corrected return response for ```PartitionMetadataRequest``` at Discovery-partition-lookup.
