### PR TITLE
Fix: Fair message consumption from all partitions in partitioned-cons…

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -126,8 +126,10 @@ public class PartitionedConsumerImpl extends ConsumerBase {
             // Process the message, add to the queue and trigger listener or async callback
             messageReceived(message);
 
-            if (incomingMessages.size() >= maxReceiverQueueSize) {
-                // No more space left in shared queue, mark this consumer to be resumed later
+            if (incomingMessages.size() >= maxReceiverQueueSize
+                    || (incomingMessages.size() > sharedQueueResumeThreshold && !pausedConsumers.isEmpty())) {
+                // mark this consumer to be resumed later: if No more space left in shared queue,
+                // or if any consumer is already paused (to create fair chance for already paused consumers)
                 pausedConsumers.add(consumer);
             } else {
                 // Schedule next receiveAsync() if the incoming queue is not full. Use a different thread to avoid


### PR DESCRIPTION
…umer

### Motivation

Based on #153 (creating patch to branch-1.15) : Partitioned-consumer may not fairly consume messages from consumers added into ```pausedConsumers``` list until client clean-up queue up to ```sharedQueueResumeThreshold``` by receiving messages from the queue.  

### Modifications

consume from ```pausedConsumers``` when queue has space to add message.

### Result

All partitioned-consumers will have fair chance to consume messages.
