### PR TITLE
Uri encoding for http topic lookup

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -59,7 +59,10 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         int numPartitions = 4;
-        DestinationName dn = DestinationName.get("persistent://my-property/use/my-ns/my-partitionedtopic1");
+        // creating topicName with special characters such as space,{,\,*,. for encoding
+        final String specialCharacter = "! * ' ( ) ; : @ & = + $ , /\\ ? % # [ ]";
+        final String topicName = "my-partitionedtopic1" + specialCharacter;
+        DestinationName dn = DestinationName.get("persistent://my-property/use/my-ns/" + topicName);
 
         ConsumerConfiguration conf = new ConsumerConfiguration();
         conf.setSubscriptionType(SubscriptionType.Exclusive);

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/LookupService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import com.yahoo.pulsar.client.util.FutureUtil;
 import com.yahoo.pulsar.common.lookup.data.LookupData;
 import com.yahoo.pulsar.common.naming.DestinationName;
+import static com.yahoo.pulsar.common.util.Codec.encode;
 
 class LookupService {
 
@@ -36,7 +37,7 @@ class LookupService {
 
     @SuppressWarnings("deprecation")
     public CompletableFuture<InetSocketAddress> getBroker(DestinationName destination) {
-        return httpClient.get(BasePath + destination.getLookupName(), LookupData.class).thenCompose(lookupData -> {
+        return httpClient.get(BasePath + getLookupName(destination), LookupData.class).thenCompose(lookupData -> {
             // Convert LookupData into as SocketAddress, handling exceptions
             try {
                 URI uri;
@@ -55,5 +56,11 @@ class LookupService {
                 return FutureUtil.failedFuture(e);
             }
         });
+    }
+    
+    public static String getLookupName(DestinationName destination) {
+        return String.format("%s/%s/%s/%s/%s", destination.getDomain(), destination.getProperty(),
+                destination.getCluster(), destination.getNamespacePortion(),
+                encode(destination.getLocalName()).replaceAll("\\+", "%20"));
     }
 }


### PR DESCRIPTION
### Motivation

As other client libraries follows uri encoding which encodes topic name different than existing ```java.net.URLDecoder``` encoding (URLDecoder encodes space as + compare to %20). This different encoding causes invalid bundle assignment at broker. We can close this PR if we decides to make change client-cpp library (or client-cpp will not have http lookup in future).

### Modifications

Http lookup url encoding as ```URLEncoder``` has only [reserved](http://www.permadi.com/tutorial/urlEncoding/) ```+ or %20``` separately for ```space```. 
### Result

Solve invalid bundle lookup for topic with special character such as space.

