### PR TITLE
Update README to set correct config path to start pulsar-standalone

### DIFF
--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -58,7 +58,7 @@ Tests:
 
 ```
  1. Start the standalone pulsar
-    export PULSAR_STANDALONE_CONF=tests/standalone.conf
+    export PULSAR_STANDALONE_CONF=$(pwd)/tests/standalone.conf
     ../bin/pulsar standalone
 
  2. Run tests


### PR DESCRIPTION
### Motivation

with current instruction in README, it gives following exception while starting pulsar-standalone instance. 
```Exception in thread "main" java.io.FileNotFoundException: tests/standalone.conf (No such file or directory)```

It requires to set correct path of the standalone.conf file to start pulsar instance.