### PR TITLE
Initialize lookup-request variables locally before request-instance recycle

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
@@ -497,6 +497,7 @@ public class ServerCnxTest {
         doReturn(authorizationManager).when(brokerService).getAuthorizationManager();
         doReturn(true).when(brokerService).isAuthenticationEnabled();
         doReturn(true).when(brokerService).isAuthorizationEnabled();
+        doReturn("prod1").when(brokerService).generateUniqueProducerName();
         resetChannel();
         setChannelConnected();
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BinaryProtoLookupService.java
@@ -15,7 +15,6 @@
  */
 package com.yahoo.pulsar.client.impl;
 
-import static com.yahoo.pulsar.client.impl.PulsarClientImpl.requestIdGenerator;
 import static java.lang.String.format;
 
 import java.net.InetSocketAddress;
@@ -34,13 +33,13 @@ import io.netty.buffer.ByteBuf;
 
 class BinaryProtoLookupService implements LookupService {
 
-    private final ConnectionPool cnxPool;
+    private final PulsarClientImpl client;
     protected final InetSocketAddress serviceAddress;
     private final boolean useTls;
 
-    public BinaryProtoLookupService(ConnectionPool cnxPool, String serviceUrl, boolean useTls)
+    public BinaryProtoLookupService(PulsarClientImpl client, String serviceUrl, boolean useTls)
             throws PulsarClientException {
-        this.cnxPool = cnxPool;
+        this.client = client;
         this.useTls = useTls;
         URI uri;
         try {
@@ -75,8 +74,8 @@ class BinaryProtoLookupService implements LookupService {
             DestinationName destination) {
         CompletableFuture<InetSocketAddress> addressFuture = new CompletableFuture<InetSocketAddress>();
 
-        cnxPool.getConnection(socketAddress).thenAccept(clientCnx -> {
-            long requestId = requestIdGenerator.getAndIncrement();
+        client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
+            long requestId = client.newRequestId();
             ByteBuf request = Commands.newLookup(destination.toString(), authoritative, requestId);
             clientCnx.newLookup(request, requestId).thenAccept(lookupDataResult -> {
                 URI uri = null;
@@ -133,8 +132,8 @@ class BinaryProtoLookupService implements LookupService {
 
         CompletableFuture<PartitionedTopicMetadata> partitionFuture = new CompletableFuture<PartitionedTopicMetadata>();
 
-        cnxPool.getConnection(socketAddress).thenAccept(clientCnx -> {
-            long requestId = requestIdGenerator.getAndIncrement();
+        client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
+            long requestId = client.newRequestId();
             ByteBuf request = Commands.newPartitionMetadataRequest(destination.toString(), requestId);
             clientCnx.newLookup(request, requestId).thenAccept(lookupDataResult -> {
                 try {

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
@@ -71,7 +71,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     private final AtomicLong producerIdGenerator = new AtomicLong();
     private final AtomicLong consumerIdGenerator = new AtomicLong();
-    protected static final AtomicLong requestIdGenerator = new AtomicLong();
+    private final AtomicLong requestIdGenerator = new AtomicLong();
 
     private final EventLoopGroup eventLoopGroup;
 
@@ -93,7 +93,7 @@ public class PulsarClientImpl implements PulsarClient {
                     conf.isTlsAllowInsecureConnection(), conf.getTlsTrustCertsFilePath());
             lookup = new HttpLookupService(httpClient, conf.isUseTls());
         } else {
-            lookup = new BinaryProtoLookupService(cnxPool, serviceUrl, conf.isUseTls());
+            lookup = new BinaryProtoLookupService(this, serviceUrl, conf.isUseTls());
         }
         timer = new HashedWheelTimer(new DefaultThreadFactory("pulsar-timer"), 1, TimeUnit.MILLISECONDS);
         externalExecutorProvider = new ExecutorProvider(conf.getListenerThreads(), "pulsar-external-listener");
@@ -363,6 +363,10 @@ public class PulsarClientImpl implements PulsarClient {
 
     long newRequestId() {
         return requestIdGenerator.getAndIncrement();
+    }
+
+    ConnectionPool getCnxPool() {
+        return cnxPool;
     }
 
     EventLoopGroup eventLoopGroup() {


### PR DESCRIPTION
### Motivation

As lookup (PartitionMetadata/Lookup-topic) requests being processed async: Lookup-request instance gets recycled immediately after main-io thread completes its process and triggers async-processing of request in a different thread. So, we need to copy request-variables locally for processing-thread before instance gets recycled.

### Modifications

Initialize lookup-request variable locally before Lookup-request instance gets recycled.

### Result

It returns lookup-response with correct response-value.