### PR TITLE
Discovery service should use HTTP temporary redirect (307)

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
@@ -96,10 +96,12 @@ public class DiscoveryServiceWebTest extends ProducerConsumerBase {
          * verify : every time when vip receives a request: it redirects to above brokers sequentially and broker
          * returns appropriate response which must not be null.
          **/
-        assertEquals("Cannot get the replication clusters for a non-global namespace", hitBrokerService(HttpMethod.POST, postRequestUrl, Lists.newArrayList("use")));
-        assertEquals("Property does not exist", hitBrokerService(HttpMethod.PUT, putRequestUrl, new BundlesData(1)));
-        assertEquals("Property does not exist", hitBrokerService(HttpMethod.GET, getRequestUrl, null));
-        
+
+        assertEquals(hitBrokerService(HttpMethod.POST, postRequestUrl, Lists.newArrayList("use")),
+                "Cannot set replication on a non-global namespace");
+        assertEquals(hitBrokerService(HttpMethod.PUT, putRequestUrl, new BundlesData(1)), "Property does not exist");
+        assertEquals(hitBrokerService(HttpMethod.GET, getRequestUrl, null), "Property does not exist");
+
         server.stop();
 
     }
@@ -128,15 +130,15 @@ public class DiscoveryServiceWebTest extends ProducerConsumerBase {
         String serviceResponse = jsonObject.get("reason").getAsString();
         return serviceResponse;
     }
-    
+
     static class DiscoveryZooKeeperClientFactoryImpl implements ZooKeeperClientFactory {
-    	static ZooKeeper zk;
-    	
-		@Override
-		public CompletableFuture<ZooKeeper> create(String serverList, SessionType sessionType,
-				int zkSessionTimeoutMillis) {
-    		return CompletableFuture.completedFuture(zk);
-		}
+        static ZooKeeper zk;
+
+        @Override
+        public CompletableFuture<ZooKeeper> create(String serverList, SessionType sessionType,
+                int zkSessionTimeoutMillis) {
+            return CompletableFuture.completedFuture(zk);
+        }
     }
 
 }

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceServlet.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/DiscoveryServiceServlet.java
@@ -134,7 +134,9 @@ public class DiscoveryServiceServlet extends HttpServlet {
             if (log.isDebugEnabled()) {
                 log.info("Redirecting to {}", location);
             }
-            response.sendRedirect(location.toString());
+
+            response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
+            response.setHeader("Location", location.toString());
         } catch (URISyntaxException e) {
             log.warn("No broker found in zookeeper {}", e.getMessage(), e);
             throw new RestException(Status.SERVICE_UNAVAILABLE, "Broker is not available");


### PR DESCRIPTION
### Motivation

HTTP redirections in discovery service component need to be done with 307 code instead of 302, as the broker is already doing.

When redirecting with 302, the HTTP method gets converted into a GET in the subsequent requests, when originally it might have been a POST or a PUT request.
