### PR TITLE
Add tls authentication plugin for cpp client

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Auth.h
+++ b/pulsar-client-cpp/include/pulsar/Auth.h
@@ -19,36 +19,57 @@
 
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include <boost/shared_ptr.hpp>
 #include <pulsar/Result.h>
 
 #pragma GCC visibility push(default)
 
 namespace pulsar {
-
-class Authentication {
+    
+    typedef std::unordered_map<std::string, std::string> ParamMap;
+    
+    class AuthenticationDataProvider {
+    public:
+        virtual ~AuthenticationDataProvider();
+        virtual bool hasDataForTls();
+        virtual std::string getTlsCertificates();
+        virtual std::string getTlsPrivateKey();
+        virtual bool hasDataForHttp();
+        virtual std::string getHttpAuthType();
+        virtual std::string getHttpHeaders();
+        virtual bool hasDataFromCommand();
+        virtual std::string getCommandData();
+    protected:
+        AuthenticationDataProvider();
+    };
+    
+    typedef boost::shared_ptr<AuthenticationDataProvider> AuthenticationDataPtr;
+    
+    class Authentication {
     public:
         virtual ~Authentication();
         virtual const std::string getAuthMethodName() const = 0;
-        virtual Result getAuthData(std::string& authDataContent) const = 0;
-
+        virtual Result getAuthData(AuthenticationDataPtr& authDataContent) const = 0;
+        
     protected:
         Authentication();
-};
-
-typedef boost::shared_ptr<Authentication> AuthenticationPtr;
-
-class Auth {
+    };
+    
+    typedef boost::shared_ptr<Authentication> AuthenticationPtr;
+    
+    class Auth {
     public:
         static AuthenticationPtr Disabled();
         static AuthenticationPtr create(const std::string& dynamicLibPath);
-        static AuthenticationPtr create(const std::string& dynamicLibPath, const std::string& params);
+        static AuthenticationPtr create(const std::string& dynamicLibPath, const std::string& authParamsString);
+        static AuthenticationPtr create(const std::string& dynamicLibPath, ParamMap& params);
     protected:
         static bool isShutdownHookRegistered_;
         static std::vector<void *> loadedLibrariesHandles_;
         static void release_handles();
-};
-
+    };
+    
 }
 // namespace pulsar
 

--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -111,6 +111,15 @@ class ClientConfiguration {
      */
     const std::string& getLogConfFilePath() const;
 
+    ClientConfiguration& setUseTls(bool useTls);
+    bool isUseTls() const;
+
+    ClientConfiguration& setTlsTrustCertsFilePath(const std::string &tlsTrustCertsFilePath);
+    std::string getTlsTrustCertsFilePath() const;
+
+    ClientConfiguration& setTlsAllowInsecureConnection(bool allowInsecure);
+    bool isTlsAllowInsecureConnection() const;
+
  private:
     const AuthenticationPtr& getAuthenticationPtr() const;
 

--- a/pulsar-client-cpp/lib/Auth.cc
+++ b/pulsar-client-cpp/lib/Auth.cc
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <stdio.h>
 
 #include <pulsar/Auth.h>
@@ -25,82 +26,148 @@
 #include <cstdlib>
 #include <boost/make_shared.hpp>
 #include <boost/thread.hpp>
-
-// Built-in authentications
-#include "auth/AuthTls.h"
+#include <boost/algorithm/string.hpp>
 
 DECLARE_LOG_OBJECT()
 
 namespace pulsar {
-
-Authentication::Authentication() {
-}
-
-Authentication::~Authentication() {
-}
-
-class AuthDisabled : public Authentication {
- public:
-    AuthDisabled()
-            : Authentication() {
+    
+    AuthenticationDataProvider::AuthenticationDataProvider(){
+        
     }
-
-    static AuthenticationPtr create() {
-        return boost::make_shared<AuthDisabled>();
+    
+    AuthenticationDataProvider::~AuthenticationDataProvider() {
+        
     }
-
-    const std::string getAuthMethodName() const {
+    
+    bool AuthenticationDataProvider::hasDataForTls() {
+        return false;
+    }
+    
+    std::string AuthenticationDataProvider::getTlsCertificates() {
         return "none";
     }
-
-    Result getAuthData(std::string&) const {
-        return ResultOk;
+    
+    std::string AuthenticationDataProvider::getTlsPrivateKey() {
+        return "none";
     }
-};
-
-AuthenticationPtr Auth::Disabled() {
-    return AuthDisabled::create();
-}
-
-AuthenticationPtr Auth::create(const std::string& dynamicLibPath) {
-    return Auth::create(dynamicLibPath, "");
-}
-
-boost::mutex mutex;
-std::vector<void*> Auth::loadedLibrariesHandles_;
-bool Auth::isShutdownHookRegistered_ = false;
-
-void Auth::release_handles() {
-    boost::lock_guard<boost::mutex> lock(mutex);
-    for (std::vector<void*>::iterator ite = Auth::loadedLibrariesHandles_.begin(); ite != Auth::loadedLibrariesHandles_.end();
-            ite++) {
-        dlclose(*ite);
+    
+    bool AuthenticationDataProvider::hasDataForHttp() {
+        return false;
     }
-    loadedLibrariesHandles_.clear();
-}
-
-AuthenticationPtr Auth::create(const std::string& dynamicLibPath, const std::string& params) {
-    {
-        boost::lock_guard<boost::mutex> lock(mutex);
-        if (!Auth::isShutdownHookRegistered_) {
-            atexit(release_handles);
-            Auth::isShutdownHookRegistered_ = true;
+    
+    std::string AuthenticationDataProvider::getHttpAuthType() {
+        return "none";
+    }
+    
+    std::string AuthenticationDataProvider::getHttpHeaders() {
+        return "none";
+    }
+    
+    bool AuthenticationDataProvider::hasDataFromCommand(){
+        return false;
+    }
+    
+    std::string AuthenticationDataProvider::getCommandData() {
+        return "none";
+    }
+    
+    
+    Authentication::Authentication() {
+    }
+    
+    Authentication::~Authentication() {
+    }
+    
+    class AuthDisabledData : public AuthenticationDataProvider {
+    public:
+        AuthDisabledData(ParamMap& params){
         }
+    };
+    
+    class AuthDisabled : public Authentication {
+    public:
+        AuthDisabled(AuthenticationDataPtr& authData) {
+            authData_ = authData;
+        }
+        
+        static AuthenticationPtr create(ParamMap& params) {
+            AuthenticationDataPtr authData = AuthenticationDataPtr(new AuthDisabledData(params));
+            return AuthenticationPtr(new AuthDisabled(authData));
+        }
+        
+        const std::string getAuthMethodName() const {
+            return "none";
+        }
+        
+        Result getAuthData(AuthenticationDataPtr& authDataContent) const {
+            authDataContent = authData_;
+            return ResultOk;
+        }
+    private:
+        AuthenticationDataPtr authData_;
+    };
+    
+    
+    AuthenticationPtr Auth::Disabled() {
+        ParamMap params;
+        return AuthDisabled::create(params);
     }
-    Authentication *auth = NULL;
-    void *handle = dlopen(dynamicLibPath.c_str(), RTLD_LAZY);
-    if (handle != NULL) {
+    
+    AuthenticationPtr Auth::create(const std::string& dynamicLibPath) {
+        ParamMap params;
+        return Auth::create(dynamicLibPath, params);
+    }
+    
+    boost::mutex mutex;
+    std::vector<void*> Auth::loadedLibrariesHandles_;
+    bool Auth::isShutdownHookRegistered_ = false;
+    
+    void Auth::release_handles() {
+        boost::lock_guard<boost::mutex> lock(mutex);
+        for (std::vector<void*>::iterator ite = Auth::loadedLibrariesHandles_.begin(); ite != Auth::loadedLibrariesHandles_.end();
+             ite++) {
+            dlclose(*ite);
+        }
+        loadedLibrariesHandles_.clear();
+    }
+    
+    AuthenticationPtr Auth::create(const std::string& dynamicLibPath, const std::string& authParamsString) {
+        ParamMap paramMap;
+        if(!authParamsString.empty()) {
+            std::vector<std::string> params;
+            boost::algorithm::split(params, authParamsString, boost::is_any_of(","));
+            for(auto& p: params) {
+                std::vector<std::string> kv;
+                boost::algorithm::split(kv, p, boost::is_any_of(":"));
+                if (kv.size() == 2) {
+                    paramMap[kv[0]] = kv[1];
+                }
+            }
+        }
+        return Auth::create(dynamicLibPath, paramMap);
+    }
+    
+    AuthenticationPtr Auth::create(const std::string& dynamicLibPath, ParamMap& params) {
         {
             boost::lock_guard<boost::mutex> lock(mutex);
+            if (!Auth::isShutdownHookRegistered_) {
+                atexit(release_handles);
+                Auth::isShutdownHookRegistered_ = true;
+            }
+        }
+        Authentication *auth = NULL;
+        void *handle = dlopen(dynamicLibPath.c_str(), RTLD_LAZY);
+        if (handle != NULL) {
+            boost::lock_guard<boost::mutex> lock(mutex);
             loadedLibrariesHandles_.push_back(handle);
+            Authentication *(*createAuthentication)(ParamMap&);
+            *(void **) (&createAuthentication) = dlsym(handle, "create");
+            if (createAuthentication != NULL) {
+                auth = createAuthentication(params);
+            }
         }
-        Authentication *(*createAuthentication)(const std::string);
-        *(void **) (&createAuthentication) = dlsym(handle, "create");
-        if (createAuthentication != NULL) {
-            auth = createAuthentication(params);
-        }
+        return boost::shared_ptr<Authentication>(auth);
     }
-    return boost::shared_ptr<Authentication>(auth);
-}
-
+    
 }

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -36,6 +36,9 @@ struct ClientConfiguration::Impl {
     int operationTimeoutSeconds;
     int messageListenerThreads;
     std::string logConfFilePath;
+    bool useTls;
+    std::string tlsTrustCertsFilePath;
+    bool tlsAllowInsecureConnection;
     Impl() : authData(Auth::Disabled()),
              ioThreads(1),
              operationTimeoutSeconds(30),
@@ -99,6 +102,33 @@ int ClientConfiguration::getMessageListenerThreads() const {
     return impl_->messageListenerThreads;
 }
 
+ClientConfiguration& ClientConfiguration::setUseTls(bool useTls) {
+    impl_->useTls = useTls;
+    return *this;
+}
+
+bool ClientConfiguration::isUseTls() const {
+    return impl_->useTls;
+}
+
+ClientConfiguration& ClientConfiguration::setTlsTrustCertsFilePath(const std::string &filePath) {
+    impl_->tlsTrustCertsFilePath = filePath;
+    return *this;
+}
+
+std::string ClientConfiguration::getTlsTrustCertsFilePath() const {
+    return impl_->tlsTrustCertsFilePath;
+}
+
+ClientConfiguration& ClientConfiguration::setTlsAllowInsecureConnection(bool allowInsecure) {
+    impl_->tlsAllowInsecureConnection = allowInsecure;
+    return *this;
+}
+
+bool ClientConfiguration::isTlsAllowInsecureConnection() const {
+    return impl_->tlsAllowInsecureConnection;
+}
+    
 ClientConfiguration& ClientConfiguration::setLogConfFilePath(const std::string& logConfFilePath) {
     impl_->logConfFilePath = logConfFilePath;
     return *this;

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -134,9 +134,9 @@ SharedBuffer Commands::newConnect(const AuthenticationPtr& authentication) {
     connect->set_client_version(_PULSAR_VERSION_);
     connect->set_auth_method_name(authentication->getAuthMethodName());
     connect->set_protocol_version(ProtocolVersion_MAX);
-    std::string authDataContent;
-    if (authentication->getAuthData(authDataContent) == ResultOk) {
-        connect->set_auth_data(authDataContent);
+    AuthenticationDataPtr authDataContent;
+    if (authentication->getAuthData(authDataContent) == ResultOk && authDataContent->hasDataFromCommand()) {
+        connect->set_auth_data(authDataContent->getCommandData());
     }
     return writeMessageWithSize(cmd);
 }

--- a/pulsar-client-cpp/lib/ExecutorService.cc
+++ b/pulsar-client-cpp/lib/ExecutorService.cc
@@ -42,6 +42,10 @@ SocketPtr ExecutorService::createSocket() {
     return boost::make_shared<boost::asio::ip::tcp::socket>(boost::ref(io_service_));
 }
 
+TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx) {
+    return boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> >(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> (*socket, ctx));
+}
+
 /*
  *  factory method of Resolver object associated with io_service_ instance
  *  @returns shraed_ptr to resolver object

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -19,6 +19,7 @@
 
 #include <boost/scoped_ptr.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 #include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/mutex.hpp>
@@ -27,6 +28,7 @@
 
 namespace pulsar {
 typedef boost::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
+typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > TlsSocketPtr;
 typedef boost::shared_ptr<boost::asio::ip::tcp::resolver> TcpResolverPtr;
 typedef boost::shared_ptr<boost::asio::deadline_timer> DeadlineTimerPtr;
 class ExecutorService : private boost::noncopyable {
@@ -36,6 +38,7 @@ class ExecutorService : private boost::noncopyable {
     ~ExecutorService();
 
     SocketPtr createSocket();
+    TlsSocketPtr createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx);
     TcpResolverPtr createTcpResolver();
     DeadlineTimerPtr createDeadlineTimer();
     void postWork(boost::function<void(void)> task);

--- a/pulsar-client-cpp/lib/auth/AuthTls.cc
+++ b/pulsar-client-cpp/lib/auth/AuthTls.cc
@@ -14,12 +14,53 @@
  * limitations under the License.
  */
 
-#include "AuthTls.h"
+#include <lib/auth/AuthTls.h>
 
 namespace pulsar {
-
-extern "C" Authentication* create(const std::string &params) {
-    return new AuthTls(params);
-}
-
+    AuthDataTls::AuthDataTls(ParamMap& params) {
+        tlsCertificates_ = params["tlsCertificates"];
+        tlsPrivateKey_ = params["tlsPrivateKey"];
+    }
+    
+    AuthDataTls::~AuthDataTls() {
+        
+    }
+    
+    bool AuthDataTls::hasDataForTls() {
+        return true;
+    }
+    
+    std::string AuthDataTls::getTlsCertificates() {
+        return tlsCertificates_;
+    }
+    
+    std::string AuthDataTls::getTlsPrivateKey() {
+        return tlsPrivateKey_;
+    }
+    
+    AuthTls::AuthTls(AuthenticationDataPtr& authDataTls) {
+        authDataTls_ = authDataTls;
+    }
+    
+    AuthTls::~AuthTls() {
+    }
+    
+    AuthenticationPtr AuthTls::create(ParamMap& params) {
+        AuthenticationDataPtr authDataTls = AuthenticationDataPtr(new AuthDataTls(params));
+        return AuthenticationPtr(new AuthTls(authDataTls));
+    }
+    
+    const std::string AuthTls::getAuthMethodName() const {
+        return "tls";
+    }
+    
+    Result AuthTls::getAuthData(AuthenticationDataPtr& authDataContent) const {
+        authDataContent = authDataTls_;
+        return ResultOk;
+    }
+    
+    extern "C" Authentication* create(ParamMap& params) {
+        AuthenticationDataPtr authDataTls = AuthenticationDataPtr(new AuthDataTls(params));
+        return new AuthTls(authDataTls);
+    }
 }

--- a/pulsar-client-cpp/lib/auth/AuthTls.h
+++ b/pulsar-client-cpp/lib/auth/AuthTls.h
@@ -19,31 +19,35 @@
 
 #include <pulsar/Auth.h>
 #include <lib/LogUtils.h>
+#include <iostream>
 #include <string>
 
 namespace pulsar {
-
-class AuthTls : public Authentication {
-public:
-    AuthTls(const std::string& params) {
-    }
-
-    ~AuthTls() {
-    }
-
-    static AuthenticationPtr create(const std::string& params) {
-        return boost::shared_ptr<Authentication>(new AuthTls(params));
-    }
-
-    const std::string getAuthMethodName() const {
-        return "tls";
-    }
-
-    Result getAuthData(std::string& authDataContent) const {
-        authDataContent = "THIS_SHOULD_BE_REPLACED";
-        return ResultOk;
-    }
-};
-
+    
+    class AuthDataTls : public AuthenticationDataProvider {
+        
+    public:
+        AuthDataTls(ParamMap& params);
+        ~AuthDataTls();
+        bool hasDataForTls();
+        std::string getTlsCertificates();
+        std::string getTlsPrivateKey();
+    private:
+        std::string tlsCertificates_;
+        std::string tlsPrivateKey_;
+    };
+    
+    class AuthTls : public Authentication {
+        
+    public:
+        AuthTls(AuthenticationDataPtr&);
+        ~AuthTls();
+        static AuthenticationPtr create(ParamMap& params);
+        const std::string getAuthMethodName() const;
+        Result getAuthData(AuthenticationDataPtr& authDataTls) const;
+    private:
+        AuthenticationDataPtr authDataTls_;
+    };
+    
 }
 #endif /* PULSAR_AUTH_TLS_H_ */

--- a/pulsar-client-cpp/perf/PerfConsumer.cc
+++ b/pulsar-client-cpp/perf/PerfConsumer.cc
@@ -38,6 +38,7 @@ using namespace boost::accumulators;
 #include <lib/Latch.h>
 
 #include <pulsar/Client.h>
+#include <pulsar/Auth.h>
 using namespace pulsar;
 
 static int64_t currentTimeMillis() {
@@ -51,6 +52,11 @@ static int64_t currentTimeMillis() {
 }
 
 struct Arguments {
+    std::string authParams;
+    std::string authPlugin;
+    bool isUseTls;
+    bool isTlsAllowInsecureConnection;
+    std::string tlsTrustCertsFilePath;
     std::string topic;
     int numTopics;
     int numConsumers;
@@ -122,8 +128,19 @@ void handleSubscribe(Result result, Consumer consumer, Latch latch) {
 
 void startPerfConsumer(const Arguments& args) {
     ClientConfiguration conf;
+
+    conf.setUseTls(args.isUseTls);
+    conf.setTlsAllowInsecureConnection(args.isTlsAllowInsecureConnection);
+    if (!args.tlsTrustCertsFilePath.empty()) {
+        std::string tlsTrustCertsFilePath(args.tlsTrustCertsFilePath);
+        conf.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);
+    }
     conf.setIOThreads(args.ioThreads);
     conf.setMessageListenerThreads(args.listenerThreads);
+    if(!args.authPlugin.empty()) {
+        AuthenticationPtr auth = Auth::create(args.authPlugin, args.authParams);
+        conf.setAuthentication(auth);
+    }
 
     Client client(pulsar::PulsarFriend::getClient(args.serviceURL, conf, false));
 
@@ -208,7 +225,18 @@ int main(int argc, char** argv) {
 
     po::options_description desc("Allowed options");
     desc.add_options()  //
+
     ("help,h", "Print this help message")  //
+
+    ("auth-params,v", po::value<std::string>(&args.authParams)->default_value(""), "Authentication parameters, e.g., \"key1:val1,key2:val2\"") //
+
+    ("auth-plugin,a", po::value<std::string>(&args.authPlugin)->default_value(""), "Authentication plugin class library path") //
+
+    ("use-tls,b", po::value<bool>(&args.isUseTls)->default_value(false), "Whether tls connection is used")  //
+
+    ("allow-insecure,d", po::value<bool>(&args.isTlsAllowInsecureConnection)->default_value(true), "Whether insecure tls connection is allowed")  //
+
+    ("trust-cert-file,c", po::value<std::string>(&args.tlsTrustCertsFilePath)->default_value(""), "TLS trust certification file path")  //
 
     ("num-topics,t", po::value<int>(&args.numTopics)->default_value(1), "Number of topics")  //
 

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -18,23 +18,24 @@
 #include <gtest/gtest.h>
 
 TEST(AuthPluginTest, testCreate) {
-    std::string data;
+    pulsar::AuthenticationDataPtr data;
 
     pulsar::AuthenticationPtr auth = pulsar::Auth::create("../lib/auth/libauthtls.so");
     ASSERT_TRUE(auth != NULL);
     ASSERT_EQ(auth->getAuthMethodName(), "tls");
     ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);
-    ASSERT_EQ(data, "THIS_SHOULD_BE_REPLACED");
+    ASSERT_EQ(data->getCommandData(), "none");
+    ASSERT_EQ(data->hasDataForTls(), true);
     ASSERT_EQ(auth.use_count(), 1);
 }
 
 TEST(AuthPluginTest, testDisable) {
-    std::string data;
+    pulsar::AuthenticationDataPtr data;
 
     pulsar::AuthenticationPtr auth = pulsar::Auth::Disabled();
     ASSERT_TRUE(auth != NULL);
     ASSERT_EQ(auth->getAuthMethodName(), "none");
     ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);
-    ASSERT_EQ(data, "");
+    ASSERT_EQ(data->getCommandData(), "none");
 	ASSERT_EQ(auth.use_count(), 1);
 }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -497,8 +497,8 @@ TEST(BasicEndToEndTest, testPartitionedProducerConsumer)
     config1.setLogConfFilePath("/tmp/");
 
     ClientConfiguration config2 = config1;
-    std::string str = "";
-    ASSERT_EQ(ResultOk, config1.getAuthentication().getAuthData(str));
+    AuthenticationDataPtr authData;
+    ASSERT_EQ(ResultOk, config1.getAuthentication().getAuthData(authData));
     ASSERT_EQ(100, config2.getOperationTimeoutSeconds());
     ASSERT_EQ(10, config2.getIOThreads());
     ASSERT_EQ(1, config2.getMessageListenerThreads());


### PR DESCRIPTION
### Motivation

Authentication plugin for C++ client is empty.

### Modifications

- Support TLS connection
- Add TLS authentication plugin
- Enable performance tools to use authentication plugin

### Result

C++ client can be authenticated and authorized by broker with AuthenticationProviderTls.