### PR TITLE
Fix: PartitionedConsumer support queueSize 1

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -380,6 +380,57 @@ public class PartitionedProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
+    @Test(timeOut = 4000)
+    public void testAsyncPartitionedProducerConsumerQueueSizeOne() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final int totalMsg = 100;
+        final Set<String> produceMsgs = Sets.newHashSet();
+        final Set<String> consumeMsgs = Sets.newHashSet();
+
+        int numPartitions = 4;
+        DestinationName dn = DestinationName.get("persistent://my-property/use/my-ns/my-partitionedtopic1");
+
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(1);
+
+        admin.persistentTopics().createPartitionedTopic(dn.toString(), numPartitions);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        producerConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+        Producer producer = pulsarClient.createProducer(dn.toString(), producerConf);
+
+        Consumer consumer = pulsarClient.subscribe(dn.toString(), "my-partitioned-subscriber", conf);
+
+        // produce messages
+        for (int i = 0; i < totalMsg; i++) {
+            String message = "my-message-" + i;
+            produceMsgs.add(message);
+            producer.send(message.getBytes());
+        }
+
+        System.out.println(" start receiving messages :");
+
+        // receive messages
+        CountDownLatch latch = new CountDownLatch(totalMsg);
+        receiveAsync(consumer, totalMsg, 0, latch, consumeMsgs, Executors.newFixedThreadPool(1));
+
+        latch.await();
+
+        // verify message produced correctly
+        assertEquals(produceMsgs.size(), totalMsg);
+        // verify produced and consumed messages must be exactly same
+        produceMsgs.removeAll(consumeMsgs);
+        assertTrue(produceMsgs.isEmpty());
+
+        producer.close();
+        consumer.unsubscribe();
+        consumer.close();
+        admin.persistentTopics().deletePartitionedTopic(dn.toString());
+
+        log.info("-- Exiting {} test --", methodName);
+    }
+
     private void receiveAsync(Consumer consumer, int totalMessage, int currentMessage, CountDownLatch latch,
             final Set<String> consumeMsg, ExecutorService executor) throws PulsarClientException {
         if (currentMessage < totalMessage) {

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -51,16 +51,16 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
     protected final int maxReceiverQueueSize;
 
     protected ConsumerBase(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
-            ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
+            int receiverQueueSize, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
         super(client, topic);
-        this.maxReceiverQueueSize = conf.getReceiverQueueSize();
+        this.maxReceiverQueueSize = receiverQueueSize;
         this.subscription = subscription;
         this.conf = conf;
         this.consumerName = conf.getConsumerName() == null
                 ? DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 5) : conf.getConsumerName();
         this.subscribeFuture = subscribeFuture;
         this.listener = conf.getMessageListener();
-        if (conf.getReceiverQueueSize() <= 1) {
+        if (receiverQueueSize <= 1) {
             this.incomingMessages = Queues.newArrayBlockingQueue(1);
         } else {
             this.incomingMessages = new GrowableArrayBlockingQueue<>();

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
@@ -98,7 +98,7 @@ public class ConsumerImpl extends ConsumerBase {
 
     ConsumerImpl(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
                  ExecutorService listenerExecutor, int partitionIndex, CompletableFuture<Consumer> subscribeFuture) {
-        super(client, topic, subscription, conf, listenerExecutor, subscribeFuture);
+        super(client, topic, subscription, conf, conf.getReceiverQueueSize(), listenerExecutor, subscribeFuture);
         this.consumerId = client.newConsumerId();
         this.availablePermits = new AtomicInteger(0);
         this.subscribeTimeout = System.currentTimeMillis() + client.getConfiguration().getOperationTimeoutMs();

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -62,7 +62,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     PartitionedConsumerImpl(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
             int numPartitions, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
-        super(client, topic, subscription, conf, listenerExecutor, subscribeFuture);
+        super(client, topic, subscription, conf, Math.max(numPartitions, conf.getReceiverQueueSize()), listenerExecutor,
+                subscribeFuture);
         this.consumers = Lists.newArrayListWithCapacity(numPartitions);
         this.pausedConsumers = new ConcurrentLinkedQueue<>();
         this.sharedQueueResumeThreshold = maxReceiverQueueSize / 2;


### PR DESCRIPTION
### Motivation

#146 PartitionedConsumer with receiverQueueSize=1 initializes receiverQueue with type of ```ArrayBlockingQueue``` which can't consume messages from multiple partitions. Therefore, minimum size of  partitioned-consumer's receiverQueue should be: Number of partitions in the topic.

### Result

It can support partitioned-consumer with queue-size 1.