### PR TITLE
Fix: split-package conflict while server startup

### DIFF
--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-buffer</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

- Split-package issue due to netty artifact conflict
```
com.yahoo.pulsar.PulsarBrokerStarter - Uncaught exception in thread main: io.netty.util.internal.MathUtil.safeFindNextPositivePowerOfTwo(I)I
java.lang.NoSuchMethodError: io.netty.util.internal.MathUtil.safeFindNextPositivePowerOfTwo(I)I
        at io.netty.buffer.PoolThreadCache$MemoryRegionCache.<init>(PoolThreadCache.java:372) ~[netty-buffer-4.0.42.Final.jar:4.0.42.Final]
```

### Modifications

- exclude conflicting ```netty-buffer``` artifact

### Result

- It will fix broker-deployment failure which may occur due to split-package conflict.

