### PR TITLE
Cleanup pending lookup request on connection close

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/MockBrokerServiceHooks.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/MockBrokerServiceHooks.java
@@ -27,6 +27,14 @@ public interface MockBrokerServiceHooks {
         public void apply(ChannelHandlerContext ctx, PulsarApi.CommandConnect connect);
     }
 
+    public interface CommandPartitionLookupHook {
+        public void apply(ChannelHandlerContext ctx, PulsarApi.CommandPartitionedTopicMetadata connect);
+    }
+
+    public interface CommandTopicLookupHook {
+        public void apply(ChannelHandlerContext ctx, PulsarApi.CommandLookupTopic connect);
+    }
+
     public interface CommandSubscribeHook {
         public void apply(ChannelHandlerContext ctx, PulsarApi.CommandSubscribe subscribe);
     }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -106,6 +106,7 @@ public class ClientCnx extends PulsarHandler {
 
         // Fail out all the pending ops
         pendingRequests.forEach((key, future) -> future.completeExceptionally(e));
+        pendingLookupRequests.forEach((key, future) -> future.completeExceptionally(e));
 
         // Notify all attached producers/consumers so they have a chance to reconnect
         producers.forEach((id, producer) -> producer.connectionClosed(this));


### PR DESCRIPTION
### Motivation

Incase client lost connection with broker, all pendingLookupRequests get stuck. So, all pendingLookupRequests need to be failed on connection close with the broker.

### Modifications

Fail and cleanup pendingLookupRequest on connection close with broker.

### Result

producer/consumer connection with broker will not stuck and it can be reconnected for binaryProtoLookup.

