### PR TITLE
signSafeMod while getting next-broker index in discovery service

### DIFF
--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceServlet.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceServlet.java
@@ -15,6 +15,8 @@
  */
 package com.yahoo.pulsar.discovery.service.web;
 
+import static org.apache.bookkeeper.util.MathUtils.signSafeMod;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -151,7 +153,7 @@ public class DiscoveryServiceServlet extends HttpServlet {
             throw new RestException(Status.SERVICE_UNAVAILABLE, "No active broker is available");
         } else {
             int brokersCount = availableBrokers.size();
-            int nextIdx = Math.abs(counter.getAndIncrement()) % brokersCount;
+            int nextIdx = signSafeMod(counter.getAndIncrement(), brokersCount);
             return availableBrokers.get(nextIdx);
         }
     }


### PR DESCRIPTION
### Motivation

[compute safe modulo](http://stackoverflow.com/questions/5444611/math-abs-returns-wrong-value-for-integer-min-value) in case of overflow while getting next broker index.

### Modifications

We already have same fix for [DiscoveryProvider](https://github.com/yahoo/pulsar/blob/master/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java#L75) and [PulsarClient](https://github.com/rdhabalia/pulsar/blob/08fe7d836ae1f00abadebb5be83dc6fe2ca4d27b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConnectionPool.java#L118)





