### PR TITLE
Initialize: Minimum receiverQueueSize should be number of partitions in a partition consumer

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <groupId>com.yahoo.pulsar</groupId>
   <artifactId>pulsar</artifactId>
 
-  <version>1.15.3</version>
+  <version>1.15.4-SNAPSHOT</version>
 
   <name>Pulsar</name>
   <description>Pulsar is a distributed pub-sub messaging platform with a very

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>pulsar-broker-common</artifactId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-checksum/pom.xml
+++ b/pulsar-checksum/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>com.yahoo.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
-		<version>1.15.3</version>
+		<version>1.15.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -50,7 +50,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
     protected final int maxReceiverQueueSize;
 
     protected ConsumerBase(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
-            ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
+            int receiverQueueSize, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
         super(client, topic);
         this.maxReceiverQueueSize = conf.getReceiverQueueSize();
         this.subscription = subscription;
@@ -59,7 +59,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
                 ? DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 5) : conf.getConsumerName();
         this.subscribeFuture = subscribeFuture;
         this.listener = conf.getMessageListener();
-        if (conf.getReceiverQueueSize() <= 1) {
+        if (receiverQueueSize <= 1) {
             this.incomingMessages = Queues.newArrayBlockingQueue(1);
         } else {
             this.incomingMessages = new GrowableArrayBlockingQueue<>();

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
@@ -96,7 +96,7 @@ public class ConsumerImpl extends ConsumerBase {
 
     ConsumerImpl(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
             ExecutorService listenerExecutor, int partitionIndex, CompletableFuture<Consumer> subscribeFuture) {
-        super(client, topic, subscription, conf, listenerExecutor, subscribeFuture);
+        super(client, topic, subscription, conf, conf.getReceiverQueueSize(), listenerExecutor, subscribeFuture);
         this.consumerId = client.newConsumerId();
         this.availablePermits = new AtomicInteger(0);
         this.subscribeTimeout = System.currentTimeMillis() + client.getConfiguration().getOperationTimeoutMs();

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -60,7 +60,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     PartitionedConsumerImpl(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
             int numPartitions, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
-        super(client, topic, subscription, conf, listenerExecutor, subscribeFuture);
+        super(client, topic, subscription, conf, Math.max(numPartitions, conf.getReceiverQueueSize()), listenerExecutor,
+                subscribeFuture);
         this.consumers = Lists.newArrayListWithCapacity(numPartitions);
         this.pausedConsumers = new ConcurrentLinkedQueue<>();
         this.sharedQueueResumeThreshold = maxReceiverQueueSize / 2;

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-storm/pom.xml
+++ b/pulsar-storm/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.yahoo.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
-		<version>1.15.3</version>
+		<version>1.15.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.15.3</version>
+    <version>1.15.4-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
### Motivation

PartitionedConsumer with receiverQueueSize=1 initializes receiverQueue with type of ```ArrayBlockingQueue``` which can't consume messages from multiple partitions. Therefore, minimum size of  partitioned-consumer's receiverQueue should be: Number of partitions in the topic.

### Result

It can support partitioned-consumer with queue-size 1.
