### PR TITLE
Update Broker service configuration dynamically

### DIFF
--- a/docs/AdminTools.md
+++ b/docs/AdminTools.md
@@ -14,6 +14,9 @@
 		- [Brokers](#brokers)
 			- [list of active brokers](#list-of-active-brokers)
 			- [list of namespaces owned by a given broker](#list-of-namespaces-owned-by-a-given-broker)
+			- [update dynamic configuration](#update-dynamic-configuration)
+			- [get list of dynamic configuration name](#get-list-of-dynamic-configuration-name)
+			- [get value of dynamic configurations](#get-value-of-dynamic-configurations)
 		- [Properties](#properties)
 			- [list existing properties](#list-existing-properties)
 			- [create property](#create-property)
@@ -232,6 +235,157 @@ GET /admin/brokers/{cluster}/{broker}/ownedNamespaces
 ```java
 admin.brokers().getOwnedNamespaces(cluster,brokerUrl)
 ```
+
+#### update dynamic configuration
+Broker can locally override value of updatable dynamic service-configurations that are stored into zookeeper. This interface allows to change the value of broker's dynamic-configuration into the zookeeper. Broker receives zookeeper-watch with new changed value and broker updates new value locally.
+
+###### CLI
+
+```
+$ pulsar-admin brokers update-dynamic-config brokerShutdownTimeoutMs 100
+```
+
+```
+N/A
+```
+
+###### REST
+
+```
+GET /admin/brokers/configuration/{configName}/{configValue}
+```
+
+###### Java
+
+```java
+admin.brokers().updateDynamicConfiguration(configName, configValue)
+```
+
+#### get list of dynamic configuration name
+It gives list of updatable dynamic service-configuration name.
+
+###### CLI
+
+```
+$ pulsar-admin brokers list-dynamic-config
+```
+
+```
+brokerShutdownTimeoutMs
+```
+
+###### REST
+
+```
+GET /admin/brokers/configuration
+```
+
+###### Java
+
+```java
+admin.brokers().getDynamicConfigurationNames()
+```
+
+#### get value of dynamic configurations
+It gives value of all dynamic configurations stored in zookeeper
+
+###### CLI
+
+```
+$ pulsar-admin brokers get-all-dynamic-config
+```
+
+```
+brokerShutdownTimeoutMs:100
+```
+
+###### REST
+
+```
+GET /admin/brokers/configuration/values
+```
+
+###### Java
+
+```java
+admin.brokers().getAllDynamicConfigurations()
+```
+
+#### Update dynamic configuration
+Broker can locally override value of updatable dynamic service-configurations that are stored into zookeeper. This interface allows to change the value of broker's dynamic-configuration into the zookeeper. Broker receives zookeeper-watch with new changed value and broker updates new value locally.
+
+###### CLI
+
+```
+$ pulsar-admin brokers update-dynamic-config brokerShutdownTimeoutMs 100
+```
+
+```
+N/A
+```
+
+###### REST
+
+```
+GET /admin/brokers/configuration/{configName}/{configValue}
+```
+
+###### Java
+
+```java
+admin.brokers().updateDynamicConfiguration(configName, configValue)
+```
+
+#### Get list of dynamic configuration name
+It gives list of updatable dynamic service-configuration name.
+
+###### CLI
+
+```
+$ pulsar-admin brokers list-dynamic-config
+```
+
+```
+brokerShutdownTimeoutMs
+```
+
+###### REST
+
+```
+GET /admin/brokers/configuration
+```
+
+###### Java
+
+```java
+admin.brokers().getDynamicConfigurationNames()
+```
+
+#### Get value of dynamic configurations
+It gives value of all dynamic configurations stored in zookeeper
+
+###### CLI
+
+```
+$ pulsar-admin brokers get-all-dynamic-config
+```
+
+```
+brokerShutdownTimeoutMs:100
+```
+
+###### REST
+
+```
+GET /admin/brokers/configuration/values
+```
+
+###### Java
+
+```java
+admin.brokers().getAllDynamicConfigurations()
+```
+
 
 
 ### Properties

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -62,6 +62,7 @@ public class ServiceConfiguration implements PulsarConfiguration{
     private long zooKeeperSessionTimeoutMillis = 30000;
     // Time to wait for broker graceful shutdown. After this time elapses, the
     // process will be killed
+    @FieldContext(dynamic = true)
     private long brokerShutdownTimeoutMs = 3000;
     // Enable backlog quota check. Enforces action on topic when the quota is
     // reached

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/FieldContext.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/common/configuration/FieldContext.java
@@ -56,4 +56,11 @@ public @interface FieldContext {
      * @return character length of field
      */
     public int maxCharLength() default Integer.MAX_VALUE;
+    
+    /**
+     * allow field to be updated dynamically
+     * 
+     * @return
+     */
+    public boolean dynamic() default false;
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Brokers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Brokers.java
@@ -15,32 +15,48 @@
  */
 package com.yahoo.pulsar.broker.admin;
 
+import static com.yahoo.pulsar.broker.service.BrokerService.BROKER_SERVICE_CONFIGURATION_PATH;
+
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
 
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+import com.yahoo.pulsar.broker.ServiceConfiguration;
+import com.yahoo.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
+import com.yahoo.pulsar.broker.web.RestException;
+import com.yahoo.pulsar.common.configuration.FieldContext;
+import com.yahoo.pulsar.common.policies.data.NamespaceOwnershipStatus;
+import com.yahoo.pulsar.common.util.ObjectMapperFactory;
+import com.yahoo.pulsar.zookeeper.ZooKeeperDataCache;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import com.yahoo.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
-import com.yahoo.pulsar.broker.web.RestException;
-import com.yahoo.pulsar.common.policies.data.NamespaceOwnershipStatus;
+
 
 @Path("/brokers")
 @Api(value = "/brokers", description = "Brokers admin apis", tags = "brokers")
 @Produces(MediaType.APPLICATION_JSON)
 public class Brokers extends AdminResource {
     private static final Logger LOG = LoggerFactory.getLogger(Brokers.class);
-
+    private int serviceConfigZkVersion = -1;
+    
     @GET
     @Path("/{cluster}")
     @ApiOperation(value = "Get the list of active brokers (web service addresses) in the cluster.", response = String.class, responseContainer = "Set")
@@ -78,5 +94,80 @@ public class Brokers extends AdminResource {
                     cluster, broker);
             throw new RestException(e);
         }
+    }
+    
+    @POST
+    @Path("/configuration/{configName}/{configValue}")
+    @ApiOperation(value = "Update broker service configuration. This operation requires Pulsar super-user privileges.")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Service configuration updated successfully"),
+            @ApiResponse(code = 403, message = "You don't have admin permission to update service-configuration"),
+            @ApiResponse(code = 404, message = "Configuration not found"),
+            @ApiResponse(code = 412, message = "Configuration can't be updated dynamically") })
+    public void updateConfiguration(@PathParam("configName") String configName, @PathParam("configValue") String configValue) throws Exception{
+        validateSuperUserAccess();
+        updateServiecConfiguration(configName, configValue);
+    }
+
+    /**
+     * if {@link ServiceConfiguration}-field is allowed to be modified dynamically, update configuration-map into zk, so
+     * all other brokers can see the change and take appropriate action on the change.
+     * 
+     * @param configName
+     *            : configuration key
+     * @param configValue
+     *            : configuration value
+     */
+    private void updateServiecConfiguration(String configName, String configValue) {
+        try {
+            Field field = ServiceConfiguration.class.getDeclaredField(configName);
+            if (field != null && field.isAnnotationPresent(FieldContext.class)) {
+                field.setAccessible(true);
+                boolean dynamic = ((FieldContext) field.getAnnotation(FieldContext.class)).dynamic();
+                if (dynamic) {
+                    updateConfigurationOnZk(configName, configValue);
+                } else {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("[{}] Can't update non-dynamic configuration {}/{}", clientAppId(), configName,
+                                configValue);
+                    }
+                    throw new RestException(Status.PRECONDITION_FAILED, " Can't update non-dynamic configuration");
+                }
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[{}] Configuration {}/{} is not dynamic", clientAppId(), configName, configValue);
+                }
+                throw new RestException(Status.NOT_FOUND, "Configuration not found");
+            }
+        } catch (NoSuchFieldException nse) {
+            LOG.error("[{}] Configuration {}/{} not found", clientAppId(), configName, configValue);
+            throw new RestException(Status.NOT_FOUND, "Configuration not found");
+        } catch (RestException re) {
+            throw re;
+        } catch (Exception ie) {
+            LOG.error("[{}] Failed to update configuration {}/{}, {}", clientAppId(), configName, configValue,
+                    ie.getMessage(), ie);
+            throw new RestException(ie);
+        }
+    }
+
+    private synchronized void updateConfigurationOnZk(String key, String value) throws Exception {
+        ZooKeeperDataCache<Map<String, String>> dynamicConfigurationCache = pulsar().getBrokerService()
+                .getDynamicConfigurationCache();
+        Map<String, String> configurationMap = dynamicConfigurationCache.get(BROKER_SERVICE_CONFIGURATION_PATH)
+                .orElse(null);
+        if (configurationMap != null) {
+            configurationMap.put(key, value);
+            byte[] content = ObjectMapperFactory.getThreadLocal().writeValueAsBytes(configurationMap);
+            dynamicConfigurationCache.invalidate(BROKER_SERVICE_CONFIGURATION_PATH);
+            serviceConfigZkVersion = localZk()
+                    .setData(BROKER_SERVICE_CONFIGURATION_PATH, content, serviceConfigZkVersion).getVersion();
+        } else {
+            configurationMap = Maps.newHashMap();
+            configurationMap.put(key, value);
+            byte[] content = ObjectMapperFactory.getThreadLocal().writeValueAsBytes(configurationMap);
+            ZkUtils.createFullPathOptimistic(localZk(), BROKER_SERVICE_CONFIGURATION_PATH, content,
+                    ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        }
+        LOG.info("[{}] Updated Service configuration {}/{}", clientAppId(), key, value);
     }
 }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
@@ -414,7 +414,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         try {
             admin.brokers().updateConfiguration("test", Long.toString(shutdownTime));
         } catch (Exception e) {
-            assertTrue(e instanceof NotFoundException);
+            assertTrue(e instanceof PreconditionFailedException);
         }
 
     }

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Brokers.java
@@ -69,11 +69,30 @@ public interface Brokers {
     Map<String, NamespaceOwnershipStatus> getOwnedNamespaces(String cluster, String brokerUrl) throws PulsarAdminException;
     
     /**
-     * Update value of any dynamic {@link ServiceConfiguration} 
+	 * It updates dynamic configuration value in to Zk that triggers watch on
+	 * brokers and all brokers can update {@link ServiceConfiguration} value
+	 * locally
+	 * 
+	 * @param key
+	 * @param value
+	 * @throws PulsarAdminException
+	 */
+    void updateDynamicConfiguration(String configName, String configValue) throws PulsarAdminException;
+
+    /**
+     * Get list of updatable configuration name
      * 
-     * @param key
-     * @param value
+     * @return
      * @throws PulsarAdminException
      */
-    void updateConfiguration(String configName, String configValue) throws PulsarAdminException;
+    List<String> getDynamicConfigurationNames() throws PulsarAdminException;
+
+    /**
+     * Get values of all overridden dynamic-configs
+     * 
+     * @return
+     * @throws PulsarAdminException
+     */
+    Map<String, String> getAllDynamicConfigurations() throws PulsarAdminException;
+
 }

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Brokers.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Brokers.java
@@ -67,4 +67,13 @@ public interface Brokers {
      * @throws PulsarAdminException
      */
     Map<String, NamespaceOwnershipStatus> getOwnedNamespaces(String cluster, String brokerUrl) throws PulsarAdminException;
+    
+    /**
+     * Update value of any dynamic {@link ServiceConfiguration} 
+     * 
+     * @param key
+     * @param value
+     * @throws PulsarAdminException
+     */
+    void updateConfiguration(String configName, String configValue) throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/BrokersImpl.java
@@ -18,12 +18,14 @@ package com.yahoo.pulsar.client.admin.internal;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 
 import com.yahoo.pulsar.client.admin.Brokers;
 import com.yahoo.pulsar.client.admin.PulsarAdminException;
 import com.yahoo.pulsar.client.api.Authentication;
+import com.yahoo.pulsar.common.policies.data.ErrorData;
 import com.yahoo.pulsar.common.policies.data.NamespaceOwnershipStatus;
 
 public class BrokersImpl extends BaseResource implements Brokers {
@@ -51,6 +53,16 @@ public class BrokersImpl extends BaseResource implements Brokers {
             return request(brokers.path(cluster).path(brokerUrl).path("ownedNamespaces")).get(
                     new GenericType<Map<String, NamespaceOwnershipStatus>>() {
                     });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void updateConfiguration(String configName, String configValue) throws PulsarAdminException {
+        try {
+            request(brokers.path("/configuration/").path(configName).path(configValue)).post(Entity.json(""),
+                    ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/BrokersImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/BrokersImpl.java
@@ -59,10 +59,30 @@ public class BrokersImpl extends BaseResource implements Brokers {
     }
 
     @Override
-    public void updateConfiguration(String configName, String configValue) throws PulsarAdminException {
+    public void updateDynamicConfiguration(String configName, String configValue) throws PulsarAdminException {
         try {
             request(brokers.path("/configuration/").path(configName).path(configValue)).post(Entity.json(""),
                     ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public Map<String, String> getAllDynamicConfigurations() throws PulsarAdminException {
+        try {
+            return request(brokers.path("/configuration/").path("values")).get(new GenericType<Map<String, String>>() {
+            });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public List<String> getDynamicConfigurationNames() throws PulsarAdminException {
+        try {
+            return request(brokers.path("/configuration")).get(new GenericType<List<String>>() {
+            });
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
@@ -57,14 +57,34 @@ public class CmdBrokers extends CmdBase {
 
         @Override
         void run() throws Exception {
-            admin.brokers().updateConfiguration(configName, configValue);
+            admin.brokers().updateDynamicConfiguration(configName, configValue);
         }
     }
 
+    @Parameters(commandDescription = "Get all overridden dynamic-configuration values")
+    private class GetAllConfigurationsCmd extends CliCommand {
+
+        @Override
+        void run() throws Exception {
+            print(admin.brokers().getAllDynamicConfigurations());
+        }
+    }
+    
+    @Parameters(commandDescription = "Get list of updatable configuration name")
+    private class GetUpdatableConfigCmd extends CliCommand {
+
+        @Override
+        void run() throws Exception {
+            print(admin.brokers().getDynamicConfigurationNames());
+        }
+    }
+    
     CmdBrokers(PulsarAdmin admin) {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
         jcommander.addCommand("namespaces", new Namespaces());
-        jcommander.addCommand("update-config", new UpdateConfigurationCmd());
+        jcommander.addCommand("update-dynamic-config", new UpdateConfigurationCmd());
+        jcommander.addCommand("list-dynamic-config", new GetUpdatableConfigCmd());
+        jcommander.addCommand("get-all-dynamic-config", new GetAllConfigurationsCmd());
     }
 }

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
@@ -65,6 +65,6 @@ public class CmdBrokers extends CmdBase {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
         jcommander.addCommand("namespaces", new Namespaces());
-        jcommander.addCommand("updateConfig", new UpdateConfigurationCmd());
+        jcommander.addCommand("update-config", new UpdateConfigurationCmd());
     }
 }

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
@@ -48,9 +48,23 @@ public class CmdBrokers extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Update dynamic-serviceConfiguration of broker")
+    private class UpdateConfigurationCmd extends CliCommand {
+        @Parameter(names = "--config", description = "service-configuration name", required = true)
+        private String configName;
+        @Parameter(names = "--value", description = "service-configuration value", required = true)
+        private String configValue;
+
+        @Override
+        void run() throws Exception {
+            admin.brokers().updateConfiguration(configName, configValue);
+        }
+    }
+
     CmdBrokers(PulsarAdmin admin) {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
         jcommander.addCommand("namespaces", new Namespaces());
+        jcommander.addCommand("updateConfig", new UpdateConfigurationCmd());
     }
 }

--- a/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -59,6 +59,15 @@ public class PulsarAdminToolTest {
 
         brokers.run(split("list use"));
         verify(mockBrokers).getActiveBrokers("use");
+        
+        brokers.run(split("get-all-dynamic-config"));
+        verify(mockBrokers).getAllDynamicConfigurations();
+        
+        brokers.run(split("list-dynamic-config"));
+        verify(mockBrokers).getDynamicConfigurationNames();
+        
+        brokers.run(split("update-dynamic-config --config brokerShutdownTimeoutMs --value 100"));
+        verify(mockBrokers).updateDynamicConfiguration("brokerShutdownTimeoutMs", "100");
     }
 
     @Test

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/FieldParser.java
@@ -135,7 +135,7 @@ public final class FieldParser {
      *            : field of the attribute
      * @return
      */
-    private static Object value(String strValue, Field field) {
+    public static Object value(String strValue, Field field) {
         checkNotNull(field);
         // if field is not primitive type
         if (field.getGenericType() instanceof ParameterizedType) {


### PR DESCRIPTION
### Motivation

as discussed at #184 : sometime it requires to update Broker-serviceConfiguration dynamically with the help of generic api.

### Modifications

- Annotation which defines service-configuration is dynamic
- znode which contains map of dynamic serviceConfiguration's name and value
- REST/AdminTool api to update specific dynamic-configuration by passing name/value 
- API to register listener which can be notified on config value change

### Result

Broker can update serviceConfiguration dynamically and can execute appropriate action on configuration-value change.
