### PR TITLE
Fix file descriptor leak on LinuxBrokerHostUsageImpl

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Class that will return the broker host usage.
@@ -120,8 +121,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
      * this would include iowait, irq and steal.
      */
     private CpuStat getTotalCpuUsage() {
-        try {
-            String[] words = Files.lines(Paths.get("/proc/stat"))
+        try (Stream<String> stream = Files.lines(Paths.get("/proc/stat"))) {
+            String[] words = stream
                     .findFirst()
                     .get().split("\\s+");
 
@@ -146,8 +147,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     }
 
     private List<String> getNics() {
-        try {
-            return Files.list(Paths.get("/sys/class/net/"))
+        try (Stream<Path> stream = Files.list(Paths.get("/sys/class/net/"))) {
+            return stream
                     .filter(this::isPhysicalNic)
                     .map(path -> path.getFileName().toString())
                     .collect(Collectors.toList());


### PR DESCRIPTION
### Motivation

LinuxBrokerHostUsageImpl is leaking file descriptors when reading `/proc/stats` and when reading files in `/sys/class/net`.
It's counter-intuitive, but java file streams must be closed, [reference](http://stackoverflow.com/questions/34072035/why-is-files-lines-and-similar-streams-not-automatically-closed).

### Modifications

Stream now are opened using try-with-resource.

### Result

There should be no more file descriptor leaks.