### PR TITLE
Add client and server lookup throttling

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -102,6 +102,9 @@ tlsAllowInsecureConnection=false
 # Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction 
 maxUnackedMessagesPerConsumer=50000
 
+# Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
+maxConcurrentLookupRequest=20000
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -87,6 +87,8 @@ public class ServiceConfiguration implements PulsarConfiguration{
     // messages to consumer once, this limit reaches until consumer starts acknowledging messages back
     // Using a value of 0, is disabling unackedMessage-limit check and consumer can receive messages without any restriction
     private int maxUnackedMessagesPerConsumer = 50000;
+    // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
+    private int maxConcurrentLookupRequest = 20000;
 
     /***** --- TLS --- ****/
     // Enable TLS
@@ -414,6 +416,14 @@ public class ServiceConfiguration implements PulsarConfiguration{
 
     public void setMaxUnackedMessagesPerConsumer(int maxUnackedMessagesPerConsumer) {
         this.maxUnackedMessagesPerConsumer = maxUnackedMessagesPerConsumer;
+    }
+
+    public int getMaxConcurrentLookupRequest() {
+        return maxConcurrentLookupRequest;
+    }
+
+    public void setMaxConcurrentLookupRequest(int maxConcurrentLookupRequest) {
+        this.maxConcurrentLookupRequest = maxConcurrentLookupRequest;
     }
 
     public boolean isTlsEnabled() {

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Lookup.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Lookup.java
@@ -28,4 +28,12 @@ public interface Lookup {
      * @return the broker URL that serves the destination
      */
     public String lookupDestination(String destination) throws PulsarAdminException;
+    
+    /**
+     * Update number of lookup permits allowed simultaneously for throttling 
+     * 
+     * @param permits
+     * @throws PulsarAdminException
+     */
+    public void updateLookupPermits(int permits) throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/LookupImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/LookupImpl.java
@@ -16,10 +16,11 @@
 package com.yahoo.pulsar.client.admin.internal;
 
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 
-import com.yahoo.pulsar.client.admin.PulsarAdminException;
 import com.yahoo.pulsar.client.admin.Lookup;
+import com.yahoo.pulsar.client.admin.PulsarAdminException;
 import com.yahoo.pulsar.client.api.Authentication;
 import com.yahoo.pulsar.common.lookup.data.LookupData;
 import com.yahoo.pulsar.common.naming.DestinationName;
@@ -48,6 +49,15 @@ public class LookupImpl extends BaseResource implements Lookup {
         try {
             DestinationName destName = DestinationName.get(destination);
             return doDestinationLookup(v2lookup.path("/destination"), destName);
+        } catch (Exception e) {
+            throw getLookupApiException(e);
+        }
+    }
+
+    @Override
+    public void updateLookupPermits(int permits) throws PulsarAdminException {
+        try {
+            request(v2lookup.path("/destination/permits/").path(Integer.toString(permits))).put(Entity.json(""));
         } catch (Exception e) {
             throw getLookupApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
@@ -18,6 +18,7 @@ package com.yahoo.pulsar.admin.cli;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.yahoo.pulsar.client.admin.PulsarAdmin;
+import com.yahoo.pulsar.client.admin.PulsarAdminException;
 
 @Parameters(commandDescription = "Operations about brokers")
 public class CmdBrokers extends CmdBase {
@@ -48,9 +49,21 @@ public class CmdBrokers extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Update number of lookup permits allowed simultaneously for throttling ")
+    private class UpdateLookupPermitsCmd extends CliCommand {
+        @Parameter(description = "number of lookup permits", required = true)
+        private int permits;
+
+        @Override
+        void run() throws PulsarAdminException {
+            admin.lookups().updateLookupPermits(permits);
+        }
+    }
+
     CmdBrokers(PulsarAdmin admin) {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
         jcommander.addCommand("namespaces", new Namespaces());
+        jcommander.addCommand("updateLookupPermits", new UpdateLookupPermitsCmd());
     }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
@@ -48,6 +48,7 @@ public class ClientConfiguration implements Serializable {
     private boolean useTls = false;
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
+    private int concurrentLookupRequest = 5000;
 
     /**
      * @return the authentication provider to be used
@@ -308,5 +309,23 @@ public class ClientConfiguration implements Serializable {
      */
     public void setStatsInterval(long statsInterval, TimeUnit unit) {
         this.statsIntervalSeconds = unit.toSeconds(statsInterval);
+    }
+
+    /**
+     * Get configured total allowed concurrent lookup-request.
+     * 
+     * @return
+     */
+    public int getConcurrentLookupRequest() {
+        return concurrentLookupRequest;
+    }
+
+    /**
+     * Configure total allowed concurrent lookup-request to prevent overload on broker.
+     * 
+     * @param concurrentLookupRequest
+     */
+    public void setConcurrentLookupRequest(int concurrentLookupRequest) {
+        this.concurrentLookupRequest = concurrentLookupRequest;
     }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
@@ -60,6 +60,12 @@ public class PulsarClientException extends IOException {
         }
     }
 
+    public static class TooManyLookupRequestException extends LookupException {
+        public TooManyLookupRequestException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class ConnectException extends PulsarClientException {
         public ConnectException(String msg) {
             super(msg);

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -59,6 +60,7 @@ public class ClientCnx extends PulsarHandler {
     private final ConcurrentLongHashMap<ConsumerImpl> consumers = new ConcurrentLongHashMap<>(16, 1);
 
     private final CompletableFuture<Void> connectionFuture = new CompletableFuture<Void>();
+    private final Semaphore pendingLookupRequestSemaphore;
 
     enum State {
         None, SentConnectFrame, Ready
@@ -66,6 +68,8 @@ public class ClientCnx extends PulsarHandler {
 
     public ClientCnx(PulsarClientImpl pulsarClient) {
         super(30, TimeUnit.SECONDS);
+        this.pendingLookupRequestSemaphore = new Semaphore(pulsarClient.getConfiguration().getConcurrentLookupRequest(),
+                true);
         authentication = pulsarClient.getConfiguration().getAuthentication();
         state = State.None;
     }
@@ -105,7 +109,7 @@ public class ClientCnx extends PulsarHandler {
 
         // Fail out all the pending ops
         pendingRequests.forEach((key, future) -> future.completeExceptionally(e));
-        pendingLookupRequests.forEach((key, future) -> future.completeExceptionally(e));
+        pendingLookupRequests.forEach((key, future) -> getAndRemovePendingLookupRequest(key).completeExceptionally(e));
 
         // Notify all attached producers/consumers so they have a chance to reconnect
         producers.forEach((id, producer) -> producer.connectionClosed(this));
@@ -202,7 +206,7 @@ public class ClientCnx extends PulsarHandler {
         log.info("Received Broker lookup response: {}", lookupResult.getResponse());
 
         long requestId = lookupResult.getRequestId();
-        CompletableFuture<LookupDataResult> requestFuture = pendingLookupRequests.remove(requestId);
+        CompletableFuture<LookupDataResult> requestFuture = getAndRemovePendingLookupRequest(requestId);
 
         if (requestFuture != null) {
             // Complete future with exception if : Result.response=fail/null
@@ -230,7 +234,7 @@ public class ClientCnx extends PulsarHandler {
         log.info("Received Broker Partition response: {}", lookupResult.getPartitions());
 
         long requestId = lookupResult.getRequestId();
-        CompletableFuture<LookupDataResult> requestFuture = pendingLookupRequests.remove(requestId);
+        CompletableFuture<LookupDataResult> requestFuture = getAndRemovePendingLookupRequest(requestId);
 
         if (requestFuture != null) {
             // Complete future with exception if : Result.response=fail/null
@@ -249,6 +253,22 @@ public class ClientCnx extends PulsarHandler {
         } else {
             log.warn("{} Received unknown request id from server: {}", ctx.channel(), lookupResult.getRequestId());
         }
+    }
+
+    private boolean addPendingLookupRequests(long requestId, CompletableFuture<LookupDataResult> future) {
+        if (pendingLookupRequestSemaphore.tryAcquire()) {
+            pendingLookupRequests.put(requestId, future);
+            return true;
+        }
+        return false;
+    }
+
+    private CompletableFuture<LookupDataResult> getAndRemovePendingLookupRequest(long requestId) {
+        CompletableFuture<LookupDataResult> result = pendingLookupRequests.remove(requestId);
+        if (result != null) {
+            pendingLookupRequestSemaphore.release();
+        }
+        return result;
     }
 
     @Override
@@ -312,13 +332,20 @@ public class ClientCnx extends PulsarHandler {
 
     CompletableFuture<LookupDataResult> newLookup(ByteBuf request, long requestId) {
         CompletableFuture<LookupDataResult> future = new CompletableFuture<>();
-        pendingLookupRequests.put(requestId, future);
-        ctx.writeAndFlush(request).addListener(writeFuture -> {
-            if (!writeFuture.isSuccess()) {
-                log.warn("{} Failed to send request to broker: {}", ctx.channel(), writeFuture.cause().getMessage());
-                future.completeExceptionally(writeFuture.cause());
-            }
-        });
+
+        if (addPendingLookupRequests(requestId, future)) {
+            ctx.writeAndFlush(request).addListener(writeFuture -> {
+                if (!writeFuture.isSuccess()) {
+                    log.warn("{} Failed to send request {} to broker: {}", ctx.channel(), requestId,
+                            writeFuture.cause().getMessage());
+                    future.completeExceptionally(writeFuture.cause());
+                }
+            });
+        } else {
+            log.warn("{} Failed to add lookup-request into pending queue", requestId);
+            future.completeExceptionally(new PulsarClientException.TooManyLookupRequestException(
+                    "Failed due to too many pending lookup requests"));
+        }
         return future;
     }
 
@@ -384,6 +411,8 @@ public class ClientCnx extends PulsarHandler {
             return new PulsarClientException.BrokerPersistenceException(errorMsg);
         case ServiceNotReady:
             return new PulsarClientException.LookupException(errorMsg);
+        case TooManyRequest:
+            return new PulsarClientException.TooManyLookupRequestException(errorMsg);
         case ProducerBlockedQuotaExceededError:
             return new PulsarClientException.ProducerBlockedQuotaExceededError(errorMsg);
         case ProducerBlockedQuotaExceededException:

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/proto/PulsarApi.java
@@ -64,6 +64,7 @@ public final class PulsarApi {
     ProducerBlockedQuotaExceededError(7, 7),
     ProducerBlockedQuotaExceededException(8, 8),
     ChecksumError(9, 9),
+    TooManyRequest(10, 10),
     ;
     
     public static final int UnknownError_VALUE = 0;
@@ -76,6 +77,7 @@ public final class PulsarApi {
     public static final int ProducerBlockedQuotaExceededError_VALUE = 7;
     public static final int ProducerBlockedQuotaExceededException_VALUE = 8;
     public static final int ChecksumError_VALUE = 9;
+    public static final int TooManyRequest_VALUE = 10;
     
     
     public final int getNumber() { return value; }
@@ -92,6 +94,7 @@ public final class PulsarApi {
         case 7: return ProducerBlockedQuotaExceededError;
         case 8: return ProducerBlockedQuotaExceededException;
         case 9: return ChecksumError;
+        case 10: return TooManyRequest;
         default: return null;
       }
     }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -77,6 +77,7 @@ enum ServerError {
     ProducerBlockedQuotaExceededError = 7; // Unable to create producer because backlog quota exceeded
     ProducerBlockedQuotaExceededException = 8; // Exception while creating producer because quota exceeded
     ChecksumError = 9; // Error while verifying message checksum
+    TooManyRequest = 10; // Error with too many simultaneously request 
 }
 
 enum AuthMethod {


### PR DESCRIPTION
### Motivation

Sometimes, broker requires a way to throttle newly incoming traffic and requires to restrict number of incoming concurrent lookup requests. It is also useful to throttle at client in order to avoid large number of concurrent lookup-requests while creating producers/consumers.

### Modifications

- Add broker side throttling to serve max allowed concurrent lookup request
- Add client side lookup throttling
- Update value of maxConcurrentLookupRequest dynamically at broker
- AdminApi command to update maxConcurrentLookupRequest

### Result

Broker can have capability to throttle newly incoming traffic by restricting number of concurrent lookup request.
