### PR TITLE
Support url/uri encoding of topic-name for http-request

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/lookup/DestinationLookup.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.yahoo.pulsar.common.lookup.data.LookupData;
 import com.yahoo.pulsar.common.naming.DestinationName;
 import com.yahoo.pulsar.broker.web.NoSwaggerDocumentation;
+import com.yahoo.pulsar.common.util.Codec;
 
 @Path("/v2/destination/")
 @NoSwaggerDocumentation
@@ -45,8 +47,9 @@ public class DestinationLookup extends LookupResource {
     @Path("persistent/{property}/{cluster}/{namespace}/{dest}")
     @Produces(MediaType.APPLICATION_JSON)
     public LookupData lookupDestination(@PathParam("property") String property, @PathParam("cluster") String cluster,
-            @PathParam("namespace") String namespace, @PathParam("dest") String dest,
+            @PathParam("namespace") String namespace, @PathParam("dest") @Encoded String dest,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) throws URISyntaxException {
+        dest = Codec.decode(dest);
         DestinationName fqdn = DestinationName.get("persistent", property, cluster, namespace, dest);
         return lookupFQDN(fqdn, authoritative);
     }

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/lookup/data/LookupDataTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/lookup/data/LookupDataTest.java
@@ -19,10 +19,10 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.Test;
 
-import com.yahoo.pulsar.common.lookup.data.LookupData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.pulsar.common.util.Codec;
 import com.yahoo.pulsar.common.util.ObjectMapperFactory;
 
 @Test
@@ -49,5 +49,15 @@ public class LookupDataTest {
         assertEquals(jsonMap.get("brokerUrlSsl"), "");
         assertEquals(jsonMap.get("nativeUrl"), "pulsar://localhost:8888");
         assertEquals(jsonMap.get("httpUrl"), "http://localhost:8080");
+    }
+
+    @Test
+    void testUrlEncoder() {
+        final String str = "specialCharacters_+&*%{}() \\/$@#^%";
+        final String urlEncoded = Codec.encode(str);
+        final String uriEncoded = urlEncoded.replaceAll("//+", "%20");
+        assertEquals("specialCharacters_%2B%26*%25%7B%7D%28%29+%5C%2F%24%40%23%5E%25", urlEncoded);
+        assertEquals(str, Codec.decode(urlEncoded));
+        assertEquals(Codec.decode(urlEncoded), Codec.decode(uriEncoded));
     }
 }


### PR DESCRIPTION
### Motivation

Based on #148 (creating patch on branch-1.15): Broker has lookup and admin REST-api on top of JAX-RS which doesn't follow urlencoding spec while decoding query-param.
```application/x-www-form-urlencoded uses + and properly encoded URIs use %20```. So, if client sends request with url-encoded query-param (topicName) then broker may not decode it properly due to jax-rs limitation. Therefore, broker should use url-decoder which can handle decoding properly. ( both ```+``` and ``` %20``` can be decoded into space)

### Modifications

Take encoded topic-name query-param from the http-request and decodes it using url-encoder.

### Result

Broker can support both url/uri encoded topic-name request (lookup and admin rest-api).