### PR TITLE
Safely stop(close replication-producer) and remove replicator

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -605,7 +605,8 @@ public class PersistentReplicator implements ReadEntriesCallback, DeleteCallback
             return disconnectFuture;
         }
 
-        if (producer != null && state.compareAndSet(State.Started, State.Stopping)) {
+        if (producer != null && (state.compareAndSet(State.Starting, State.Stopping)
+                || state.compareAndSet(State.Started, State.Stopping))) {
             log.info("[{}][{} -> {}] Disconnect replicator at position {} with backlog {}", topicName, localCluster,
                     remoteCluster, cursor.getMarkDeletedPosition(), cursor.getNumberOfEntriesInBacklog());
             return closeProducerAsync();

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -119,6 +119,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     public final String replicatorPrefix;
 
     private static final double MESSAGE_EXPIRY_THRESHOLD = 1.5;
+    
+    private static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
 
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
 
@@ -544,6 +546,22 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return closeFuture;
     }
 
+    private CompletableFuture<Void> checkReplicationAndRetryOnFailure() {
+        CompletableFuture<Void> result = new CompletableFuture<Void>();
+        checkReplication().thenAccept(res -> {
+            log.info("[{}] Policies updated successfully", topic);
+            result.complete(null);
+        }).exceptionally(th -> {
+            log.error("[{}] Policies update failed {}, scheduled retry in {} seconds", topic, th.getMessage(),
+                    POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, th);
+            brokerService.executor().schedule(this::checkReplicationAndRetryOnFailure,
+                    POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, TimeUnit.SECONDS);
+            result.completeExceptionally(th);
+            return null;
+        });
+        return result;
+    }
+    
     @Override
     public CompletableFuture<Void> checkReplication() {
         DestinationName name = DestinationName.get(topic);
@@ -665,15 +683,13 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.error("[{}] Failed to delete cursor {}", topic, name);
-                    // Connect the producers back
-                    replicators.get(remoteCluster).startProducer();
+                    log.error("[{}] Failed to delete cursor {} {}", topic, name, exception.getMessage(), exception);
                     future.completeExceptionally(new PersistenceException(exception));
                 }
             }, null);
 
         }).exceptionally(e -> {
-            log.error("[{}] Failed to close replication producer {}", topic, name);
+            log.error("[{}] Failed to close replication producer {} {}", topic, name, e.getMessage(), e);
             future.completeExceptionally(e);
             return null;
         });
@@ -1082,7 +1098,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         producers.forEach(Producer::checkPermissions);
         subscriptions.forEach((subName, sub) -> sub.getConsumers().forEach(Consumer::checkPermissions));
         checkMessageExpiry();
-        return checkReplication();
+        return checkReplicationAndRetryOnFailure();
     }
 
     /**

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/Policies.java
@@ -73,4 +73,15 @@ public class Policies {
         bundle.setBoundaries(boundaries);
         return bundle;
     }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("auth_policies", auth_policies)
+                .add("replication_clusters", replication_clusters).add("bundles", bundles)
+                .add("backlog_quota_map", backlog_quota_map).add("persistence", persistence)
+                .add("latency_stats_sample_rate", latency_stats_sample_rate)
+                .add("message_ttl_in_seconds", message_ttl_in_seconds).add("retention_policies", retention_policies)
+                .add("deleted", deleted).toString();
+    }
+    
 }


### PR DESCRIPTION
### Motivation

- Safely close replication-producer while disconnecting replicator
- While deleting replication-cluster of the topic: Sometime broker fails to delete replicator-cursor and it tries to restart even after closing the cursor. It causes broker to retries cursor-recovery for already deleted replicator-cluster.

### Modifications

- On replicator-disconnect: close producer even it's not connected with remote yet.
- Avoid restarting of replicator when get error while deleting cursor.

### Result

- It will prevent producer to reconnect event after replicator disconnection
- It will prevent broker to keep retrying cursor recovery for already deleted replication-cluster.

