### PR TITLE
Validate cursor-readPosition before reading while checkingBacklogCursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -733,6 +733,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             long backlogEntries = cursor.getNumberOfEntries();
             if (backlogEntries > maxActiveCursorBacklogEntries) {
                 PositionImpl readPosition = (PositionImpl) cursor.getReadPosition();
+                readPosition = isValidPosition(readPosition) ? readPosition : getNextValidPosition(readPosition);
+                if (readPosition == null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Couldn't find valid read position [{}] {}", name, cursor.getName(),
+                                cursor.getReadPosition());
+                    }
+                    continue;
+                }
                 try {
                     asyncReadEntry(readPosition, new ReadEntryCallback() {
 


### PR DESCRIPTION
### Motivation

Cursor's ```readPosition``` might not be a valid (when cursor read last entry of the ledger) when ```checkBackloggedCursors``` task tries to read from BK and it raises below exception due to invalid entry: 
```
Caused by: org.apache.bookkeeper.client.BKException$BKReadException: null
at org.apache.bookkeeper.client.LedgerHandle.asyncReadEntries(LedgerHandle.java:459)
```

### Modifications

Get next valid entry before reading from BK if cursor's current ```readPosition``` is invalid.

### Result

It prevents to failure of checkBacklogCursor if cursor's readPosition is invalid. 
