### PR TITLE
Support online consumer cursor reset

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -157,7 +157,7 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
         closeFuture = new CompletableFuture<>();
 
         if (!consumers.isEmpty()) {
-            consumers.forEach(consumer -> consumer.disconnect());
+            consumers.forEach(Consumer::disconnect);
             if (havePendingRead && cursor.cancelPendingReadRequest()) {
                 havePendingRead = false;
             }


### PR DESCRIPTION
### Motivation

A consumer should be able to reset it's cursor without taking down the process.

### Modifications

Allow for reset when consumers are connected.
Fence subscription, disconnect all consumer, reset cursor, the un-fence the subscription.

I'm a bit weary of fencing the subscription, if something would go wrong, we would leave the subscription locked, but I think it's the only way of making sure no consumer connects while we reset the cursor.

Anyway, What could happen if consumers are online while cursor is being reset? Maybe it's not such a bad thing, and disconnecting consumers is not a pretty way to handle this.

_Edit: [cursor reset](https://github.com/yahoo/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L646) seems to be pretty safe with respect to acks._

Just want a review to see if this is the correct way to do it, then I'll try to add a test case.

### Result

Consumer should now be able to reset cursors without taking down processes
