### PR TITLE
Getting the code to run with old boost asio

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -136,17 +136,17 @@ void ClientConnection::handlePulsarConnected(const CommandConnected& cmdConnecte
 }
 
 /// The number of unacknowledged probes to send before considering the connection dead and notifying the application layer
-typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_TCP), TCP_KEEPCNT> tcp_keep_alive_count;
+typedef boost::asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPCNT> tcp_keep_alive_count;
 
 /// The interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
-typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_TCP), TCP_KEEPINTVL> tcp_keep_alive_interval;
+typedef boost::asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPINTVL> tcp_keep_alive_interval;
 
 /// The interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive
 /// probe; after the connection is marked to need keepalive, this counter is not used any further
 #ifdef __APPLE__
-  typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_TCP), TCP_KEEPALIVE> tcp_keep_alive_idle;
+  typedef boost::asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPALIVE> tcp_keep_alive_idle;
 #else
-  typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_TCP), TCP_KEEPIDLE> tcp_keep_alive_idle;
+  typedef boost::asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPIDLE> tcp_keep_alive_idle;
 #endif
 
 /*


### PR DESCRIPTION
### Motivation

C++ Library could not be compiled with boost 1.41 since ASIO_OS_DEF macro is relatively new. 

### Modifications

Removed the macro ASIO_OS_DEF, since this macro was introduced to get asio to work with windows, see the commit given below for more details: https://github.com/chriskohlhoff/asio/blob/51bba37e7da598ae7ac684b631c06bda80d6203c/asio/include/asio/detail/socket_types.hpp

### Result

C++ Library is compatible with old boost version (1.41) but may not work on windows.
