### PR TITLE
Generalize PulsarConfigurationLoader

### DIFF
--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -22,13 +22,15 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 import com.yahoo.pulsar.client.impl.auth.AuthenticationDisabled;
+import com.yahoo.pulsar.common.configuration.FieldContext;
+import com.yahoo.pulsar.common.configuration.PulsarConfiguration;
 
 /**
  *
  * Pulsar service configuration object.
  *
  */
-public class ServiceConfiguration {
+public class ServiceConfiguration implements PulsarConfiguration{
 
     /***** --- pulsar configuration --- ****/
     // Zookeeper quorum connection string

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/FieldContext.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/FieldContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yahoo.pulsar.broker;
+package com.yahoo.pulsar.common.configuration;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/PulsarConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/PulsarConfiguration.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.common.configuration;
+
+import java.util.Properties;
+
+public interface PulsarConfiguration {
+
+    public Properties getProperties();
+
+    public void setProperties(Properties properties);
+}

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -70,7 +70,7 @@ public class PulsarConfigurationLoader {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private static <T extends PulsarConfiguration> T create(Properties properties,
+    protected static <T extends PulsarConfiguration> T create(Properties properties,
             Class<? extends PulsarConfiguration> clazz) throws IOException, IllegalArgumentException {
         checkNotNull(properties);
         T configuration = null;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/PulsarBrokerStarter.java
@@ -15,8 +15,8 @@
  */
 package com.yahoo.pulsar;
 
-import static com.yahoo.pulsar.broker.ServiceConfigurationLoader.create;
-import static com.yahoo.pulsar.broker.ServiceConfigurationLoader.isComplete;
+import static com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader.create;
+import static com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader.isComplete;
 
 import java.io.FileInputStream;
 
@@ -33,7 +33,7 @@ public class PulsarBrokerStarter {
     private static ServiceConfiguration loadConfig(String configFile) throws Exception {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
-        ServiceConfiguration config = create((new FileInputStream(configFile)));
+        ServiceConfiguration config = create((new FileInputStream(configFile)), ServiceConfiguration.class);
         // it validates provided configuration is completed
         isComplete(config);
         return config;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/PulsarStandaloneStarter.java
@@ -29,9 +29,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.yahoo.pulsar.broker.PulsarService;
 import com.yahoo.pulsar.broker.ServiceConfiguration;
-import com.yahoo.pulsar.broker.ServiceConfigurationLoader;
 import com.yahoo.pulsar.client.admin.PulsarAdmin;
 import com.yahoo.pulsar.client.admin.PulsarAdminException;
+import com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader;
 import com.yahoo.pulsar.common.policies.data.ClusterData;
 import com.yahoo.pulsar.common.policies.data.PropertyAdmin;
 import com.yahoo.pulsar.zookeeper.LocalBookkeeperEnsemble;
@@ -96,8 +96,8 @@ public class PulsarStandaloneStarter {
             return;
         }
 
-        this.config = ServiceConfigurationLoader.create((new FileInputStream(configFile)));
-        ServiceConfigurationLoader.isComplete(config);
+        this.config = PulsarConfigurationLoader.create((new FileInputStream(configFile)), ServiceConfiguration.class);
+        PulsarConfigurationLoader.isComplete(config);
         // Set ZK server's host to localhost
         config.setZookeeperServers("127.0.0.1:" + zkPort);
         config.setGlobalZookeeperServers("127.0.0.1:" + zkPort);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -15,12 +15,10 @@
  */
 package com.yahoo.pulsar.broker.service;
 
-import static com.yahoo.pulsar.broker.ServiceConfigurationLoader.create;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.net.URL;
-import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -77,7 +75,7 @@ public class BacklogQuotaManagerTest {
             bkEnsemble.start();
 
             // start pulsar service
-            config = create(new Properties(System.getProperties()));
+            config = new ServiceConfiguration();
             config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
             config.setWebServicePort(BROKER_WEBSERVICE_PORT);
             config.setClusterName("usc");

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTestBase.java
@@ -15,13 +15,11 @@
  */
 package com.yahoo.pulsar.broker.service;
 
-import static com.yahoo.pulsar.broker.ServiceConfigurationLoader.create;
 import static org.testng.Assert.assertEquals;
 
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -104,7 +102,7 @@ public class ReplicatorTestBase {
         // NOTE: we have to instantiate a new copy of System.getProperties() to make sure pulsar1 and pulsar2 have
         // completely
         // independent config objects instead of referring to the same properties object
-        ServiceConfiguration config1 = create(new Properties(System.getProperties()));
+        ServiceConfiguration config1 = new ServiceConfiguration();
         config1.setClusterName("r1");
         config1.setWebServicePort(webServicePort1);
         config1.setZookeeperServers("127.0.0.1:" + zkPort1);
@@ -128,7 +126,7 @@ public class ReplicatorTestBase {
         bkEnsemble2.start();
 
         int webServicePort2 = PortManager.nextFreePort();
-        config2 = create(new Properties(System.getProperties()));
+        config2 = new ServiceConfiguration();
         config2.setClusterName("r2");
         config2.setWebServicePort(webServicePort2);
         config2.setZookeeperServers("127.0.0.1:" + zkPort2);
@@ -152,7 +150,7 @@ public class ReplicatorTestBase {
         bkEnsemble3.start();
 
         int webServicePort3 = PortManager.nextFreePort();
-        config3 = create(new Properties(System.getProperties()));
+        config3 = new ServiceConfiguration();
         config3.setClusterName("r3");
         config3.setWebServicePort(webServicePort3);
         config3.setZookeeperServers("127.0.0.1:" + zkPort3);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/common/naming/ServiceConfigurationLoaderTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/common/naming/ServiceConfigurationLoaderTest.java
@@ -15,7 +15,7 @@
  */
 package com.yahoo.pulsar.common.naming;
 
-import static com.yahoo.pulsar.broker.ServiceConfigurationLoader.isComplete;
+import static com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader.isComplete;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -26,9 +26,9 @@ import java.util.Properties;
 
 import org.testng.annotations.Test;
 
-import com.yahoo.pulsar.broker.FieldContext;
 import com.yahoo.pulsar.broker.ServiceConfiguration;
-import com.yahoo.pulsar.broker.ServiceConfigurationLoader;
+import com.yahoo.pulsar.common.configuration.FieldContext;
+import com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader;
 
 public class ServiceConfigurationLoaderTest {
 
@@ -36,7 +36,7 @@ public class ServiceConfigurationLoaderTest {
     public void testServiceConfiguraitonLoadingStream() throws Exception {
         final String fileName = "configurations/pulsar_broker_test.conf"; // test-resource file
         InputStream stream = this.getClass().getClassLoader().getResourceAsStream(fileName);
-        final ServiceConfiguration serviceConfig = ServiceConfigurationLoader.create(stream);
+        final ServiceConfiguration serviceConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
         assertNotNull(serviceConfig);
     }
 
@@ -45,7 +45,7 @@ public class ServiceConfigurationLoaderTest {
         final String zk = "localhost:2184";
         final Properties prop = new Properties();
         prop.setProperty("zookeeperServers", zk);
-        final ServiceConfiguration serviceConfig = ServiceConfigurationLoader.create(prop);
+        final ServiceConfiguration serviceConfig = new ServiceConfiguration();
         assertNotNull(serviceConfig);
         assertEquals(serviceConfig.getZookeeperServers(), zk);
     }
@@ -55,7 +55,7 @@ public class ServiceConfigurationLoaderTest {
         final String zk = "localhost:2184";
         final Properties prop = new Properties();
         prop.setProperty("zookeeperServers", zk);
-        final ServiceConfiguration serviceConfig = ServiceConfigurationLoader.create(prop);
+        final ServiceConfiguration serviceConfig = new ServiceConfiguration();
         assertEquals(serviceConfig.getZookeeperServers(), zk);
     }
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/common/naming/ServiceConfigurationTest.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 import org.testng.annotations.Test;
 
 import com.yahoo.pulsar.broker.ServiceConfiguration;
-import com.yahoo.pulsar.broker.ServiceConfigurationLoader;
+import com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader;
 
 /**
  * 
@@ -51,7 +51,7 @@ public class ServiceConfigurationTest {
         final String zookeeperServer = "localhost:2184";
         final int brokerServicePort = 1000;
         InputStream newStream = updateProp(zookeeperServer, String.valueOf(brokerServicePort), "ns1,ns2");
-        final ServiceConfiguration config = ServiceConfigurationLoader.create(newStream);
+        final ServiceConfiguration config = PulsarConfigurationLoader.create(newStream, ServiceConfiguration.class);
         assertTrue(isNotBlank(config.getZookeeperServers()));
         assertTrue(config.getBrokerServicePort() == brokerServicePort);
         assertEquals(config.getBootstrapNamespaces().get(1), "ns2");
@@ -66,7 +66,7 @@ public class ServiceConfigurationTest {
     public void testInitFailure() throws Exception {
         final String zookeeperServer = "localhost:2184";
         InputStream newStream = updateProp(zookeeperServer, String.valueOf("invalid-string"), null);
-        ServiceConfigurationLoader.create(newStream);
+        PulsarConfigurationLoader.create(newStream, ServiceConfiguration.class);
     }
 
     private InputStream updateProp(String zookeeperServer, String brokerServicePort, String namespace)

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/server/ServiceConfig.java
@@ -19,13 +19,14 @@ import java.util.Properties;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
+import com.yahoo.pulsar.common.configuration.PulsarConfiguration;
 import com.yahoo.pulsar.discovery.service.web.DiscoveryServiceServlet;
 
 /**
  * Service Configuration to start :{@link DiscoveryServiceServlet}
  *
  */
-public class ServiceConfig {
+public class ServiceConfig implements PulsarConfiguration{
 
     // Local-Zookeeper quorum connection string
     private String zookeeperServers;

--- a/pulsar-discovery-service/src/test/java/com/yahoo/pulsar/discovery/service/server/DiscoveryServiceWebTest.java
+++ b/pulsar-discovery-service/src/test/java/com/yahoo/pulsar/discovery/service/server/DiscoveryServiceWebTest.java
@@ -25,6 +25,8 @@ import java.io.PrintWriter;
 
 import org.testng.annotations.Test;
 
+import com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader;
+
 /**
  * 1. starts discovery service a. loads broker list from zk 2. http-client calls multiple http request: GET, PUT and
  * POST. 3. discovery service redirects to appropriate brokers in round-robin 4. client receives unknown host exception
@@ -48,7 +50,7 @@ public class DiscoveryServiceWebTest {
         printWriter.println("webServicePort=" + port);
         printWriter.close();
         testConfigFile.deleteOnExit();
-        final ServiceConfig config = DiscoveryServiceStarter.load(testConfigFile.getAbsolutePath());
+        final ServiceConfig config = PulsarConfigurationLoader.create(testConfigFile.getAbsolutePath(), ServiceConfig.class);
         final ServerManager server = new ServerManager(config);
         DiscoveryServiceStarter.startWebService(server, config);
         assertTrue(server.isStarted());

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -15,12 +15,14 @@
  */
 package com.yahoo.pulsar.websocket.service;
 
+import java.util.Properties;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import com.yahoo.pulsar.broker.FieldContext;
+import com.yahoo.pulsar.common.configuration.FieldContext;
+import com.yahoo.pulsar.common.configuration.PulsarConfiguration;
 
-public class WebSocketProxyConfiguration {
+public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     // Name of the cluster to which this broker belongs to
     @FieldContext(required = true)
@@ -63,6 +65,8 @@ public class WebSocketProxyConfiguration {
     private String tlsCertificateFilePath;
     // Path for the TLS private key file
     private String tlsKeyFilePath;
+    
+    private Properties properties = new Properties();
 
     public String getClusterName() {
         return clusterName;
@@ -198,6 +202,14 @@ public class WebSocketProxyConfiguration {
 
     public void setTlsKeyFilePath(String tlsKeyFilePath) {
         this.tlsKeyFilePath = tlsKeyFilePath;
+    }
+    
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
     }
 
 }

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketServiceStarter.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketServiceStarter.java
@@ -16,18 +16,11 @@
 package com.yahoo.pulsar.websocket.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.yahoo.pulsar.common.util.FieldParser.update;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.yahoo.pulsar.common.configuration.PulsarConfigurationLoader;
 import com.yahoo.pulsar.websocket.WebSocketConsumerServlet;
 import com.yahoo.pulsar.websocket.WebSocketProducerServlet;
 import com.yahoo.pulsar.websocket.WebSocketService;
@@ -40,7 +33,8 @@ public class WebSocketServiceStarter {
             // load config file and start proxy service
             String configFile = args[0];
             log.info("Loading configuration from {}", configFile);
-            WebSocketProxyConfiguration config = load(configFile);
+            WebSocketProxyConfiguration config = PulsarConfigurationLoader.create(configFile,
+                    WebSocketProxyConfiguration.class);
             ProxyServer proxyServer = new ProxyServer(config);
             WebSocketService service = new WebSocketService(config);
             start(proxyServer, service);
@@ -57,23 +51,6 @@ public class WebSocketServiceStarter {
         service.start();
     }
     
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static WebSocketProxyConfiguration load(String configFile) throws IOException, IllegalArgumentException {
-        final InputStream inStream = new FileInputStream(configFile);
-        try {
-            checkNotNull(inStream, "Unbable to read config file " + configFile);
-            WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
-            Properties properties = new Properties();
-            properties.load(inStream);
-            update((Map) properties, config);
-            return config;
-        } finally {
-            if (inStream != null) {
-                inStream.close();
-            }
-        }
-    }
-
     private static final Logger log = LoggerFactory.getLogger(WebSocketServiceStarter.class);
 
 }


### PR DESCRIPTION
### Motivation

Generalizing PulsarConfigurationLoader helps to load different ```ServiceConfiguration``` of ```BrokerService```, ```DiscoveryService```, ```WebSocketProxy``` in a generic way without adding additional logic-layer to parse those config.

### Modifications

Generalizing "Config" Parsing for all the services such as ```BrokerService```, ```DiscoveryService```, ```WebSocketProxy```

### Result

No functionality change.
