### PR TITLE
Fix: Error-log noise and split-package conflict while server startup

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -159,7 +159,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
 
     private boolean isPhysicalNic(Path path) {
         try {
-            if (!Files.readSymbolicLink(path).toString().contains("/virtual/")) {
+            path = Files.isSymbolicLink(path) ? Files.readSymbolicLink(path) : path;
+            if (!path.toString().contains("/virtual/")) {
                 try {
                     Files.readAllBytes(path.resolve("speed"));
                     return true;

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-buffer</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -44,12 +44,6 @@
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-buffer</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

- Split-package issue due to netty artifact conflict
```
com.yahoo.pulsar.PulsarBrokerStarter - Uncaught exception in thread main: io.netty.util.internal.MathUtil.safeFindNextPositivePowerOfTwo(I)I
java.lang.NoSuchMethodError: io.netty.util.internal.MathUtil.safeFindNextPositivePowerOfTwo(I)I
        at io.netty.buffer.PoolThreadCache$MemoryRegionCache.<init>(PoolThreadCache.java:372) ~[netty-buffer-4.0.42.Final.jar:4.0.42.Final]
```
- Error-logging noise: while deriving NIC path : below exception occurs while try to read nonSymbolicLink file 
```
INFO  c.y.p.zookeeper.ZooKeeperDataCache   - [State:CONNECTED Timeout:30000 sessionid:0x1565cebba204ff5 local:/10.210.13
...skipping...
java.nio.file.NotLinkException: /sys/class/net/bonding_masters
        at sun.nio.fs.UnixFileSystemProvider.readSymbolicLink(UnixFileSystemProvider.java:495) ~[na:1.8.0_102]
        at java.nio.file.Files.readSymbolicLink(Files.java:1432) ~[na:1.8.0_102]
        at com.yahoo.pulsar.broker.loadbalance.impl.LinuxBrokerHostUsageImpl.isPhysicalNic(LinuxBrokerHostUsageImpl.java:162)
```

### Modifications

- exclude conflicting ```netty-buffer``` artifact
- Precondition check while deriving NIC path to avoid error-logging noise 

### Result

- It will fix broker-deployment failure which may occur due to split-package conflict.
