### PR TITLE
Excluded travis-build.sh from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,7 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>pulsar-client-cpp/lib/lz4/lz4.*</exclude>
             <exclude>pulsar-client-cpp/lib/PulsarApi.pb.*</exclude>
             <exclude>pulsar-client-cpp/CMakeFiles/**</exclude>
+            <exclude>pulsar-client-cpp/travis-build.sh</exclude>
           </excludes>
           <mapping>
             <proto>JAVADOC_STYLE</proto>


### PR DESCRIPTION
### Motivation

The first line line "#!/bin/bash" in travis-build.sh seems to confuse the license plugin to think the license header is missing even though its there.

Travis build fails with the following error:

[WARNING] Missing header in: /home/travis/build/yahoo/pulsar/pulsar-client-cpp/travis-build.sh
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:3.0.rc1:check (default) on project pulsar: Some files do not have the expected license header -> [Help 1]


### Modifications

Added travis-build.sh to exclude from license check

### Result

Build should succeed.