### PR TITLE
Using TLSv1 since boost1_41 supports TLS v1.0

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Auth.h
+++ b/pulsar-client-cpp/include/pulsar/Auth.h
@@ -19,7 +19,7 @@
 
 #include <vector>
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <boost/shared_ptr.hpp>
 #include <pulsar/Result.h>
 
@@ -27,7 +27,7 @@
 
 namespace pulsar {
     
-    typedef std::unordered_map<std::string, std::string> ParamMap;
+    typedef std::map<std::string, std::string> ParamMap;
     
     class AuthenticationDataProvider {
     public:

--- a/pulsar-client-cpp/lib/Auth.cc
+++ b/pulsar-client-cpp/lib/Auth.cc
@@ -137,9 +137,9 @@ namespace pulsar {
         if(!authParamsString.empty()) {
             std::vector<std::string> params;
             boost::algorithm::split(params, authParamsString, boost::is_any_of(","));
-            for(auto& p: params) {
-                std::vector<std::string> kv;
-                boost::algorithm::split(kv, p, boost::is_any_of(":"));
+            for(int i = 0; i<params.size(); i++) {
+		std::vector<std::string> kv;
+                boost::algorithm::split(kv, params[i], boost::is_any_of(":"));
                 if (kv.size() == 2) {
                     paramMap[kv[0]] = kv[1];
                 }

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -114,8 +114,11 @@ isTlsAllowInsecureConnection_(false) {
     if (clientConfiguration.isUseTls()) {
         using namespace boost::filesystem;
 
+#if BOOST_VERSION >= 105400
+        boost::asio::ssl::context ctx(executor_->io_service_, boost::asio::ssl::context::tlsv12_client);
+#else
         boost::asio::ssl::context ctx(executor_->io_service_, boost::asio::ssl::context::tlsv1_client);
-
+#endif
         if (clientConfiguration.isTlsAllowInsecureConnection()) {
             ctx.set_verify_mode(boost::asio::ssl::context::verify_none);
             isTlsAllowInsecureConnection_ = true;

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -114,13 +114,13 @@ isTlsAllowInsecureConnection_(false) {
     if (clientConfiguration.isUseTls()) {
         using namespace boost::filesystem;
 
-        boost::asio::ssl::context ctx(boost::asio::ssl::context::tlsv12_client);
+        boost::asio::ssl::context ctx(executor_->io_service_, boost::asio::ssl::context::tlsv1_client);
 
         if (clientConfiguration.isTlsAllowInsecureConnection()) {
-            ctx.set_verify_mode(boost::asio::ssl::verify_none);
+            ctx.set_verify_mode(boost::asio::ssl::context::verify_none);
             isTlsAllowInsecureConnection_ = true;
         } else {
-            ctx.set_verify_mode(boost::asio::ssl::verify_peer);
+            ctx.set_verify_mode(boost::asio::ssl::context::verify_peer);
             std::string trustCertFilePath = clientConfiguration.getTlsTrustCertsFilePath();
             if (exists(path(trustCertFilePath))) {
                 ctx.load_verify_file(trustCertFilePath);
@@ -227,14 +227,13 @@ void ClientConnection::handleTcpConnected(const boost::system::error_code& err,
 
         if (tlsSocket_) {
             if (!isTlsAllowInsecureConnection_) {
-            boost::system::error_code err;
-            Url service_url;
+                boost::system::error_code err;
+                Url service_url;
                 if (!Url::parse(address_, service_url)) {
                     LOG_ERROR(cnxString_ << "Invalid Url, unable to parse: " << err << " " << err.message());
                     close();
                     return;
                 }
-                tlsSocket_->set_verify_callback(boost::asio::ssl::rfc2818_verification(service_url.host()));
             }
             tlsSocket_->async_handshake(boost::asio::ssl::stream<tcp::socket>::client, boost::bind(&ClientConnection::handleHandshake, shared_from_this(), boost::asio::placeholders::error));
         } else {

--- a/pulsar-client-cpp/lib/ExecutorService.h
+++ b/pulsar-client-cpp/lib/ExecutorService.h
@@ -32,7 +32,7 @@ typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&
 typedef boost::shared_ptr<boost::asio::ip::tcp::resolver> TcpResolverPtr;
 typedef boost::shared_ptr<boost::asio::deadline_timer> DeadlineTimerPtr;
 class ExecutorService : private boost::noncopyable {
-
+ friend class ClientConnection;
  public:
     ExecutorService();
     ~ExecutorService();
@@ -43,7 +43,6 @@ class ExecutorService : private boost::noncopyable {
     DeadlineTimerPtr createDeadlineTimer();
     void postWork(boost::function<void(void)> task);
     void close();
-
  private:
 
     /*


### PR DESCRIPTION
### Motivation
TLS code in current master was incompatible with C++98 and boost 1.41
### Modifications

Removed C++11 features
Used TLSv1.0 from boost 1.41

### Result

the code can be compiled on an env with C++98 and boost1.41 