### PR TITLE
Update log4j.properties

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -34,7 +34,7 @@ log4j.rootLogger=${pulsar.root.logger}
 # Log INFO level and above messages to the console
 #
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.Threshold=INFO
+log4j.appender.CONSOLE.Threshold=DEBUG
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n
 
@@ -43,7 +43,7 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p - [%t:%C{1}@%
 #    Log DEBUG level and above messages to a log file
 log4j.appender.ROLLINGFILE=org.apache.log4j.DailyRollingFileAppender
 
-log4j.appender.ROLLINGFILE.Threshold=INFO
+log4j.appender.ROLLINGFILE.Threshold=DEBUG
 log4j.appender.ROLLINGFILE.File=${pulsar.log.dir}/${pulsar.log.file}
 log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n

--- a/conf/log4j.shell.properties
+++ b/conf/log4j.shell.properties
@@ -27,7 +27,7 @@ log4j.rootLogger=${bookkeeper.root.logger}
 # Log INFO level and above messages to the console
 #
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.Threshold=INFO
+log4j.appender.CONSOLE.Threshold=DEBUG
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ABSOLUTE} %-5p %m%n
 


### PR DESCRIPTION
### Motivation

Currently you can't print DEBUG level logs even if you change the configuration.

a. Open ./bin/pulsar and change INFO to DEBUG
b. try running ./bin/pulsar standalone -> You will still get only INFO logs
c. Play around with WARN and ERROR levels to understand the problem better

### Modifications

Changed the thresholds to DEBUG as per 
http://stackoverflow.com/questions/15086818/log4j-debug-messages-not-showing-in-console-despite-isdebugenabled-being-true

### Result

Can go upto DEBUG level logs.