### PR TITLE
Update AdminTools.md

### DIFF
--- a/docs/AdminTools.md
+++ b/docs/AdminTools.md
@@ -966,7 +966,7 @@ It shows configured persistence policies of a given namespace.
 ###### CLI
 
 ```
-$ pulsar-admin namespaces set-persistence test-property/cl1/ns1
+$ pulsar-admin namespaces get-persistence test-property/cl1/ns1
 ```
 
 ```json


### PR DESCRIPTION
fix a typo

### Motivation

There is a minor typo in the AdminTools.md and it may mislead the users.

### Modifications

I changed the CLI command about getting persistence policies. The example CLI command will be changed from 

`pulsar-admin namespaces set-persistence test-property/cl1/ns1`
to

`pulsar-admin namespaces get-persistence test-property/cl1/ns1`

### Result

A typo in the document will be fixed.
