### PR TITLE
exclude: conflicting artifact from async-http-client to avoid split-package conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,17 @@ flexible messaging model and an intuitive client API.</description>
 
   <dependencyManagement>
     <dependencies>
+    
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>2.0.19</version>
+        <exclusions>
+         <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -44,12 +44,6 @@
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-buffer</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

Fix: same as #122 : Avoid broker run time failure due to conflicting package-name of class.
