### PR TITLE
Replace usages of Atomic* for Atomic*FieldUpdater

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -137,8 +137,8 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         OpAddEntry firstInQueue = ml.pendingAddEntries.poll();
         checkArgument(this == firstInQueue);
 
-        ml.numberOfEntries.incrementAndGet();
-        ml.totalSize.addAndGet(dataLength);
+        ManagedLedgerImpl.NUMBER_OF_ENTRIES_UPDATER.incrementAndGet(ml);
+        ManagedLedgerImpl.TOTAL_SIZE_UPDATER.addAndGet(ml, dataLength);
         if (ml.hasActiveCursors()) {
             // Avoid caching entries if no cursor has been created
             ml.entryCache.insert(new EntryImpl(ledger.getId(), entryId, data));
@@ -148,7 +148,7 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         data.release();
 
         PositionImpl lastEntry = PositionImpl.get(ledger.getId(), entryId);
-        ml.entriesAddedCounter.incrementAndGet();
+        ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(ml);
         ml.lastConfirmedEntry = lastEntry;
 
         if (closeWhenDone) {

--- a/pulsar-broker/src/test/java/org/testng/listener/TestListener.java
+++ b/pulsar-broker/src/test/java/org/testng/listener/TestListener.java
@@ -39,7 +39,7 @@ public class TestListener extends TestListenerAdapter {
     @Override
     public void onTestFailure(ITestResult tr) {
         log.error("------------ Test Failed - {} / {} -- attrs: {}", tr.getTestClass().getName(),
-                tr.getMethod().getMethodName(), tr.getAttributeNames());
+                tr.getMethod().getMethodName(), tr.getAttributeNames(), tr.getThrowable());
     }
 
     @Override

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -77,7 +77,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
                     "Cannot use receive() when a listener has been set");
         }
 
-        switch (state.get()) {
+        switch (getState()) {
         case Ready:
         case Connecting:
             break; // Ok
@@ -100,7 +100,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
                     "Cannot use receive() when a listener has been set"));
         }
 
-        switch (state.get()) {
+        switch (getState()) {
         case Ready:
         case Connecting:
             break; // Ok
@@ -130,7 +130,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
                     "Cannot use receive() when a listener has been set");
         }
 
-        switch (state.get()) {
+        switch (getState()) {
         case Ready:
         case Connecting:
             break; // Ok

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerBase.java
@@ -17,7 +17,6 @@ package com.yahoo.pulsar.client.impl;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import com.yahoo.pulsar.client.api.Message;
 import com.yahoo.pulsar.client.api.MessageBuilder;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
@@ -342,7 +342,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     protected CompletableFuture<ClientCnx> getConnection(final String topic) {
         DestinationName destinationName = DestinationName.get(topic);
-        return lookup.getBroker(destinationName).thenCompose((brokerAddress) -> cnxPool.getConnection(brokerAddress));
+        return lookup.getBroker(destinationName).thenCompose(cnxPool::getConnection);
     }
 
     protected Timer timer() {


### PR DESCRIPTION
Replaced some usages of AtomicInteger, AtomicLong and AtomicReference for their Atomic*FieldUpdater counterpart on classes which get instantiated a lot, this should reduce memory usage for the broker and clients which use lots of topics and consumers.
