### PR TITLE
Add client-side lookup throttling

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
@@ -48,6 +48,7 @@ public class ClientConfiguration implements Serializable {
     private boolean useTls = false;
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
+    private int concurrentLookupRequest = 5000;
 
     /**
      * @return the authentication provider to be used
@@ -308,5 +309,25 @@ public class ClientConfiguration implements Serializable {
      */
     public void setStatsInterval(long statsInterval, TimeUnit unit) {
         this.statsIntervalSeconds = unit.toSeconds(statsInterval);
+    }
+
+    /**
+     * Get configured total allowed concurrent lookup-request.
+     * 
+     * @return
+     */
+    public int getConcurrentLookupRequest() {
+        return concurrentLookupRequest;
+    }
+
+    /**
+     * Number of concurrent lookup-requests allowed on each broker-connection to prevent overload on broker.
+     * <i>(default: 5000)</i> It should be configured with higher value only in case of it requires to produce/subscribe on
+     * thousands of topic using created {@link PulsarClient}
+     * 
+     * @param concurrentLookupRequest
+     */
+    public void setConcurrentLookupRequest(int concurrentLookupRequest) {
+        this.concurrentLookupRequest = concurrentLookupRequest;
     }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
@@ -60,6 +60,12 @@ public class PulsarClientException extends IOException {
         }
     }
 
+    public static class TooManyLookupRequestException extends LookupException {
+        public TooManyLookupRequestException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class ConnectException extends PulsarClientException {
         public ConnectException(String msg) {
             super(msg);


### PR DESCRIPTION
### Motivation

Sometimes, It is useful to throttle at client in order to avoid large number of concurrent lookup-requests going to broker while creating producers/consumers.

### Modifications

Add client side lookup throttling while creating producer and consumer.

### Result

Client can have capability to restrict number of concurrent lookup request to broker in order to throttle while creating producer/consumer.