### PR TITLE
Persist and recover individual deleted messages

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -198,6 +198,8 @@ managedLedgerCursorMaxEntriesPerLedger=50000
 # Max time before triggering a rollover on a cursor ledger
 managedLedgerCursorRolloverTimeInSeconds=14400
 
+managedLedgerMaxUnackedRangesToPersist=1000
+
 
 
 ### --- Load balancer --- ###

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -15,9 +15,7 @@
  */
 package org.apache.bookkeeper.mledger;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.annotations.Beta;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
@@ -26,8 +24,10 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.SkipEntriesCallback;
 
-import com.google.common.annotations.Beta;
-import com.google.common.base.Predicate;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A ManangedCursor is a persisted cursor inside a ManagedLedger.
@@ -326,7 +326,7 @@ public interface ManagedCursor {
      *            opaque context
      */
     public void asyncFindNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition,
-            FindEntryCallback callback, Object ctx);
+                                        FindEntryCallback callback, Object ctx);
 
     /**
      * reset the cursor to specified position to enable replay of messages

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -31,6 +31,7 @@ import com.google.common.base.Charsets;
 @Beta
 public class ManagedLedgerConfig {
 
+    private int maxUnackedRangesToPersist = 1000;
     private int maxEntriesPerLedger = 50000;
     private int maxSizePerLedgerMb = 100;
     private int minimumRolloverTimeMs = 0;
@@ -346,5 +347,22 @@ public class ManagedLedgerConfig {
      */
     public long getRetentionSizeInMB() {
         return retentionSizeInMB;
+    }
+
+    /**
+     * @return max unacked message ranges that will be persisted and recovered.
+     *
+     */
+    public int getMaxUnackedRangesToPersist() {
+        return maxUnackedRangesToPersist;
+    }
+
+    /**
+     * @param maxUnackedRangesToPersist
+     *            max unacked message ranges that will be persisted and receverd.
+     */
+    public ManagedLedgerConfig setMaxUnackedRangesToPersist(int maxUnackedRangesToPersist) {
+        this.maxUnackedRangesToPersist = maxUnackedRangesToPersist;
+        return this;
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 
 import java.util.ArrayDeque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -28,11 +29,18 @@ import java.util.concurrent.atomic.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
+import com.google.common.base.Objects;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.TreeRangeSet;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.DeleteCallback;
 import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.BKException.Code;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -52,22 +60,16 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.Version;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.mledger.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Range;
-import com.google.common.collect.RangeSet;
-import com.google.common.collect.Sets;
-import com.google.common.collect.TreeRangeSet;
-import com.google.common.util.concurrent.RateLimiter;
-import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ManagedCursorImpl implements ManagedCursor {
 
@@ -124,7 +126,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private final ArrayDeque<PendingMarkDeleteEntry> pendingMarkDeleteOps = new ArrayDeque<PendingMarkDeleteEntry>();
+    private final ArrayDeque<PendingMarkDeleteEntry> pendingMarkDeleteOps = new ArrayDeque<>();
     private static final AtomicIntegerFieldUpdater<ManagedCursorImpl> PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(ManagedCursorImpl.class, "pendingMarkDeletedSubmittedCount");
     private volatile int pendingMarkDeletedSubmittedCount = 0;
@@ -136,16 +138,16 @@ public class ManagedCursorImpl implements ManagedCursor {
         Open, // Metadata ledger is ready
         SwitchingLedger, // The metadata ledger is being switched
         Closed // The managed cursor has been closed
-    };
+    }
 
     private static final AtomicReferenceFieldUpdater<ManagedCursorImpl, State> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(ManagedCursorImpl.class, State.class, "state");
     private volatile State state = null;
 
     public interface VoidCallback {
-        public void operationComplete();
+        void operationComplete();
 
-        public void operationFailed(ManagedLedgerException exception);
+        void operationFailed(ManagedLedgerException exception);
     }
 
     ManagedCursorImpl(BookKeeper bookkeeper, ManagedLedgerConfig config, ManagedLedgerImpl ledger, String cursorName) {
@@ -186,6 +188,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                     // closed and the last mark-delete position is stored in the ManagedCursorInfo itself.s
                     PositionImpl recoveredPosition = new PositionImpl(info.getMarkDeleteLedgerId(),
                             info.getMarkDeleteEntryId());
+                    if (info.getIndividualDeletedMessagesCount() > 0) {
+                        recoverIndividualDeletedMessages(info.getIndividualDeletedMessagesList());
+                    }
                     recoveredCursor(recoveredPosition);
                     callback.operationComplete();
                 } else {
@@ -255,10 +260,29 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }
 
                 PositionImpl position = new PositionImpl(positionInfo);
+                if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
+                    recoverIndividualDeletedMessages(positionInfo.getIndividualDeletedMessagesList());
+                }
                 recoveredCursor(position);
                 callback.operationComplete();
             }, null);
         }, null);
+    }
+
+    private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
+        lock.writeLock().lock();
+        try {
+            individualDeletedMessages.clear();
+            individualDeletedMessagesList
+                    .forEach(messageRange -> individualDeletedMessages.add(
+                            Range.openClosed(
+                                    new PositionImpl(messageRange.getLowerEndpoint()),
+                                    new PositionImpl(messageRange.getUpperEndpoint())
+                            )
+                    ));
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     private void recoveredCursor(PositionImpl position) {
@@ -611,7 +635,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public void asyncFindNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition,
-            FindEntryCallback callback, Object ctx) {
+                                        FindEntryCallback callback, Object ctx) {
         OpFindNewest op;
         PositionImpl startPosition = null;
         long max = 0;
@@ -836,10 +860,8 @@ public class ManagedCursorImpl implements ManagedCursor {
         Set<Position> alreadyAcknowledgedPositions = Sets.newHashSet();
         lock.readLock().lock();
         try {
-            positions.stream().filter(position -> {
-                return individualDeletedMessages.contains((PositionImpl) position)
-                        || ((PositionImpl) position).compareTo(markDeletePosition) < 0;
-            }).forEach(pos -> alreadyAcknowledgedPositions.add(pos));
+            positions.stream().filter(position -> individualDeletedMessages.contains((PositionImpl) position)
+                    || ((PositionImpl) position).compareTo(markDeletePosition) < 0).forEach(alreadyAcknowledgedPositions::add);
         } finally {
             lock.readLock().unlock();
         }
@@ -871,7 +893,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 log.warn("[{}][{}] Error while replaying entries", ledger.getName(), name, mle);
                 if (exception.compareAndSet(null, mle)) {
                     // release the entries just once, any further read success will release the entry straight away
-                    entries.forEach(e -> e.release());
+                    entries.forEach(Entry::release);
                 }
                 if (--pendingCallbacks == 0) {
                     callback.readEntriesFailed(exception.get(), ctx);
@@ -879,9 +901,9 @@ public class ManagedCursorImpl implements ManagedCursor {
             }
         };
 
-        positions.stream().filter(position -> !alreadyAcknowledgedPositions.contains(position)).forEach(p -> {
-            ledger.asyncReadEntry((PositionImpl) p, cb, ctx);
-        });
+        positions.stream()
+                .filter(position -> !alreadyAcknowledgedPositions.contains(position))
+                .forEach(p -> ledger.asyncReadEntry((PositionImpl) p, cb, ctx));
         
         return alreadyAcknowledgedPositions;
     }
@@ -1631,9 +1653,14 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         // When closing we store the last mark-delete position in the z-node itself, so we won't need the cursor ledger,
         // hence we write it as -1. The cursor ledger is deleted once the z-node write is confirmed.
-        ManagedCursorInfo info = ManagedCursorInfo.newBuilder().setCursorsLedgerId(-1)
-                .setMarkDeleteLedgerId(markDeletePosition.getLedgerId())
-                .setMarkDeleteEntryId(markDeletePosition.getEntryId()).build();
+        ManagedCursorInfo.Builder builder = ManagedCursorInfo.newBuilder()
+            .setCursorsLedgerId(-1)
+            .setMarkDeleteLedgerId(markDeletePosition.getLedgerId())
+            .setMarkDeleteEntryId(markDeletePosition.getEntryId());
+        if (!individualDeletedMessages.isEmpty()) {
+            builder.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges());
+        }
+        ManagedCursorInfo info = builder.build();
         if (log.isDebugEnabled()) {
             log.debug("[{}][{}]  Closing cursor at md-position: {}", ledger.getName(), name, markDeletePosition);
         }
@@ -1791,39 +1818,66 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }, null);
     }
 
+    private List<MLDataFormats.MessageRange> buildIndividualDeletedMessageRanges() {
+        lock.readLock().lock();
+        try {
+            MLDataFormats.NestedPositionInfo.Builder nestedPositionBuilder = MLDataFormats.NestedPositionInfo.newBuilder();
+            MLDataFormats.MessageRange.Builder messageRangeBuilder = MLDataFormats.MessageRange.newBuilder();
+            return individualDeletedMessages.asRanges().stream()
+                    .limit(config.getMaxUnackedRangesToPersist())
+                    .map(positionRange -> {
+                        PositionImpl p = positionRange.lowerEndpoint();
+                        nestedPositionBuilder.setLedgerId(p.getLedgerId());
+                        nestedPositionBuilder.setEntryId(p.getEntryId());
+                        messageRangeBuilder.setLowerEndpoint(nestedPositionBuilder.build());
+                        p = positionRange.upperEndpoint();
+                        nestedPositionBuilder.setLedgerId(p.getLedgerId());
+                        nestedPositionBuilder.setEntryId(p.getEntryId());
+                        messageRangeBuilder.setUpperEndpoint(nestedPositionBuilder.build());
+                        return messageRangeBuilder.build();
+                    })
+                    .collect(Collectors.toList());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     void persistPosition(final LedgerHandle lh, final PositionImpl position, final VoidCallback callback) {
-        PositionInfo pi = position.getPositionInfo();
+        PositionInfo.Builder builder = PositionInfo.newBuilder()
+                .setLedgerId(position.getLedgerId())
+                .setEntryId(position.getEntryId());
+        if (!individualDeletedMessages.isEmpty()) {
+            builder.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges());
+        }
+        PositionInfo pi = builder.build();
         if (log.isDebugEnabled()) {
             log.debug("[{}] Cursor {} Appending to ledger={} position={}", ledger.getName(), name, lh.getId(),
                     position);
         }
 
-        lh.asyncAddEntry(pi.toByteArray(), new AddCallback() {
-            @Override
-            public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
-                if (rc == BKException.Code.OK) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Updated cursor {} position {} in meta-ledger {}", ledger.getName(), name,
-                                position, lh.getId());
-                    }
-
-                    if (shouldCloseLedger(lh)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Need to create new metadata ledger for consumer {}", ledger.getName(),
-                                    name);
-                        }
-                        startCreatingNewMetadataLedger();
-                    }
-
-                    callback.operationComplete();
-                } else {
-                    log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,
-                            position, lh.getId(), BKException.getMessage(rc));
-                    // If we've had a write error, the ledger will be automatically closed, we need to create a new one,
-                    // in the meantime the mark-delete will be queued.
-                    STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
-                    callback.operationFailed(new ManagedLedgerException(BKException.getMessage(rc)));
+        lh.asyncAddEntry(pi.toByteArray(), (rc, lh1, entryId, ctx) -> {
+            if (rc == BKException.Code.OK) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Updated cursor {} position {} in meta-ledger {}", ledger.getName(), name,
+                            position, lh1.getId());
                 }
+
+                if (shouldCloseLedger(lh1)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Need to create new metadata ledger for consumer {}", ledger.getName(),
+                                name);
+                    }
+                    startCreatingNewMetadataLedger();
+                }
+
+                callback.operationComplete();
+            } else {
+                log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,
+                        position, lh1.getId(), BKException.getMessage(rc));
+                // If we've had a write error, the ledger will be automatically closed, we need to create a new one,
+                // in the meantime the mark-delete will be queued.
+                STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
+                callback.operationFailed(new ManagedLedgerException(BKException.getMessage(rc)));
             }
         }, null);
     }
@@ -1846,9 +1900,14 @@ public class ManagedCursorImpl implements ManagedCursor {
         // Now we have an opened ledger that already has the acknowledged
         // position written into. At this point we can start using this new
         // ledger and delete the old one.
-        ManagedCursorInfo info = ManagedCursorInfo.newBuilder().setCursorsLedgerId(lh.getId())
+        ManagedCursorInfo.Builder builder = ManagedCursorInfo.newBuilder()
+                .setCursorsLedgerId(lh.getId())
                 .setMarkDeleteLedgerId(markDeletePosition.getLedgerId())
-                .setMarkDeleteEntryId(markDeletePosition.getEntryId()).build();
+                .setMarkDeleteEntryId(markDeletePosition.getEntryId());
+        if (!individualDeletedMessages.isEmpty()) {
+            builder.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges());
+        }
+        ManagedCursorInfo info = builder.build();
         if (log.isDebugEnabled()) {
             log.debug("[{}] Switching cursor {} to ledger {}", ledger.getName(), name, lh.getId());
         }
@@ -1999,9 +2058,9 @@ public class ManagedCursorImpl implements ManagedCursor {
      */
     private static boolean isBkErrorNotRecoverable(int rc) {
         switch (rc) {
-        case Code.NoSuchLedgerExistsException:
-        case Code.ReadException:
-        case Code.LedgerRecoveryException:
+        case BKException.Code.NoSuchLedgerExistsException:
+        case BKException.Code.ReadException:
+        case BKException.Code.LedgerRecoveryException:
             return true;
 
         default:

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -15,13 +15,14 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
-import com.google.common.base.Predicate;
+
+import java.util.function.Predicate;
 
 /**
  */
@@ -43,7 +44,7 @@ public class OpFindNewest implements ReadEntryCallback {
     State state;
 
     public OpFindNewest(ManagedCursorImpl cursor, PositionImpl startPosition, Predicate<Entry> condition,
-            long numberOfEntries, FindEntryCallback callback, Object ctx) {
+                        long numberOfEntries, FindEntryCallback callback, Object ctx) {
         this.cursor = cursor;
         this.startPosition = startPosition;
         this.callback = callback;
@@ -61,7 +62,7 @@ public class OpFindNewest implements ReadEntryCallback {
     public void readEntryComplete(Entry entry, Object ctx) {
         switch (state) {
         case checkFirst:
-            if (!condition.apply(entry)) {
+            if (!condition.test(entry)) {
                 callback.findEntryComplete(null, OpFindNewest.this.ctx);
                 return;
             } else {
@@ -74,7 +75,7 @@ public class OpFindNewest implements ReadEntryCallback {
             }
             break;
         case checkLast:
-            if (condition.apply(entry)) {
+            if (condition.test(entry)) {
                 callback.findEntryComplete(entry.getPosition(), OpFindNewest.this.ctx);
                 return;
             } else {
@@ -85,7 +86,7 @@ public class OpFindNewest implements ReadEntryCallback {
             }
             break;
         case searching:
-            if (condition.apply(entry)) {
+            if (condition.test(entry)) {
                 // mid - last
                 lastMatchedPosition = entry.getPosition();
                 min = mid();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImpl.java
@@ -17,8 +17,11 @@ package org.apache.bookkeeper.mledger.impl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.RangeSet;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
@@ -36,6 +39,12 @@ public class PositionImpl implements Position, Comparable<PositionImpl> {
     public PositionImpl(PositionInfo pi) {
         this.ledgerId = pi.getLedgerId();
         this.entryId = pi.getEntryId();
+        this.recyclerHandle = null;
+    }
+
+    public PositionImpl(NestedPositionInfo npi) {
+        this.ledgerId = npi.getLedgerId();
+        this.entryId = npi.getEntryId();
         this.recyclerHandle = null;
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
@@ -1098,6 +1098,16 @@ public final class MLDataFormats {
     // required int64 entryId = 2;
     boolean hasEntryId();
     long getEntryId();
+    
+    // repeated .MessageRange individualDeletedMessages = 3;
+    java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> 
+        getIndividualDeletedMessagesList();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getIndividualDeletedMessages(int index);
+    int getIndividualDeletedMessagesCount();
+    java.util.List<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+        getIndividualDeletedMessagesOrBuilderList();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder getIndividualDeletedMessagesOrBuilder(
+        int index);
   }
   public static final class PositionInfo extends
       com.google.protobuf.GeneratedMessage
@@ -1148,9 +1158,31 @@ public final class MLDataFormats {
       return entryId_;
     }
     
+    // repeated .MessageRange individualDeletedMessages = 3;
+    public static final int INDIVIDUALDELETEDMESSAGES_FIELD_NUMBER = 3;
+    private java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> individualDeletedMessages_;
+    public java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> getIndividualDeletedMessagesList() {
+      return individualDeletedMessages_;
+    }
+    public java.util.List<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+        getIndividualDeletedMessagesOrBuilderList() {
+      return individualDeletedMessages_;
+    }
+    public int getIndividualDeletedMessagesCount() {
+      return individualDeletedMessages_.size();
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getIndividualDeletedMessages(int index) {
+      return individualDeletedMessages_.get(index);
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder getIndividualDeletedMessagesOrBuilder(
+        int index) {
+      return individualDeletedMessages_.get(index);
+    }
+    
     private void initFields() {
       ledgerId_ = 0L;
       entryId_ = 0L;
+      individualDeletedMessages_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1165,6 +1197,12 @@ public final class MLDataFormats {
         memoizedIsInitialized = 0;
         return false;
       }
+      for (int i = 0; i < getIndividualDeletedMessagesCount(); i++) {
+        if (!getIndividualDeletedMessages(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -1177,6 +1215,9 @@ public final class MLDataFormats {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeInt64(2, entryId_);
+      }
+      for (int i = 0; i < individualDeletedMessages_.size(); i++) {
+        output.writeMessage(3, individualDeletedMessages_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -1194,6 +1235,10 @@ public final class MLDataFormats {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(2, entryId_);
+      }
+      for (int i = 0; i < individualDeletedMessages_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, individualDeletedMessages_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1311,6 +1356,7 @@ public final class MLDataFormats {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getIndividualDeletedMessagesFieldBuilder();
         }
       }
       private static Builder create() {
@@ -1323,6 +1369,12 @@ public final class MLDataFormats {
         bitField0_ = (bitField0_ & ~0x00000001);
         entryId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
+        if (individualDeletedMessagesBuilder_ == null) {
+          individualDeletedMessages_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          individualDeletedMessagesBuilder_.clear();
+        }
         return this;
       }
       
@@ -1369,6 +1421,15 @@ public final class MLDataFormats {
           to_bitField0_ |= 0x00000002;
         }
         result.entryId_ = entryId_;
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            individualDeletedMessages_ = java.util.Collections.unmodifiableList(individualDeletedMessages_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.individualDeletedMessages_ = individualDeletedMessages_;
+        } else {
+          result.individualDeletedMessages_ = individualDeletedMessagesBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1385,6 +1446,641 @@ public final class MLDataFormats {
       
       public Builder mergeFrom(org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo other) {
         if (other == org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo.getDefaultInstance()) return this;
+        if (other.hasLedgerId()) {
+          setLedgerId(other.getLedgerId());
+        }
+        if (other.hasEntryId()) {
+          setEntryId(other.getEntryId());
+        }
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (!other.individualDeletedMessages_.isEmpty()) {
+            if (individualDeletedMessages_.isEmpty()) {
+              individualDeletedMessages_ = other.individualDeletedMessages_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensureIndividualDeletedMessagesIsMutable();
+              individualDeletedMessages_.addAll(other.individualDeletedMessages_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.individualDeletedMessages_.isEmpty()) {
+            if (individualDeletedMessagesBuilder_.isEmpty()) {
+              individualDeletedMessagesBuilder_.dispose();
+              individualDeletedMessagesBuilder_ = null;
+              individualDeletedMessages_ = other.individualDeletedMessages_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              individualDeletedMessagesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getIndividualDeletedMessagesFieldBuilder() : null;
+            } else {
+              individualDeletedMessagesBuilder_.addAllMessages(other.individualDeletedMessages_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasLedgerId()) {
+          
+          return false;
+        }
+        if (!hasEntryId()) {
+          
+          return false;
+        }
+        for (int i = 0; i < getIndividualDeletedMessagesCount(); i++) {
+          if (!getIndividualDeletedMessages(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              onChanged();
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                onChanged();
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              ledgerId_ = input.readInt64();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              entryId_ = input.readInt64();
+              break;
+            }
+            case 26: {
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.newBuilder();
+              input.readMessage(subBuilder, extensionRegistry);
+              addIndividualDeletedMessages(subBuilder.buildPartial());
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required int64 ledgerId = 1;
+      private long ledgerId_ ;
+      public boolean hasLedgerId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public long getLedgerId() {
+        return ledgerId_;
+      }
+      public Builder setLedgerId(long value) {
+        bitField0_ |= 0x00000001;
+        ledgerId_ = value;
+        onChanged();
+        return this;
+      }
+      public Builder clearLedgerId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ledgerId_ = 0L;
+        onChanged();
+        return this;
+      }
+      
+      // required int64 entryId = 2;
+      private long entryId_ ;
+      public boolean hasEntryId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public long getEntryId() {
+        return entryId_;
+      }
+      public Builder setEntryId(long value) {
+        bitField0_ |= 0x00000002;
+        entryId_ = value;
+        onChanged();
+        return this;
+      }
+      public Builder clearEntryId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        entryId_ = 0L;
+        onChanged();
+        return this;
+      }
+      
+      // repeated .MessageRange individualDeletedMessages = 3;
+      private java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> individualDeletedMessages_ =
+        java.util.Collections.emptyList();
+      private void ensureIndividualDeletedMessagesIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          individualDeletedMessages_ = new java.util.ArrayList<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange>(individualDeletedMessages_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+      
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> individualDeletedMessagesBuilder_;
+      
+      public java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> getIndividualDeletedMessagesList() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(individualDeletedMessages_);
+        } else {
+          return individualDeletedMessagesBuilder_.getMessageList();
+        }
+      }
+      public int getIndividualDeletedMessagesCount() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return individualDeletedMessages_.size();
+        } else {
+          return individualDeletedMessagesBuilder_.getCount();
+        }
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getIndividualDeletedMessages(int index) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return individualDeletedMessages_.get(index);
+        } else {
+          return individualDeletedMessagesBuilder_.getMessage(index);
+        }
+      }
+      public Builder setIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange value) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.set(index, value);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      public Builder setIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder builderForValue) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange value) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(value);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange value) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(index, value);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder builderForValue) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(builderForValue.build());
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder builderForValue) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addAllIndividualDeletedMessages(
+          java.lang.Iterable<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> values) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          super.addAll(values, individualDeletedMessages_);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      public Builder clearIndividualDeletedMessages() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          individualDeletedMessages_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.clear();
+        }
+        return this;
+      }
+      public Builder removeIndividualDeletedMessages(int index) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.remove(index);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.remove(index);
+        }
+        return this;
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder getIndividualDeletedMessagesBuilder(
+          int index) {
+        return getIndividualDeletedMessagesFieldBuilder().getBuilder(index);
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder getIndividualDeletedMessagesOrBuilder(
+          int index) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return individualDeletedMessages_.get(index);  } else {
+          return individualDeletedMessagesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      public java.util.List<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+           getIndividualDeletedMessagesOrBuilderList() {
+        if (individualDeletedMessagesBuilder_ != null) {
+          return individualDeletedMessagesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(individualDeletedMessages_);
+        }
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder addIndividualDeletedMessagesBuilder() {
+        return getIndividualDeletedMessagesFieldBuilder().addBuilder(
+            org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDefaultInstance());
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder addIndividualDeletedMessagesBuilder(
+          int index) {
+        return getIndividualDeletedMessagesFieldBuilder().addBuilder(
+            index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDefaultInstance());
+      }
+      public java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder> 
+           getIndividualDeletedMessagesBuilderList() {
+        return getIndividualDeletedMessagesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+          getIndividualDeletedMessagesFieldBuilder() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          individualDeletedMessagesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder>(
+                  individualDeletedMessages_,
+                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  getParentForChildren(),
+                  isClean());
+          individualDeletedMessages_ = null;
+        }
+        return individualDeletedMessagesBuilder_;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:PositionInfo)
+    }
+    
+    static {
+      defaultInstance = new PositionInfo(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:PositionInfo)
+  }
+  
+  public interface NestedPositionInfoOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+    
+    // required int64 ledgerId = 1;
+    boolean hasLedgerId();
+    long getLedgerId();
+    
+    // required int64 entryId = 2;
+    boolean hasEntryId();
+    long getEntryId();
+  }
+  public static final class NestedPositionInfo extends
+      com.google.protobuf.GeneratedMessage
+      implements NestedPositionInfoOrBuilder {
+    // Use NestedPositionInfo.newBuilder() to construct.
+    private NestedPositionInfo(Builder builder) {
+      super(builder);
+    }
+    private NestedPositionInfo(boolean noInit) {}
+    
+    private static final NestedPositionInfo defaultInstance;
+    public static NestedPositionInfo getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public NestedPositionInfo getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_NestedPositionInfo_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_NestedPositionInfo_fieldAccessorTable;
+    }
+    
+    private int bitField0_;
+    // required int64 ledgerId = 1;
+    public static final int LEDGERID_FIELD_NUMBER = 1;
+    private long ledgerId_;
+    public boolean hasLedgerId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public long getLedgerId() {
+      return ledgerId_;
+    }
+    
+    // required int64 entryId = 2;
+    public static final int ENTRYID_FIELD_NUMBER = 2;
+    private long entryId_;
+    public boolean hasEntryId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public long getEntryId() {
+      return entryId_;
+    }
+    
+    private void initFields() {
+      ledgerId_ = 0L;
+      entryId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasLedgerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasEntryId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, entryId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, ledgerId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, entryId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_NestedPositionInfo_descriptor;
+      }
+      
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_NestedPositionInfo_fieldAccessorTable;
+      }
+      
+      // Construct using org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+      
+      private Builder(BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        ledgerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        entryId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDescriptor();
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getDefaultInstanceForType() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo build() {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo buildPartial() {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo result = new org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.ledgerId_ = ledgerId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.entryId_ = entryId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo) {
+          return mergeFrom((org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo other) {
+        if (other == org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance()) return this;
         if (other.hasLedgerId()) {
           setLedgerId(other.getLedgerId());
         }
@@ -1488,15 +2184,614 @@ public final class MLDataFormats {
         return this;
       }
       
-      // @@protoc_insertion_point(builder_scope:PositionInfo)
+      // @@protoc_insertion_point(builder_scope:NestedPositionInfo)
     }
     
     static {
-      defaultInstance = new PositionInfo(true);
+      defaultInstance = new NestedPositionInfo(true);
       defaultInstance.initFields();
     }
     
-    // @@protoc_insertion_point(class_scope:PositionInfo)
+    // @@protoc_insertion_point(class_scope:NestedPositionInfo)
+  }
+  
+  public interface MessageRangeOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+    
+    // required .NestedPositionInfo lowerEndpoint = 1;
+    boolean hasLowerEndpoint();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getLowerEndpoint();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getLowerEndpointOrBuilder();
+    
+    // required .NestedPositionInfo upperEndpoint = 2;
+    boolean hasUpperEndpoint();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getUpperEndpoint();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getUpperEndpointOrBuilder();
+  }
+  public static final class MessageRange extends
+      com.google.protobuf.GeneratedMessage
+      implements MessageRangeOrBuilder {
+    // Use MessageRange.newBuilder() to construct.
+    private MessageRange(Builder builder) {
+      super(builder);
+    }
+    private MessageRange(boolean noInit) {}
+    
+    private static final MessageRange defaultInstance;
+    public static MessageRange getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public MessageRange getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_MessageRange_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_MessageRange_fieldAccessorTable;
+    }
+    
+    private int bitField0_;
+    // required .NestedPositionInfo lowerEndpoint = 1;
+    public static final int LOWERENDPOINT_FIELD_NUMBER = 1;
+    private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo lowerEndpoint_;
+    public boolean hasLowerEndpoint() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getLowerEndpoint() {
+      return lowerEndpoint_;
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getLowerEndpointOrBuilder() {
+      return lowerEndpoint_;
+    }
+    
+    // required .NestedPositionInfo upperEndpoint = 2;
+    public static final int UPPERENDPOINT_FIELD_NUMBER = 2;
+    private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo upperEndpoint_;
+    public boolean hasUpperEndpoint() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getUpperEndpoint() {
+      return upperEndpoint_;
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getUpperEndpointOrBuilder() {
+      return upperEndpoint_;
+    }
+    
+    private void initFields() {
+      lowerEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+      upperEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasLowerEndpoint()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasUpperEndpoint()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getLowerEndpoint().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getUpperEndpoint().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeMessage(1, lowerEndpoint_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeMessage(2, upperEndpoint_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, lowerEndpoint_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, upperEndpoint_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_MessageRange_descriptor;
+      }
+      
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_MessageRange_fieldAccessorTable;
+      }
+      
+      // Construct using org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+      
+      private Builder(BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getLowerEndpointFieldBuilder();
+          getUpperEndpointFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        if (lowerEndpointBuilder_ == null) {
+          lowerEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+        } else {
+          lowerEndpointBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (upperEndpointBuilder_ == null) {
+          upperEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+        } else {
+          upperEndpointBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDescriptor();
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getDefaultInstanceForType() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDefaultInstance();
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange build() {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange buildPartial() {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange result = new org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        if (lowerEndpointBuilder_ == null) {
+          result.lowerEndpoint_ = lowerEndpoint_;
+        } else {
+          result.lowerEndpoint_ = lowerEndpointBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        if (upperEndpointBuilder_ == null) {
+          result.upperEndpoint_ = upperEndpoint_;
+        } else {
+          result.upperEndpoint_ = upperEndpointBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange) {
+          return mergeFrom((org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange other) {
+        if (other == org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDefaultInstance()) return this;
+        if (other.hasLowerEndpoint()) {
+          mergeLowerEndpoint(other.getLowerEndpoint());
+        }
+        if (other.hasUpperEndpoint()) {
+          mergeUpperEndpoint(other.getUpperEndpoint());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasLowerEndpoint()) {
+          
+          return false;
+        }
+        if (!hasUpperEndpoint()) {
+          
+          return false;
+        }
+        if (!getLowerEndpoint().isInitialized()) {
+          
+          return false;
+        }
+        if (!getUpperEndpoint().isInitialized()) {
+          
+          return false;
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              onChanged();
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                onChanged();
+                return this;
+              }
+              break;
+            }
+            case 10: {
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder();
+              if (hasLowerEndpoint()) {
+                subBuilder.mergeFrom(getLowerEndpoint());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setLowerEndpoint(subBuilder.buildPartial());
+              break;
+            }
+            case 18: {
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder();
+              if (hasUpperEndpoint()) {
+                subBuilder.mergeFrom(getUpperEndpoint());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setUpperEndpoint(subBuilder.buildPartial());
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required .NestedPositionInfo lowerEndpoint = 1;
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo lowerEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder> lowerEndpointBuilder_;
+      public boolean hasLowerEndpoint() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getLowerEndpoint() {
+        if (lowerEndpointBuilder_ == null) {
+          return lowerEndpoint_;
+        } else {
+          return lowerEndpointBuilder_.getMessage();
+        }
+      }
+      public Builder setLowerEndpoint(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo value) {
+        if (lowerEndpointBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          lowerEndpoint_ = value;
+          onChanged();
+        } else {
+          lowerEndpointBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      public Builder setLowerEndpoint(
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder builderForValue) {
+        if (lowerEndpointBuilder_ == null) {
+          lowerEndpoint_ = builderForValue.build();
+          onChanged();
+        } else {
+          lowerEndpointBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      public Builder mergeLowerEndpoint(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo value) {
+        if (lowerEndpointBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+              lowerEndpoint_ != org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance()) {
+            lowerEndpoint_ =
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder(lowerEndpoint_).mergeFrom(value).buildPartial();
+          } else {
+            lowerEndpoint_ = value;
+          }
+          onChanged();
+        } else {
+          lowerEndpointBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      public Builder clearLowerEndpoint() {
+        if (lowerEndpointBuilder_ == null) {
+          lowerEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+          onChanged();
+        } else {
+          lowerEndpointBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder getLowerEndpointBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getLowerEndpointFieldBuilder().getBuilder();
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getLowerEndpointOrBuilder() {
+        if (lowerEndpointBuilder_ != null) {
+          return lowerEndpointBuilder_.getMessageOrBuilder();
+        } else {
+          return lowerEndpoint_;
+        }
+      }
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder> 
+          getLowerEndpointFieldBuilder() {
+        if (lowerEndpointBuilder_ == null) {
+          lowerEndpointBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder>(
+                  lowerEndpoint_,
+                  getParentForChildren(),
+                  isClean());
+          lowerEndpoint_ = null;
+        }
+        return lowerEndpointBuilder_;
+      }
+      
+      // required .NestedPositionInfo upperEndpoint = 2;
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo upperEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder> upperEndpointBuilder_;
+      public boolean hasUpperEndpoint() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getUpperEndpoint() {
+        if (upperEndpointBuilder_ == null) {
+          return upperEndpoint_;
+        } else {
+          return upperEndpointBuilder_.getMessage();
+        }
+      }
+      public Builder setUpperEndpoint(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo value) {
+        if (upperEndpointBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          upperEndpoint_ = value;
+          onChanged();
+        } else {
+          upperEndpointBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder setUpperEndpoint(
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder builderForValue) {
+        if (upperEndpointBuilder_ == null) {
+          upperEndpoint_ = builderForValue.build();
+          onChanged();
+        } else {
+          upperEndpointBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder mergeUpperEndpoint(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo value) {
+        if (upperEndpointBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+              upperEndpoint_ != org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance()) {
+            upperEndpoint_ =
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder(upperEndpoint_).mergeFrom(value).buildPartial();
+          } else {
+            upperEndpoint_ = value;
+          }
+          onChanged();
+        } else {
+          upperEndpointBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder clearUpperEndpoint() {
+        if (upperEndpointBuilder_ == null) {
+          upperEndpoint_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+          onChanged();
+        } else {
+          upperEndpointBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder getUpperEndpointBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getUpperEndpointFieldBuilder().getBuilder();
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getUpperEndpointOrBuilder() {
+        if (upperEndpointBuilder_ != null) {
+          return upperEndpointBuilder_.getMessageOrBuilder();
+        } else {
+          return upperEndpoint_;
+        }
+      }
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder> 
+          getUpperEndpointFieldBuilder() {
+        if (upperEndpointBuilder_ == null) {
+          upperEndpointBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder>(
+                  upperEndpoint_,
+                  getParentForChildren(),
+                  isClean());
+          upperEndpoint_ = null;
+        }
+        return upperEndpointBuilder_;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:MessageRange)
+    }
+    
+    static {
+      defaultInstance = new MessageRange(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:MessageRange)
   }
   
   public interface ManagedCursorInfoOrBuilder
@@ -1513,6 +2808,16 @@ public final class MLDataFormats {
     // optional int64 markDeleteEntryId = 3;
     boolean hasMarkDeleteEntryId();
     long getMarkDeleteEntryId();
+    
+    // repeated .MessageRange individualDeletedMessages = 4;
+    java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> 
+        getIndividualDeletedMessagesList();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getIndividualDeletedMessages(int index);
+    int getIndividualDeletedMessagesCount();
+    java.util.List<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+        getIndividualDeletedMessagesOrBuilderList();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder getIndividualDeletedMessagesOrBuilder(
+        int index);
   }
   public static final class ManagedCursorInfo extends
       com.google.protobuf.GeneratedMessage
@@ -1573,10 +2878,32 @@ public final class MLDataFormats {
       return markDeleteEntryId_;
     }
     
+    // repeated .MessageRange individualDeletedMessages = 4;
+    public static final int INDIVIDUALDELETEDMESSAGES_FIELD_NUMBER = 4;
+    private java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> individualDeletedMessages_;
+    public java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> getIndividualDeletedMessagesList() {
+      return individualDeletedMessages_;
+    }
+    public java.util.List<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+        getIndividualDeletedMessagesOrBuilderList() {
+      return individualDeletedMessages_;
+    }
+    public int getIndividualDeletedMessagesCount() {
+      return individualDeletedMessages_.size();
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getIndividualDeletedMessages(int index) {
+      return individualDeletedMessages_.get(index);
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder getIndividualDeletedMessagesOrBuilder(
+        int index) {
+      return individualDeletedMessages_.get(index);
+    }
+    
     private void initFields() {
       cursorsLedgerId_ = 0L;
       markDeleteLedgerId_ = 0L;
       markDeleteEntryId_ = 0L;
+      individualDeletedMessages_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1586,6 +2913,12 @@ public final class MLDataFormats {
       if (!hasCursorsLedgerId()) {
         memoizedIsInitialized = 0;
         return false;
+      }
+      for (int i = 0; i < getIndividualDeletedMessagesCount(); i++) {
+        if (!getIndividualDeletedMessages(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
       }
       memoizedIsInitialized = 1;
       return true;
@@ -1602,6 +2935,9 @@ public final class MLDataFormats {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeInt64(3, markDeleteEntryId_);
+      }
+      for (int i = 0; i < individualDeletedMessages_.size(); i++) {
+        output.writeMessage(4, individualDeletedMessages_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -1623,6 +2959,10 @@ public final class MLDataFormats {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(3, markDeleteEntryId_);
+      }
+      for (int i = 0; i < individualDeletedMessages_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, individualDeletedMessages_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1740,6 +3080,7 @@ public final class MLDataFormats {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getIndividualDeletedMessagesFieldBuilder();
         }
       }
       private static Builder create() {
@@ -1754,6 +3095,12 @@ public final class MLDataFormats {
         bitField0_ = (bitField0_ & ~0x00000002);
         markDeleteEntryId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000004);
+        if (individualDeletedMessagesBuilder_ == null) {
+          individualDeletedMessages_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+        } else {
+          individualDeletedMessagesBuilder_.clear();
+        }
         return this;
       }
       
@@ -1804,6 +3151,15 @@ public final class MLDataFormats {
           to_bitField0_ |= 0x00000004;
         }
         result.markDeleteEntryId_ = markDeleteEntryId_;
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+            individualDeletedMessages_ = java.util.Collections.unmodifiableList(individualDeletedMessages_);
+            bitField0_ = (bitField0_ & ~0x00000008);
+          }
+          result.individualDeletedMessages_ = individualDeletedMessages_;
+        } else {
+          result.individualDeletedMessages_ = individualDeletedMessagesBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1829,6 +3185,32 @@ public final class MLDataFormats {
         if (other.hasMarkDeleteEntryId()) {
           setMarkDeleteEntryId(other.getMarkDeleteEntryId());
         }
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (!other.individualDeletedMessages_.isEmpty()) {
+            if (individualDeletedMessages_.isEmpty()) {
+              individualDeletedMessages_ = other.individualDeletedMessages_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+            } else {
+              ensureIndividualDeletedMessagesIsMutable();
+              individualDeletedMessages_.addAll(other.individualDeletedMessages_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.individualDeletedMessages_.isEmpty()) {
+            if (individualDeletedMessagesBuilder_.isEmpty()) {
+              individualDeletedMessagesBuilder_.dispose();
+              individualDeletedMessagesBuilder_ = null;
+              individualDeletedMessages_ = other.individualDeletedMessages_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+              individualDeletedMessagesBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getIndividualDeletedMessagesFieldBuilder() : null;
+            } else {
+              individualDeletedMessagesBuilder_.addAllMessages(other.individualDeletedMessages_);
+            }
+          }
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -1837,6 +3219,12 @@ public final class MLDataFormats {
         if (!hasCursorsLedgerId()) {
           
           return false;
+        }
+        for (int i = 0; i < getIndividualDeletedMessagesCount(); i++) {
+          if (!getIndividualDeletedMessages(i).isInitialized()) {
+            
+            return false;
+          }
         }
         return true;
       }
@@ -1877,6 +3265,12 @@ public final class MLDataFormats {
             case 24: {
               bitField0_ |= 0x00000004;
               markDeleteEntryId_ = input.readInt64();
+              break;
+            }
+            case 34: {
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.newBuilder();
+              input.readMessage(subBuilder, extensionRegistry);
+              addIndividualDeletedMessages(subBuilder.buildPartial());
               break;
             }
           }
@@ -1948,6 +3342,192 @@ public final class MLDataFormats {
         return this;
       }
       
+      // repeated .MessageRange individualDeletedMessages = 4;
+      private java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> individualDeletedMessages_ =
+        java.util.Collections.emptyList();
+      private void ensureIndividualDeletedMessagesIsMutable() {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+          individualDeletedMessages_ = new java.util.ArrayList<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange>(individualDeletedMessages_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+      
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> individualDeletedMessagesBuilder_;
+      
+      public java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> getIndividualDeletedMessagesList() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(individualDeletedMessages_);
+        } else {
+          return individualDeletedMessagesBuilder_.getMessageList();
+        }
+      }
+      public int getIndividualDeletedMessagesCount() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return individualDeletedMessages_.size();
+        } else {
+          return individualDeletedMessagesBuilder_.getCount();
+        }
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange getIndividualDeletedMessages(int index) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return individualDeletedMessages_.get(index);
+        } else {
+          return individualDeletedMessagesBuilder_.getMessage(index);
+        }
+      }
+      public Builder setIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange value) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.set(index, value);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      public Builder setIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder builderForValue) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange value) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(value);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange value) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(index, value);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder builderForValue) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(builderForValue.build());
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addIndividualDeletedMessages(
+          int index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder builderForValue) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addAllIndividualDeletedMessages(
+          java.lang.Iterable<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange> values) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          super.addAll(values, individualDeletedMessages_);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      public Builder clearIndividualDeletedMessages() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          individualDeletedMessages_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.clear();
+        }
+        return this;
+      }
+      public Builder removeIndividualDeletedMessages(int index) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          ensureIndividualDeletedMessagesIsMutable();
+          individualDeletedMessages_.remove(index);
+          onChanged();
+        } else {
+          individualDeletedMessagesBuilder_.remove(index);
+        }
+        return this;
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder getIndividualDeletedMessagesBuilder(
+          int index) {
+        return getIndividualDeletedMessagesFieldBuilder().getBuilder(index);
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder getIndividualDeletedMessagesOrBuilder(
+          int index) {
+        if (individualDeletedMessagesBuilder_ == null) {
+          return individualDeletedMessages_.get(index);  } else {
+          return individualDeletedMessagesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      public java.util.List<? extends org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+           getIndividualDeletedMessagesOrBuilderList() {
+        if (individualDeletedMessagesBuilder_ != null) {
+          return individualDeletedMessagesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(individualDeletedMessages_);
+        }
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder addIndividualDeletedMessagesBuilder() {
+        return getIndividualDeletedMessagesFieldBuilder().addBuilder(
+            org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDefaultInstance());
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder addIndividualDeletedMessagesBuilder(
+          int index) {
+        return getIndividualDeletedMessagesFieldBuilder().addBuilder(
+            index, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.getDefaultInstance());
+      }
+      public java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder> 
+           getIndividualDeletedMessagesBuilderList() {
+        return getIndividualDeletedMessagesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder> 
+          getIndividualDeletedMessagesFieldBuilder() {
+        if (individualDeletedMessagesBuilder_ == null) {
+          individualDeletedMessagesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRangeOrBuilder>(
+                  individualDeletedMessages_,
+                  ((bitField0_ & 0x00000008) == 0x00000008),
+                  getParentForChildren(),
+                  isClean());
+          individualDeletedMessages_ = null;
+        }
+        return individualDeletedMessagesBuilder_;
+      }
+      
       // @@protoc_insertion_point(builder_scope:ManagedCursorInfo)
     }
     
@@ -1975,6 +3555,16 @@ public final class MLDataFormats {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_PositionInfo_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_NestedPositionInfo_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_NestedPositionInfo_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_MessageRange_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_MessageRange_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ManagedCursorInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -1992,12 +3582,19 @@ public final class MLDataFormats {
       "\021ManagedLedgerInfo\0221\n\nledgerInfo\030\001 \003(\0132\035" +
       ".ManagedLedgerInfo.LedgerInfo\032P\n\nLedgerI" +
       "nfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entries\030\002 \001(\003\022\014" +
-      "\n\004size\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003\"1\n\014Posit" +
+      "\n\004size\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003\"c\n\014Posit" +
       "ionInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002" +
-      "(\003\"c\n\021ManagedCursorInfo\022\027\n\017cursorsLedger" +
-      "Id\030\001 \002(\003\022\032\n\022markDeleteLedgerId\030\002 \001(\003\022\031\n\021" +
-      "markDeleteEntryId\030\003 \001(\003B\'\n#org.apache.bo" +
-      "okkeeper.mledger.protoH\001"
+      "(\003\0220\n\031individualDeletedMessages\030\003 \003(\0132\r." +
+      "MessageRange\"7\n\022NestedPositionInfo\022\020\n\010le" +
+      "dgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\"f\n\014Message" +
+      "Range\022*\n\rlowerEndpoint\030\001 \002(\0132\023.NestedPos",
+      "itionInfo\022*\n\rupperEndpoint\030\002 \002(\0132\023.Neste" +
+      "dPositionInfo\"\225\001\n\021ManagedCursorInfo\022\027\n\017c" +
+      "ursorsLedgerId\030\001 \002(\003\022\032\n\022markDeleteLedger" +
+      "Id\030\002 \001(\003\022\031\n\021markDeleteEntryId\030\003 \001(\003\0220\n\031i" +
+      "ndividualDeletedMessages\030\004 \003(\0132\r.Message" +
+      "RangeB\'\n#org.apache.bookkeeper.mledger.p" +
+      "rotoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -2025,15 +3622,31 @@ public final class MLDataFormats {
           internal_static_PositionInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PositionInfo_descriptor,
-              new java.lang.String[] { "LedgerId", "EntryId", },
+              new java.lang.String[] { "LedgerId", "EntryId", "IndividualDeletedMessages", },
               org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo.Builder.class);
-          internal_static_ManagedCursorInfo_descriptor =
+          internal_static_NestedPositionInfo_descriptor =
             getDescriptor().getMessageTypes().get(2);
+          internal_static_NestedPositionInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_NestedPositionInfo_descriptor,
+              new java.lang.String[] { "LedgerId", "EntryId", },
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.class,
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder.class);
+          internal_static_MessageRange_descriptor =
+            getDescriptor().getMessageTypes().get(3);
+          internal_static_MessageRange_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_MessageRange_descriptor,
+              new java.lang.String[] { "LowerEndpoint", "UpperEndpoint", },
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.class,
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder.class);
+          internal_static_ManagedCursorInfo_descriptor =
+            getDescriptor().getMessageTypes().get(4);
           internal_static_ManagedCursorInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ManagedCursorInfo_descriptor,
-              new java.lang.String[] { "CursorsLedgerId", "MarkDeleteLedgerId", "MarkDeleteEntryId", },
+              new java.lang.String[] { "CursorsLedgerId", "MarkDeleteLedgerId", "MarkDeleteEntryId", "IndividualDeletedMessages", },
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo.Builder.class);
           return null;

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -30,6 +30,17 @@ message ManagedLedgerInfo {
 message PositionInfo {
 	required int64 ledgerId = 1;
 	required int64 entryId  = 2;
+    repeated MessageRange individualDeletedMessages = 3;
+}
+
+message NestedPositionInfo {
+    required int64 ledgerId = 1;
+    required int64 entryId  = 2;
+}
+
+message MessageRange {
+    required NestedPositionInfo lowerEndpoint = 1;
+    required NestedPositionInfo upperEndpoint = 2;
 }
 
 message ManagedCursorInfo {
@@ -40,4 +51,5 @@ message ManagedCursorInfo {
 	// Last snapshot of the mark-delete position
 	optional int64 markDeleteLedgerId = 2;
 	optional int64 markDeleteEntryId  = 3;
+	repeated MessageRange individualDeletedMessages = 4;
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -15,30 +15,17 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.bookkeeper.mledger.*;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.*;
+import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
-import org.apache.bookkeeper.mledger.AsyncCallbacks;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.SkipEntriesCallback;
-import org.apache.bookkeeper.mledger.Entry;
-import org.apache.bookkeeper.mledger.ManagedCursor;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.bookkeeper.mledger.Position;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static org.testng.Assert.*;
 
 @Test
 public class ManagedCursorContainerTest {
@@ -123,7 +110,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void asyncClose(AsyncCallbacks.CloseCallback callback, Object ctx) {
+        public void asyncClose(CloseCallback callback, Object ctx) {
         }
 
         @Override
@@ -160,11 +147,11 @@ public class ManagedCursorContainerTest {
 
         @Override
         public void asyncFindNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition,
-                AsyncCallbacks.FindEntryCallback callback, Object ctx) {
+                                            FindEntryCallback callback, Object ctx) {
         }
 
         @Override
-        public void asyncResetCursor(final Position position, AsyncCallbacks.ResetCursorCallback callback) {
+        public void asyncResetCursor(final Position position, ResetCursorCallback callback) {
 
         }
 

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -178,6 +178,11 @@ public class ServiceConfiguration implements PulsarConfiguration{
     private int managedLedgerCursorMaxEntriesPerLedger = 50000;
     // Max time before triggering a rollover on a cursor ledger
     private int managedLedgerCursorRolloverTimeInSeconds = 14400;
+    // Max number of entries to append to a ledger before triggering a rollover
+    // A ledger rollover is triggered on these conditions Either the max
+    // rollover time has been reached or max entries have been written to the
+    // ledged and at least min-time has passed
+    private int managedLedgerMaxUnackedRangesToPersist = 1000;
 
     /*** --- Load balancer --- ****/
     // Enable load balancer
@@ -678,6 +683,14 @@ public class ServiceConfiguration implements PulsarConfiguration{
 
     public void setManagedLedgerCursorRolloverTimeInSeconds(int managedLedgerCursorRolloverTimeInSeconds) {
         this.managedLedgerCursorRolloverTimeInSeconds = managedLedgerCursorRolloverTimeInSeconds;
+    }
+
+    public int getManagedLedgerMaxUnackedRangesToPersist() {
+        return managedLedgerMaxUnackedRangesToPersist;
+    }
+
+    public void setManagedLedgerMaxUnackedRangesToPersist(int managedLedgerMaxUnackedRangesToPersist) {
+        this.managedLedgerMaxUnackedRangesToPersist = managedLedgerMaxUnackedRangesToPersist;
     }
 
     public boolean isLoadBalancerEnabled() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -495,6 +495,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             config.setThrottleMarkDelete(persistencePolicies.getManagedLedgerMaxMarkDeleteRate());
             config.setDigestType(DigestType.CRC32);
 
+            config.setMaxUnackedRangesToPersist(serviceConfig.getManagedLedgerMaxUnackedRangesToPersist());
             config.setMaxEntriesPerLedger(serviceConfig.getManagedLedgerMaxEntriesPerLedger());
             config.setMinimumRolloverTime(serviceConfig.getManagedLedgerMinLedgerRolloverTimeMinutes(),
                     TimeUnit.MINUTES);


### PR DESCRIPTION
### Motivation

Issue #180 

### Modifications

Modified `ManagedCursorInfo` and `PositionInfo` to store a list of ranges of `PositionInfo`, just like `individualDeletedMessages`.

When persisting `ManagedCursorInfo` or `PositionInfo` they ges populated with the current `individualDeletedMessages`, which are then used to repopulate `individualDeletedMessages` on recover.
Theoretically it should be as simple as repopulating `individualDeletedMessages` and `ManagedCursor` should skip already acked messages when reading.

Changed `MetaStoreImplZookeeper` to store Protobuf's byte representation rather than string representation, as this change produces and exponential growth on the string representation, due to the format of the Protobuf structures.
When reading, `MetaStoreImplZookeeper` will attempt to decode the data as byte representation, if it fails, it will then fallback to parsing the string representation.

I realize this, is a short-comming, since the data stored in ZooKeeper wouldn't be human-readable, but we could maybe expose a command in pulsar-admin to ease the reading. This also benefits ZooKeeper, as the data written is now much smaller (9 bytes for a `ManagedCursorInfo` with empty `individualDeletedMessages`).

Maybe persisting all `individualDeletedMessages` everytime `PositionInfo` is stored in BookKeeper doesn't make much sense, but users can tune writes though markDeleteThrottling. Also, setting an arbitrary value on the amount of messages between first unacked message and current read position, doesn't make much sense.

### Result

Should allow for consumers to have unacked messages without affecting their backlog when bundles get unloading.

I would like for you guys @merlimat @rdhabalia to comment on this, tell me what you think, If you see this could bring unforseen issues, etc. 
