### PR TITLE
adminApi: add brokerServiceUrl while creating cluster

### DIFF
--- a/docs/AdminTools.md
+++ b/docs/AdminTools.md
@@ -400,7 +400,7 @@ It provisions a new cluster in Pulsar. It also requires Pulsar super-user privil
 ###### CLI
 
 ```
-$ pulsar-admin clusters create --url http://my-cluster.org.com:8080/ cl1
+$ pulsar-admin clusters create --url http://my-cluster.org.com:8080/ --broker-url pulsar://my-cluster.org.com:6650/ cl1
 ```
 
 ```
@@ -416,7 +416,7 @@ PUT /admin/clusters/{cluster}
 ###### Java
 
 ```java
-admin.clusters().createCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls))
+admin.clusters().createCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls))
 ```
 
 
@@ -434,7 +434,9 @@ $ pulsar-admin clusters get cl1
 ```json
 {
     "serviceUrl": "http://my-cluster.org.com:8080/",
-    "serviceUrlTls": null
+    "serviceUrlTls": null,
+    "brokerServiceUrl": "pulsar://my-cluster.org.com:6650/",
+    "brokerServiceUrlTls": null
 }
 ```
 
@@ -458,7 +460,7 @@ It updates cluster configuration data for a given existing cluster.
 ###### CLI
 
 ```
-$ pulsar-admin clusters update --url http://my-cluster.org.com:4081/ cl1
+$ pulsar-admin clusters update --url http://my-cluster.org.com:4081/ --broker-url pulsar://my-cluster.org.com:3350/ cl1
 ```
 
 ```
@@ -474,7 +476,7 @@ POST /admin/clusters/{cluster}
 ###### Java
 
 ```java
-admin.clusters().updateCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls))
+admin.clusters().updateCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls))
 ```
 
 

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdClusters.java
@@ -52,10 +52,17 @@ public class CmdClusters extends CmdBase {
 
         @Parameter(names = "--url-secure", description = "service-url for secure connection", required = false)
         private String serviceUrlTls;
+        
+        @Parameter(names = "--broker-url", description = "broker-service-url", required = false)
+        private String brokerServiceUrl;
+        
+        @Parameter(names = "--broker-url-secure", description = "broker-service-url for secure connection", required = false)
+        private String brokerServiceUrlTls;
 
         void run() throws PulsarAdminException {
             String cluster = getOneArgument(params);
-            admin.clusters().createCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls));
+            admin.clusters().createCluster(cluster,
+                    new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls));
         }
     }
 
@@ -69,10 +76,17 @@ public class CmdClusters extends CmdBase {
 
         @Parameter(names = "--url-secure", description = "service-url for secure connection", required = false)
         private String serviceUrlTls;
+        
+        @Parameter(names = "--broker-url", description = "broker-service-url", required = false)
+        private String brokerServiceUrl;
+        
+        @Parameter(names = "--broker-url-secure", description = "broker-service-url for secure connection", required = false)
+        private String brokerServiceUrlTls;
 
         void run() throws PulsarAdminException {
             String cluster = getOneArgument(params);
-            admin.clusters().updateCluster(cluster, new ClusterData(serviceUrl, serviceUrlTls));
+            admin.clusters().updateCluster(cluster,
+                    new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls));
         }
     }
 


### PR DESCRIPTION
### Motivation

Store ```brokerServiceUrl``` as part of cluster-data so, broker can use ```brokerServiceUrl``` for binary-proto-lookup while performing geo-replication.

### Modifications
AdminApi Tool/Documentation: pass ```brokerServiceUrl``` while creating/updating cluster.




