### PR TITLE
Pass brokerServiceUrl to websocket service configuration

### DIFF
--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -19,6 +19,10 @@
 # Global Zookeeper quorum connection string
 globalZookeeperServers=
 
+// Pulsar cluster url to connect to broker (optional if globalZookeeperServers present)
+serviceUrl=
+serviceUrlTls=
+
 # Port to use to server HTTP request
 webServicePort=8080
 
@@ -38,6 +42,10 @@ authenticationProviders=
 
 # Enforce authorization
 authorizationEnabled=false
+
+# Role names that are treated as "super-user", meaning they will be able to do all admin
+# operations and publish/consume from all topics
+superUserRoles=
 
 # Authentication settings of the proxy itself. Used to connect to brokers
 brokerClientAuthenticationPlugin=

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthorizationTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import com.yahoo.pulsar.broker.authorization.AuthorizationManager;
 import com.yahoo.pulsar.client.admin.PulsarAdminException;
@@ -38,6 +37,7 @@ import com.yahoo.pulsar.common.policies.data.AuthAction;
 import com.yahoo.pulsar.common.policies.data.ClusterData;
 import com.yahoo.pulsar.common.policies.data.PropertyAdmin;
 import com.yahoo.pulsar.websocket.WebSocketService;
+import com.yahoo.pulsar.websocket.service.WebSocketProxyConfiguration;
 
 public class ProxyAuthorizationTest extends MockedPulsarServiceBaseTest {
     private WebSocketService service;
@@ -53,8 +53,10 @@ public class ProxyAuthorizationTest extends MockedPulsarServiceBaseTest {
         conf.setClusterName("c1");
         internalSetup();
 
-        ServiceConfiguration config = new ServiceConfiguration();
+        WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
         Set<String> superUser = Sets.newHashSet("");
+        config.setAuthorizationEnabled(true);
+        config.setGlobalZookeeperServers("dummy-zk-servers");
         config.setSuperUserRoles(superUser);
         config.setClusterName("c1");
         config.setWebServicePort(TEST_PORT);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -32,10 +32,10 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.client.api.ProducerConsumerBase;
 import com.yahoo.pulsar.websocket.WebSocketService;
 import com.yahoo.pulsar.websocket.service.ProxyServer;
+import com.yahoo.pulsar.websocket.service.WebSocketProxyConfiguration;
 import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
 public class ProxyPublishConsumeTest extends ProducerConsumerBase {
@@ -51,9 +51,10 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
         super.internalSetup();
         super.producerBaseSetup();
 
-        ServiceConfiguration config = new ServiceConfiguration();
+        WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
         config.setWebServicePort(TEST_PORT);
         config.setClusterName("use");
+        config.setGlobalZookeeperServers("dummy-zk-servers");
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
         proxyServer = new ProxyServer(config);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
@@ -40,10 +40,10 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.client.api.ProducerConsumerBase;
 import com.yahoo.pulsar.websocket.WebSocketService;
 import com.yahoo.pulsar.websocket.service.ProxyServer;
+import com.yahoo.pulsar.websocket.service.WebSocketProxyConfiguration;
 import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -64,13 +64,14 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
         super.internalSetup();
         super.producerBaseSetup();
 
-        ServiceConfiguration config = new ServiceConfiguration();
+        WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
         config.setWebServicePort(TEST_PORT);
         config.setWebServicePortTls(TLS_TEST_PORT);
         config.setTlsEnabled(true);
         config.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
         config.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
         config.setClusterName("use");
+        config.setGlobalZookeeperServers("dummy-zk-servers");
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
         proxyServer = new ProxyServer(config);

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/ProxyServer.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/ProxyServer.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 import com.yahoo.pulsar.broker.PulsarServerException;
-import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.client.api.PulsarClientException;
 import com.yahoo.pulsar.common.util.SecurityUtility;
 
@@ -54,9 +53,9 @@ public class ProxyServer {
     private final ExecutorService executorService;
     private final Server server;
     private final List<Handler> handlers = Lists.newArrayList();
-    private final ServiceConfiguration conf;
+    private final WebSocketProxyConfiguration conf;
 
-    public ProxyServer(ServiceConfiguration config)
+    public ProxyServer(WebSocketProxyConfiguration config)
             throws PulsarClientException, MalformedURLException, PulsarServerException {
         this.conf = config;
         this.executorService = Executors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors(),

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.websocket.service;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.yahoo.pulsar.broker.FieldContext;
+
+public class WebSocketProxyConfiguration {
+
+    // Name of the cluster to which this broker belongs to
+    @FieldContext(required = true)
+    private String clusterName;
+    
+    // Pulsar cluster url to connect to broker (optional if globalZookeeperServers present)
+    private String serviceUrl;
+    private String serviceUrlTls;
+
+    // Global Zookeeper quorum connection string
+    private String globalZookeeperServers;
+    // Zookeeper session timeout in milliseconds
+    private long zooKeeperSessionTimeoutMillis = 30000;
+
+    // Port to use to server HTTP request
+    private int webServicePort = 8080;
+    // Port to use to server HTTPS request
+    private int webServicePortTls = 8443;
+    // Hostname or IP address the service binds on, default is 0.0.0.0.
+    private String bindAddress;
+    // --- Authentication ---
+    // Enable authentication
+    private boolean authenticationEnabled;
+    // Autentication provider name list, which is a list of class names
+    private Set<String> authenticationProviders = Sets.newTreeSet();
+    // Enforce authorization
+    private boolean authorizationEnabled;
+    // Role names that are treated as "super-user", meaning they will be able to
+    // do all admin operations and publish/consume from all topics
+    private Set<String> superUserRoles = Sets.newTreeSet();
+
+    // Authentication settings of the proxy itself. Used to connect to brokers
+    private String brokerClientAuthenticationPlugin;
+    private String brokerClientAuthenticationParameters;
+
+    /***** --- TLS --- ****/
+    // Enable TLS
+    private boolean tlsEnabled = false;
+    // Path for the TLS certificate file
+    private String tlsCertificateFilePath;
+    // Path for the TLS private key file
+    private String tlsKeyFilePath;
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+    
+    public String getServiceUrl() {
+        return serviceUrl;
+    }
+
+    public void setServiceUrl(String serviceUrl) {
+        this.serviceUrl = serviceUrl;
+    }
+
+    public String getServiceUrlTls() {
+        return serviceUrlTls;
+    }
+
+    public void setServiceUrlTls(String serviceUrlTls) {
+        this.serviceUrlTls = serviceUrlTls;
+    }
+
+    public String getGlobalZookeeperServers() {
+        return globalZookeeperServers;
+    }
+
+    public void setGlobalZookeeperServers(String globalZookeeperServers) {
+        this.globalZookeeperServers = globalZookeeperServers;
+    }
+
+    public long getZooKeeperSessionTimeoutMillis() {
+        return zooKeeperSessionTimeoutMillis;
+    }
+
+    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
+        this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+    }
+
+    public int getWebServicePort() {
+        return webServicePort;
+    }
+
+    public void setWebServicePort(int webServicePort) {
+        this.webServicePort = webServicePort;
+    }
+
+    public int getWebServicePortTls() {
+        return webServicePortTls;
+    }
+
+    public void setWebServicePortTls(int webServicePortTls) {
+        this.webServicePortTls = webServicePortTls;
+    }
+
+    public String getBindAddress() {
+        return bindAddress;
+    }
+
+    public void setBindAddress(String bindAddress) {
+        this.bindAddress = bindAddress;
+    }
+
+    public boolean isAuthenticationEnabled() {
+        return authenticationEnabled;
+    }
+
+    public void setAuthenticationEnabled(boolean authenticationEnabled) {
+        this.authenticationEnabled = authenticationEnabled;
+    }
+
+    public void setAuthenticationProviders(Set<String> providersClassNames) {
+        authenticationProviders = providersClassNames;
+    }
+
+    public Set<String> getAuthenticationProviders() {
+        return authenticationProviders;
+    }
+
+    public boolean isAuthorizationEnabled() {
+        return authorizationEnabled;
+    }
+
+    public void setAuthorizationEnabled(boolean authorizationEnabled) {
+        this.authorizationEnabled = authorizationEnabled;
+    }
+
+    public Set<String> getSuperUserRoles() {
+        return superUserRoles;
+    }
+
+    public void setSuperUserRoles(Set<String> superUserRoles) {
+        this.superUserRoles = superUserRoles;
+    }
+
+    public String getBrokerClientAuthenticationPlugin() {
+        return brokerClientAuthenticationPlugin;
+    }
+
+    public void setBrokerClientAuthenticationPlugin(String brokerClientAuthenticationPlugin) {
+        this.brokerClientAuthenticationPlugin = brokerClientAuthenticationPlugin;
+    }
+
+    public String getBrokerClientAuthenticationParameters() {
+        return brokerClientAuthenticationParameters;
+    }
+
+    public void setBrokerClientAuthenticationParameters(String brokerClientAuthenticationParameters) {
+        this.brokerClientAuthenticationParameters = brokerClientAuthenticationParameters;
+    }
+
+    public boolean isTlsEnabled() {
+        return tlsEnabled;
+    }
+
+    public void setTlsEnabled(boolean tlsEnabled) {
+        this.tlsEnabled = tlsEnabled;
+    }
+
+    public String getTlsCertificateFilePath() {
+        return tlsCertificateFilePath;
+    }
+
+    public void setTlsCertificateFilePath(String tlsCertificateFilePath) {
+        this.tlsCertificateFilePath = tlsCertificateFilePath;
+    }
+
+    public String getTlsKeyFilePath() {
+        return tlsKeyFilePath;
+    }
+
+    public void setTlsKeyFilePath(String tlsKeyFilePath) {
+        this.tlsKeyFilePath = tlsKeyFilePath;
+    }
+
+}


### PR DESCRIPTION
### Motivation

Provide a way to deploy websocket-proxy service independently without accessing globalZookeeper. Right now, proxy-service requires globalZK for
- fetching brokerService url for a given cluster
- enabling authorization

So, Websocket-Proxy-service should have configuration to disable authorization and get broker-service url from the config.

### Modifications

Broker-service url can be configured at Websocket-proxy-service.

### Result

Websocket-proxy can be deployed without accessing global-zookeeper.
