### PR TITLE
Fix Error in NodeJS consumer code

### DIFF
--- a/docs/WebSocket.md
+++ b/docs/WebSocket.md
@@ -271,10 +271,10 @@ ws.on('message', function(message) {
 ```javascript
 var WebSocket = require('ws');
 var socket = new WebSocket(
-	"ws://localhost:6080/pubilsh/persistent/my-property/us-west/my-ns/my-topic1/my-sub-1")
+	"ws://localhost:8080/ws/consumer/persistent/my-property/us-west/my-ns/my-topic1/my-sub1")
 
 socket.onmessage = function(pckt){
-	var receiveMsg = pckt.data;
+	var receiveMsg = JSON.parse(pckt.data);
 	var ackMsg = {"messageId" : receiveMsg.messageId}
 	socket.send(JSON.stringify(ackMsg));      
 };


### PR DESCRIPTION
### Motivation

There were some errors in the NodeJS consumer code for webservices

There was some problems with the URL and also the data packet coming in was a string and should be parsed...

The non parsing caused error in Ack which result in queue not deleting

### Modifications

I changed two parts in the consumer code document
1) URL
2) Add JSON.parse function to incoming data

### Result

publish and subscribe now works

