### PR TITLE
Fixed Discovery Service initialization of global zk cache

### DIFF
--- a/conf/discovery.conf
+++ b/conf/discovery.conf
@@ -20,6 +20,9 @@ zookeeperServers=
 # Global zookeeper quorum connection string (comma-separated)
 globalZookeeperServers=
 
+# ZooKeeper session timeout
+zookeeperSessionTimeoutMs=30000
+
 # Port to use to server binary-proto request
 servicePort=6650
 
@@ -34,7 +37,7 @@ webServicePortTls=8443
 
 # Control whether to bind directly on localhost rather than on normal hostname
 bindOnLocalhost=false
-    
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/server/ServiceConfig.java
@@ -26,12 +26,16 @@ import com.yahoo.pulsar.discovery.service.web.DiscoveryServiceServlet;
  * Service Configuration to start :{@link DiscoveryServiceServlet}
  *
  */
-public class ServiceConfig implements PulsarConfiguration{
+public class ServiceConfig implements PulsarConfiguration {
 
     // Local-Zookeeper quorum connection string
     private String zookeeperServers;
     // Global-Zookeeper quorum connection string
     private String globalZookeeperServers;
+
+    // ZooKeeper session timeout
+    private int zookeeperSessionTimeoutMs = 30_000;
+
     // Port to use to server binary-proto request
     private int servicePort = 5000;
     // Port to use to server binary-proto-tls request
@@ -43,18 +47,18 @@ public class ServiceConfig implements PulsarConfiguration{
     // Control whether to bind directly on localhost rather than on normal
     // hostname
     private boolean bindOnLocalhost = false;
-    
+
     // Role names that are treated as "super-user", meaning they will be able to
     // do all admin operations and publish/consume from all topics
     private Set<String> superUserRoles = Sets.newTreeSet();
-    
+
     // Enable authentication
     private boolean authenticationEnabled = false;
     // Authentication provider name list, which is a list of class names
     private Set<String> authenticationProviders = Sets.newTreeSet();
     // Enforce authorization
     private boolean authorizationEnabled = false;
-    
+
     /***** --- TLS --- ****/
     // Enable TLS
     private boolean tlsEnabled = false;
@@ -62,7 +66,7 @@ public class ServiceConfig implements PulsarConfiguration{
     private String tlsCertificateFilePath;
     // Path for the TLS private key file
     private String tlsKeyFilePath;
-    
+
     private Properties properties = new Properties();
 
     public String getZookeeperServers() {
@@ -81,6 +85,14 @@ public class ServiceConfig implements PulsarConfiguration{
         this.globalZookeeperServers = globalZookeeperServers;
     }
 
+    public int getZookeeperSessionTimeoutMs() {
+        return zookeeperSessionTimeoutMs;
+    }
+
+    public void setZookeeperSessionTimeoutMs(int zookeeperSessionTimeoutMs) {
+        this.zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMs;
+    }
+
     public int getServicePort() {
         return servicePort;
     }
@@ -96,7 +108,7 @@ public class ServiceConfig implements PulsarConfiguration{
     public void setServicePortTls(int servicePortTls) {
         this.servicePortTls = servicePortTls;
     }
-    
+
     public int getWebServicePort() {
         return webServicePort;
     }

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceServlet.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceServlet.java
@@ -58,6 +58,11 @@ public class DiscoveryServiceServlet extends HttpServlet {
         log.info("Initializing DiscoveryServiceServlet resource");
 
         String zookeeperServers = config.getInitParameter("zookeeperServers");
+        String zookeeperSessionTimeoutMsStr = config.getInitParameter("zookeeperSessionTimeoutMs");
+        int zookeeperSessionTimeoutMs = zookeeperSessionTimeoutMsStr != null
+                ? Integer.valueOf(zookeeperSessionTimeoutMsStr)
+                : 30_000;
+
         String zookeeperClientFactoryClassName = config.getInitParameter("zookeeperClientFactoryClass");
         if (zookeeperClientFactoryClassName == null) {
             zookeeperClientFactoryClassName = ZookeeperClientFactoryImpl.class.getName();
@@ -70,7 +75,7 @@ public class DiscoveryServiceServlet extends HttpServlet {
             ZooKeeperClientFactory zkClientFactory = (ZooKeeperClientFactory) Class
                     .forName(zookeeperClientFactoryClassName).newInstance();
 
-            zkCache = new ZookeeperCacheLoader(zkClientFactory, zookeeperServers);
+            zkCache = new ZookeeperCacheLoader(zkClientFactory, zookeeperServers, zookeeperSessionTimeoutMs);
         } catch (Throwable t) {
             throw new ServletException(t);
         }

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/ZookeeperCacheLoader.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/ZookeeperCacheLoader.java
@@ -51,17 +51,16 @@ public class ZookeeperCacheLoader implements Closeable {
 
     public static final String LOADBALANCE_BROKERS_ROOT = "/loadbalance/brokers";
 
-    private static final int zooKeeperSessionTimeoutMillis = 30_000;
-
     /**
      * Initialize ZooKeeper session and creates broker cache list
      *
      * @param zookeeperServers
      * @throws Exception
      */
-    public ZookeeperCacheLoader(ZooKeeperClientFactory zkClientFactory, String zookeeperServers) throws Exception {
+    public ZookeeperCacheLoader(ZooKeeperClientFactory zkClientFactory, String zookeeperServers,
+            int zookeeperSessionTimeoutMs) throws Exception {
         localZkConnectionSvc = new LocalZooKeeperConnectionService(zkClientFactory, zookeeperServers,
-                zooKeeperSessionTimeoutMillis);
+                zookeeperSessionTimeoutMs);
         localZkConnectionSvc.start(exitCode -> {
             log.error("Shutting down ZK sessions: {}", exitCode);
         });

--- a/pulsar-discovery-service/src/test/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
+++ b/pulsar-discovery-service/src/test/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
@@ -118,7 +118,7 @@ public class DiscoveryServiceWebTest extends BaseZKStarterTest{
         Field zkCacheField = DiscoveryServiceServlet.class.getDeclaredField("zkCache");
         zkCacheField.setAccessible(true);
         ZookeeperCacheLoader zkCache = new ZookeeperCacheLoader(new DiscoveryZooKeeperClientFactoryImpl(),
-                "zk-test-servers");
+                "zk-test-servers", 30_000);
         zkCacheField.set(discovery, zkCache);
 
         // 3. verify nextBroker functionality : round-robin in broker list

--- a/pulsar-discovery-service/src/test/java/com/yahoo/pulsar/discovery/service/web/ZookeeperCacheLoaderTest.java
+++ b/pulsar-discovery-service/src/test/java/com/yahoo/pulsar/discovery/service/web/ZookeeperCacheLoaderTest.java
@@ -56,7 +56,7 @@ public class ZookeeperCacheLoaderTest extends BaseZKStarterTest {
 
         DiscoveryZooKeeperClientFactoryImpl.zk = mockZookKeeper;
 
-        ZookeeperCacheLoader zkLoader = new ZookeeperCacheLoader(new DiscoveryZooKeeperClientFactoryImpl(), "");
+        ZookeeperCacheLoader zkLoader = new ZookeeperCacheLoader(new DiscoveryZooKeeperClientFactoryImpl(), "", 30_000);
 
         List<String> brokers = Lists.newArrayList("broker-1:15000", "broker-2:15000", "broker-3:15000");
         // 1. create znode for each broker


### PR DESCRIPTION
### Motivation

Discovery service component is failing to start up since it's wrongly expecting to find some z-nodes in global zk session.

### Modifications

Reuse the same `GlobalZookeeperCache` class used in broker to access the policies.
