### PR TITLE
Unload bundle: close topic forcefully and enable bundle on ownership removal failure

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/NamespaceService.java
@@ -677,15 +677,15 @@ public class NamespaceService {
     }
 
     public void removeOwnedServiceUnit(NamespaceName nsName) throws Exception {
-        ownershipCache.removeOwnership(getFullBundle(nsName));
+        ownershipCache.removeOwnership(getFullBundle(nsName)).get();
     }
 
     public void removeOwnedServiceUnit(NamespaceBundle nsBundle) throws Exception {
-        ownershipCache.removeOwnership(nsBundle);
+        ownershipCache.removeOwnership(nsBundle).get();
     }
 
     public void removeOwnedServiceUnits(NamespaceName nsName, BundlesData bundleData) throws Exception {
-        ownershipCache.removeOwnership(bundleFactory.getBundles(nsName, bundleData));
+        ownershipCache.removeOwnership(bundleFactory.getBundles(nsName, bundleData)).get();
     }
 
     public NamespaceBundleFactory getNamespaceBundleFactory() {

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -258,7 +258,7 @@ public class OwnershipCacheTest {
         // case 1: no one owns the namespace
         assertFalse(cache.getOwnerAsync(bundle).get().isPresent());
 
-        cache.removeOwnership(bundle);
+        cache.removeOwnership(bundle).get();
         assertTrue(cache.getOwnedBundles().isEmpty());
 
         // case 2: this broker owns the namespace
@@ -267,6 +267,7 @@ public class OwnershipCacheTest {
         assertTrue(!data1.isDisabled());
         assertTrue(cache.getOwnedBundles().size() == 1);
         cache.removeOwnership(bundle);
+        Thread.sleep(500);
         assertTrue(cache.getOwnedBundles().isEmpty());
 
         Thread.sleep(500);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
@@ -232,7 +232,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         }
 
         // restore the namespace state
-        ownerCache.removeOwnership(globalNsBundle);
+        ownerCache.removeOwnership(globalNsBundle).get();
         ownerCache.tryAcquiringOwnership(globalNsBundle);
     }
 


### PR DESCRIPTION
### Motivation

while unloading namespace bundle if ```topic.close()``` fails then bundle gets stuck by staying in ```disable``` state. Therefore, unload bundle should close topic forcefully and failure in deletion of bundle-ownership node should revert bundle state to ```enable``` back so, it can serve new topics again.

### Modifications

- close topic forcefully while unloading namespace bundle
- enable namespace bundle if unloading namespace fails

### Result

bundle will not be in stuck state in case of failure in unloading namespace bundle.
