### PR TITLE
Message dispatching based on consumer priority-level

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
@@ -60,6 +60,7 @@ public class Consumer {
     private final String appId;
 
     private final long consumerId;
+    private final int priorityLevel;
     private final String consumerName;
     private final Rate msgOut;
     private final Rate msgRedeliver;
@@ -87,12 +88,13 @@ public class Consumer {
     private volatile int unackedMessages = 0;
     private volatile boolean blockedConsumerOnUnackedMsgs = false;
 
-    public Consumer(Subscription subscription, SubType subType, long consumerId, String consumerName,
+    public Consumer(Subscription subscription, SubType subType, long consumerId, int priorityLevel, String consumerName,
             int maxUnackedMessages, ServerCnx cnx, String appId) throws BrokerServiceException {
 
         this.subscription = subscription;
         this.subType = subType;
         this.consumerId = consumerId;
+        this.priorityLevel = priorityLevel;
         this.consumerName = consumerName;
         this.maxUnackedMessages = maxUnackedMessages;
         this.cnx = cnx;
@@ -454,8 +456,10 @@ public class Consumer {
     public ConcurrentOpenHashMap<PositionImpl, Integer> getPendingAcks() {
         return pendingAcks;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(Consumer.class);
+    
+    public int getPriorityLevel() {
+        return priorityLevel;
+    }
 
     public void redeliverUnacknowledgedMessages() {
         // cleanup unackedMessage bucket and redeliver those unack-msgs again
@@ -504,4 +508,6 @@ public class Consumer {
             subscription.consumerFlow(this, numberOfBlockedPermits);
         }
     }
+    
+    private static final Logger log = LoggerFactory.getLogger(Consumer.class);
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/ServerCnx.java
@@ -246,6 +246,7 @@ public class ServerCnx extends PulsarHandler {
         final long consumerId = subscribe.getConsumerId();
         final SubType subType = subscribe.getSubType();
         final String consumerName = subscribe.getConsumerName();
+        final int priorityLevel = subscribe.hasPriorityLevel() ? subscribe.getPriorityLevel() : 0;
 
         authorizationFuture.thenApply(isAuthorized -> {
             if (isAuthorized) {
@@ -278,7 +279,7 @@ public class ServerCnx extends PulsarHandler {
                 }
 
                 service.getTopic(topicName).thenCompose(
-                        topic -> topic.subscribe(ServerCnx.this, subscriptionName, consumerId, subType, consumerName))
+                        topic -> topic.subscribe(ServerCnx.this, subscriptionName, consumerId, subType, priorityLevel, consumerName))
                         .thenAccept(consumer -> {
                             if (consumerFuture.complete(consumer)) {
                                 log.info("[{}] Created subscription on topic {} / {}", remoteAddress, topicName,

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
@@ -39,7 +39,7 @@ public interface Topic {
     void removeProducer(Producer producer);
 
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
-            String consumerName);
+            int priorityLevel, String consumerName);
 
     CompletableFuture<Void> unsubscribe(String subName);
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -299,7 +299,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
     @Override
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
-            SubType subType, String consumerName) {
+            SubType subType, int priorityLevel, String consumerName) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
@@ -336,7 +336,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                     PersistentSubscription subscription = subscriptions.computeIfAbsent(subscriptionName,
                             name -> new PersistentSubscription(PersistentTopic.this, cursor));
                     
-                    Consumer consumer = new Consumer(subscription, subType, consumerId, consumerName,
+                    Consumer consumer = new Consumer(subscription, subType, consumerId, priorityLevel, consumerName,
                             brokerService.pulsar().getConfiguration().getMaxUnackedMessagesPerConsumer(), cnx,
                             cnx.getRole());
                     subscription.addConsumer(consumer);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -31,6 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
@@ -309,10 +310,10 @@ public class PersistentDispatcherFailoverConsumerTest {
 
     private Consumer getNextConsumer(PersistentDispatcherMultipleConsumers dispatcher) throws Exception {
         Consumer consumer = dispatcher.getNextConsumer();
-        Field field = Consumer.class.getDeclaredField("messagePermits");
+        Field field = Consumer.class.getDeclaredField("MESSAGE_PERMITS_UPDATER");
         field.setAccessible(true);
-        AtomicInteger messagePermits = (AtomicInteger) field.get(consumer);
-        messagePermits.decrementAndGet();
+        AtomicIntegerFieldUpdater<Consumer> messagePermits = (AtomicIntegerFieldUpdater) field.get(consumer);
+        messagePermits.decrementAndGet(consumer);
         return consumer;
     }
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -26,9 +26,11 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
@@ -46,6 +48,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -60,6 +63,7 @@ import com.yahoo.pulsar.broker.namespace.NamespaceService;
 import com.yahoo.pulsar.broker.service.Consumer;
 import com.yahoo.pulsar.broker.service.BrokerService;
 import com.yahoo.pulsar.broker.service.ServerCnx;
+import com.yahoo.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import com.yahoo.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
 import com.yahoo.pulsar.broker.service.persistent.PersistentSubscription;
 import com.yahoo.pulsar.broker.service.persistent.PersistentTopic;
@@ -191,7 +195,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertFalse(pdfc.isConsumerConnected());
 
         // 2. Add consumer
-        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, "Cons1"/* consumer name */,
+        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, 0, "Cons1"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
@@ -208,7 +212,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer1.consumerName());
 
         // 5. Add another consumer which does not change active consumer
-        Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, "Cons2"/* consumer name */,
+        Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, 0, "Cons2"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
@@ -216,7 +220,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertEquals(3, consumers.size());
 
         // 6. Add a consumer which changes active consumer
-        Consumer consumer0 = new Consumer(sub, SubType.Exclusive, 0 /* consumer id */, "Cons0"/* consumer name */,
+        Consumer consumer0 = new Consumer(sub, SubType.Exclusive, 0 /* consumer id */, 0, "Cons0"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer0);
         consumers = pdfc.getConsumers();
@@ -256,6 +260,69 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 11. With only one consumer, unsubscribe is allowed
         assertTrue(pdfc.canUnsubscribe(consumer1));
 
+    }
+    
+    @Test
+    public void testMultipleDispatcherGetNextConsumerWithDifferentPriorityLevel() throws Exception {
+
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        Consumer consumer1 = createConsumer(0, 2, 1);
+        Consumer consumer2 = createConsumer(0, 2, 2);
+        Consumer consumer3 = createConsumer(0, 2, 3);
+        Consumer consumer4 = createConsumer(1, 2, 4);
+        Consumer consumer5 = createConsumer(1, 1, 5);
+        Consumer consumer6 = createConsumer(1, 2, 6);
+        Consumer consumer7 = createConsumer(2, 1, 7);
+        Consumer consumer8 = createConsumer(2, 1, 8);
+        Consumer consumer9 = createConsumer(2, 1, 9);
+        dispatcher.addConsumer(consumer1);
+        dispatcher.addConsumer(consumer2);
+        dispatcher.addConsumer(consumer3);
+        dispatcher.addConsumer(consumer4);
+        dispatcher.addConsumer(consumer5);
+        dispatcher.addConsumer(consumer6);
+        dispatcher.addConsumer(consumer7);
+        dispatcher.addConsumer(consumer8);
+        dispatcher.addConsumer(consumer9);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer1);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer2);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer3);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer1);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer2);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer3);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer5);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer6);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer6);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer7);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer8);
+        // in between add upper priority consumer with more permits
+        Consumer consumer10 = createConsumer(0, 2, 10);
+        dispatcher.addConsumer(consumer10);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer10);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer10);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer9);
+
+    }
+
+    private Consumer getNextConsumer(PersistentDispatcherMultipleConsumers dispatcher) throws Exception {
+        Consumer consumer = dispatcher.getNextConsumer();
+        Field field = Consumer.class.getDeclaredField("messagePermits");
+        field.setAccessible(true);
+        AtomicInteger messagePermits = (AtomicInteger) field.get(consumer);
+        messagePermits.decrementAndGet();
+        return consumer;
+    }
+
+    private Consumer createConsumer(int priority, int permit, int id) throws BrokerServiceException {
+        Consumer consumer = new Consumer(null, SubType.Shared, id, priority, ""+id, 5000, serverCnx, "appId");
+        try {
+            consumer.flowPermits(permit);
+        } catch (Exception e) {
+        }
+        return consumer;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentDispatcherFailoverConsumerTest.class);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -115,7 +115,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -173,7 +173,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -235,7 +235,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -293,7 +293,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicTest.java
@@ -333,12 +333,12 @@ public class PersistentTopicTest {
 
         // 1. simple subscribe
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         // 2. duplicate subscribe
         Future<Consumer> f2 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
 
         try {
             f2.get();
@@ -361,7 +361,7 @@ public class PersistentTopicTest {
         PersistentSubscription sub = new PersistentSubscription(topic, cursorMock);
 
         // 1. simple add consumer
-        Consumer consumer = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, "Cons1"/* consumer name */,
+        Consumer consumer = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, 0, "Cons1"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         sub.addConsumer(consumer);
         assertTrue(sub.getDispatcher().isConsumerConnected());
@@ -391,7 +391,7 @@ public class PersistentTopicTest {
     public void testUbsubscribeRaceConditions() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentSubscription sub = new PersistentSubscription(topic, cursorMock);
-        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, "Cons1"/* consumer name */,
+        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, 0, "Cons1"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         sub.addConsumer(consumer1);
 
@@ -413,7 +413,7 @@ public class PersistentTopicTest {
 
         try {
             Thread.sleep(10); /* delay to ensure that the ubsubscribe gets executed first */
-            Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, "Cons2"/* consumer name */,
+            Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, 0, "Cons2"/* consumer name */,
                     50000, serverCnx, "myrole-1");
         } catch (BrokerServiceException e) {
             assertTrue(e instanceof BrokerServiceException.SubscriptionFencedException);
@@ -443,7 +443,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -458,7 +458,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -512,7 +512,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -598,7 +598,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                cmd.getConsumerName());
+                0, cmd.getConsumerName());
 
         try {
             f.get();
@@ -709,7 +709,7 @@ public class PersistentTopicTest {
 
         // 1. Subscribe with non partition topic
         Future<Consumer> f1 = topic1.subscribe(serverCnx, cmd1.getSubscription(), cmd1.getConsumerId(),
-                cmd1.getSubType(), cmd1.getConsumerName());
+                cmd1.getSubType(), 0, cmd1.getConsumerName());
         f1.get();
 
         // 2. Subscribe with partition topic
@@ -720,7 +720,7 @@ public class PersistentTopicTest {
                 .setSubType(SubType.Failover).build();
 
         Future<Consumer> f2 = topic2.subscribe(serverCnx, cmd2.getSubscription(), cmd2.getConsumerId(),
-                cmd2.getSubType(), cmd2.getConsumerName());
+                cmd2.getSubType(), 0, cmd2.getConsumerName());
         f2.get();
 
         // 3. Subscribe and create second consumer
@@ -729,7 +729,7 @@ public class PersistentTopicTest {
                 .setSubType(SubType.Failover).build();
 
         Future<Consumer> f3 = topic2.subscribe(serverCnx, cmd3.getSubscription(), cmd3.getConsumerId(),
-                cmd3.getSubType(), cmd3.getConsumerName());
+                cmd3.getSubType(), 0, cmd3.getConsumerName());
         f3.get();
 
         assertEquals(
@@ -749,7 +749,7 @@ public class PersistentTopicTest {
                 .setSubType(SubType.Failover).build();
 
         Future<Consumer> f4 = topic2.subscribe(serverCnx, cmd4.getSubscription(), cmd4.getConsumerId(),
-                cmd4.getSubType(), cmd4.getConsumerName());
+                cmd4.getSubType(), 0, cmd4.getConsumerName());
         f4.get();
 
         assertEquals(
@@ -774,7 +774,7 @@ public class PersistentTopicTest {
                 .setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f5 = topic2.subscribe(serverCnx, cmd5.getSubscription(), cmd5.getConsumerId(),
-                cmd5.getSubType(), cmd5.getConsumerName());
+                cmd5.getSubType(), 0, cmd5.getConsumerName());
 
         try {
             f5.get();
@@ -790,7 +790,7 @@ public class PersistentTopicTest {
                 .setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f6 = topic2.subscribe(serverCnx, cmd6.getSubscription(), cmd6.getConsumerId(),
-                cmd6.getSubType(), cmd6.getConsumerName());
+                cmd6.getSubType(), 0, cmd6.getConsumerName());
         f6.get();
 
         // 7. unsubscribe exclusive sub

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
@@ -646,12 +646,12 @@ public class ServerCnxTest {
         doReturn(delayFuture).when(brokerService).getTopic(any(String.class));
         // Create subscriber first time
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
 
         // Create producer second time
         clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
 
         Object response = getResponse();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
@@ -451,7 +451,7 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf newSubscribeCmd = Commands.newSubscribe(nonExistentTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(newSubscribeCmd);
         assertTrue(getResponse() instanceof CommandError);
     }
@@ -504,7 +504,7 @@ public class ServerCnxTest {
         resetChannel();
         setChannelConnected();
         ByteBuf newSubscribeCmd = Commands.newSubscribe(nonExistentTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(newSubscribeCmd);
         topicRef = (PersistentTopic) brokerService.getTopicReference(nonExistentTopicName);
         assertNotNull(topicRef);
@@ -617,7 +617,7 @@ public class ServerCnxTest {
         // Sending multiple subscribe commands for the same consumer should succeed
 
         ByteBuf subscribe1 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe1);
 
         // 1st subscribe succeeds
@@ -626,7 +626,7 @@ public class ServerCnxTest {
         assertEquals(((CommandSuccess) response).getRequestId(), 1);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 2 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 2 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe2);
 
         // 2nd subscribe succeeds
@@ -892,22 +892,22 @@ public class ServerCnxTest {
         // (There can be more subscribe/close pairs in the sequence, depending on the client timeout
 
         ByteBuf subscribe1 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe1);
 
         ByteBuf closeConsumer = Commands.newCloseConsumer(1 /* consumer id */, 2 /* request id */ );
         channel.writeInbound(closeConsumer);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe2);
 
         ByteBuf subscribe3 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe3);
 
         ByteBuf subscribe4 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 5 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 5 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe4);
 
         openTopicTask.get().run();
@@ -975,14 +975,14 @@ public class ServerCnxTest {
         // These operations need to be serialized, to allow the last subscribe operation to finally succeed
         // (There can be more subscribe/close pairs in the sequence, depending on the client timeout
         ByteBuf subscribe1 = Commands.newSubscribe(failTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe1);
 
         ByteBuf closeConsumer = Commands.newCloseConsumer(1 /* consumer id */, 2 /* request id */ );
         channel.writeInbound(closeConsumer);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 3 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe2);
 
         openTopicFail.get().run();
@@ -1004,7 +1004,7 @@ public class ServerCnxTest {
         }
 
         ByteBuf subscribe3 = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 4 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(subscribe3);
 
         openTopicSuccess.get().run();
@@ -1033,7 +1033,7 @@ public class ServerCnxTest {
         doReturn(false).when(brokerService).isAuthorizationEnabled();
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 
@@ -1045,7 +1045,7 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic creation success and cursor failure
         clientCommand = Commands.newSubscribe(successTopicName, failSubName, 2, 2, SubType.Exclusive,
-                "test" /*
+                0, "test" /*
                         * consumer name
                         */);
         channel.writeInbound(clientCommand);
@@ -1053,7 +1053,7 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic creation failure
         clientCommand = Commands.newSubscribe(failTopicName, successSubName, 3, 3, SubType.Exclusive,
-                "test" /*
+                0, "test" /*
                         * consumer name
                         */);
         channel.writeInbound(clientCommand);
@@ -1077,7 +1077,7 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
 
         assertTrue(getResponse() instanceof CommandSuccess);
@@ -1098,7 +1098,7 @@ public class ServerCnxTest {
 
         // test SUBSCRIBE on topic and cursor creation success
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, //
-                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                successSubName, 1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandError);
 
@@ -1113,7 +1113,7 @@ public class ServerCnxTest {
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, successSubName, 1 /* consumer id */,
                 1 /*
                    * request id
-                   */, SubType.Exclusive, "test" /* consumer name */);
+                   */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 
@@ -1134,7 +1134,7 @@ public class ServerCnxTest {
         setChannelConnected();
 
         ByteBuf clientCommand = Commands.newSubscribe(successTopicName, successSubName, //
-                1 /* consumer id */, 1 /* request id */, SubType.Exclusive, "test" /* consumer name */);
+                1 /* consumer id */, 1 /* request id */, SubType.Exclusive, 0, "test" /* consumer name */);
         channel.writeInbound(clientCommand);
         assertTrue(getResponse() instanceof CommandSuccess);
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
@@ -180,13 +180,21 @@ public class ConsumerConfiguration implements Serializable {
 
     /**
      * Sets priority level for the shared subscription consumers to which broker gives more priority while dispatching
-     * messages.
-     * </p> 
-     * In Shared subscription mode, broker will first dispatch messages to upper priority-level consumers if they
-     * have permits, else broker will consider next priority level consumers.
-     * </p> 
-     * If subscription has consumer-A with  priorityLevel 1 and Consumer-B with priorityLevel 2 then broker will dispatch 
+     * messages. Here, broker follows descending priorities. (eg: 0=max-priority, 1, 2,..) </br>
+     * In Shared subscription mode, broker will first dispatch messages to max priority-level consumers if they have
+     * permits, else broker will consider next priority level consumers. </br>
+     * If subscription has consumer-A with priorityLevel 0 and Consumer-B with priorityLevel 1 then broker will dispatch
      * messages to only consumer-A until it runs out permit and then broker starts dispatching messages to Consumer-B.
+     * 
+     * <pre>
+     * Consumer PriorityLevel Permits
+     * C1       0             2
+     * C2       0             1
+     * C3       0             1
+     * C4       1             2
+     * C5       1             1
+     * Order in which broker dispatches messages to consumers: C1, C2, C3, C1, C4, C5, C4
+     * </pre>
      * 
      * @param priorityLevel
      */

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ConsumerConfiguration.java
@@ -46,6 +46,8 @@ public class ConsumerConfiguration implements Serializable {
     private String consumerName = null;
 
     private long ackTimeoutMillis = 0;
+    
+    private int priorityLevel = 0;
 
     /**
      * @return the configured timeout in milliseconds for unacked messages.
@@ -170,5 +172,25 @@ public class ConsumerConfiguration implements Serializable {
         checkArgument(consumerName != null && !consumerName.equals(""));
         this.consumerName = consumerName;
         return this;
+    }
+    
+    public int getPriorityLevel() {
+        return priorityLevel;
+    }
+
+    /**
+     * Sets priority level for the shared subscription consumers to which broker gives more priority while dispatching
+     * messages.
+     * </p> 
+     * In Shared subscription mode, broker will first dispatch messages to upper priority-level consumers if they
+     * have permits, else broker will consider next priority level consumers.
+     * </p> 
+     * If subscription has consumer-A with  priorityLevel 1 and Consumer-B with priorityLevel 2 then broker will dispatch 
+     * messages to only consumer-A until it runs out permit and then broker starts dispatching messages to Consumer-B.
+     * 
+     * @param priorityLevel
+     */
+    public void setPriorityLevel(int priorityLevel) {
+        this.priorityLevel = priorityLevel;
     }
 }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
@@ -281,7 +281,7 @@ public class Commands {
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
-            SubType subType, String consumerName) {
+            SubType subType, int priorityLevel, String consumerName) {
         CommandSubscribe.Builder subscribeBuilder = CommandSubscribe.newBuilder();
         subscribeBuilder.setTopic(topic);
         subscribeBuilder.setSubscription(subscription);
@@ -289,6 +289,7 @@ public class Commands {
         subscribeBuilder.setConsumerId(consumerId);
         subscribeBuilder.setConsumerName(consumerName);
         subscribeBuilder.setRequestId(requestId);
+        subscribeBuilder.setPriorityLevel(priorityLevel);
         CommandSubscribe subscribe = subscribeBuilder.build();
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.SUBSCRIBE).setSubscribe(subscribe));
         subscribeBuilder.recycle();

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/proto/PulsarApi.java
@@ -3991,6 +3991,10 @@ public final class PulsarApi {
     // optional string consumer_name = 6;
     boolean hasConsumerName();
     String getConsumerName();
+    
+    // optional int32 priority_level = 7;
+    boolean hasPriorityLevel();
+    int getPriorityLevel();
   }
   public static final class CommandSubscribe extends
       com.google.protobuf.GeneratedMessageLite
@@ -4197,6 +4201,16 @@ public final class PulsarApi {
       }
     }
     
+    // optional int32 priority_level = 7;
+    public static final int PRIORITY_LEVEL_FIELD_NUMBER = 7;
+    private int priorityLevel_;
+    public boolean hasPriorityLevel() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    public int getPriorityLevel() {
+      return priorityLevel_;
+    }
+    
     private void initFields() {
       topic_ = "";
       subscription_ = "";
@@ -4204,6 +4218,7 @@ public final class PulsarApi {
       consumerId_ = 0L;
       requestId_ = 0L;
       consumerName_ = "";
+      priorityLevel_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4260,6 +4275,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeBytes(6, getConsumerNameBytes());
       }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeInt32(7, priorityLevel_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -4291,6 +4309,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(6, getConsumerNameBytes());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(7, priorityLevel_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -4417,6 +4439,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000010);
         consumerName_ = "";
         bitField0_ = (bitField0_ & ~0x00000020);
+        priorityLevel_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
       
@@ -4474,6 +4498,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000020;
         }
         result.consumerName_ = consumerName_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.priorityLevel_ = priorityLevel_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -4497,6 +4525,9 @@ public final class PulsarApi {
         }
         if (other.hasConsumerName()) {
           setConsumerName(other.getConsumerName());
+        }
+        if (other.hasPriorityLevel()) {
+          setPriorityLevel(other.getPriorityLevel());
         }
         return this;
       }
@@ -4579,6 +4610,11 @@ public final class PulsarApi {
             case 50: {
               bitField0_ |= 0x00000020;
               consumerName_ = input.readBytes();
+              break;
+            }
+            case 56: {
+              bitField0_ |= 0x00000040;
+              priorityLevel_ = input.readInt32();
               break;
             }
           }
@@ -4759,6 +4795,27 @@ public final class PulsarApi {
         bitField0_ |= 0x00000020;
         consumerName_ = value;
         
+      }
+      
+      // optional int32 priority_level = 7;
+      private int priorityLevel_ ;
+      public boolean hasPriorityLevel() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      public int getPriorityLevel() {
+        return priorityLevel_;
+      }
+      public Builder setPriorityLevel(int value) {
+        bitField0_ |= 0x00000040;
+        priorityLevel_ = value;
+        
+        return this;
+      }
+      public Builder clearPriorityLevel() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        priorityLevel_ = 0;
+        
+        return this;
       }
       
       // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandSubscribe)

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -123,6 +123,7 @@ message CommandSubscribe {
 	required uint64 consumer_id  = 4;
 	required uint64 request_id   = 5;
 	optional string consumer_name = 6;
+	optional int32 priority_level = 7;
 }
 
 message CommandPartitionedTopicMetadata {


### PR DESCRIPTION
### Motivation

Addressing #134 : Message dispatching based on consumer priority-level

### Result

Shared mode consumer priority, the messages will only goes to the consumers with higher priority if there's permit, otherwise the message can also be pushed to the consumers with lower priority.
