### PR TITLE
Fixed the C++ build to work in mac

### DIFF
--- a/pulsar-client-cpp/.gitignore
+++ b/pulsar-client-cpp/.gitignore
@@ -42,11 +42,12 @@
 /perf/PerfConsumer
 /system-test/SystemTest
 
-# Eclipse generated files
+# IDE generated files
 .cproject
 .project
 .settings/
 .pydevproject
+.idea/
 
 # doxygen files
 apidocs/

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -31,6 +31,8 @@ endif()
 find_library(LOG4CXX_LIBRARY_PATH log4cxx)
 find_library(CURL_LIBRARY_PATH curl)
 find_path(LOG4CXX_INCLUDE_PATH log4cxx/logger.h)
+find_path(GTEST_INCLUDE_PATH gtest/gtest.h)
+
 
 include_directories(
   ${CMAKE_SOURCE_DIR}
@@ -40,6 +42,7 @@ include_directories(
   ${ZLIB_INCLUDE_DIR}
   ${PROTOBUF_INCLUDE_DIR}
   ${LOG4CXX_INCLUDE_PATH}
+  ${GTEST_INCLUDE_PATH}
 )
 
 set(COMMON_LIBS

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -65,26 +65,27 @@ perf/perfConsumer
 
 #### Install all dependencies:
 ```shell
-## For openSSL
+# For openSSL
 brew install openssl
 
-## For Protobuf
+# For Protobuf
 brew tap homebrew/versions
 brew install protobuf260
 
-## For gtest
+# For gtest
 cd $HOME
 git clone https://github.com/google/googletest.git
 cd googletest
 cmake .
 make 
-# Refer gtest documentation in case you get stuck somewhere
+## Refer gtest documentation in case you get stuck somewhere
 export PATH=$HOME/googletest/build/googlemock/gtest/:$HOME/googletest/googletest/include/:$PATH
 ```
 
 #### Compile Pulsar client library:
 ```shell
-cd pulsar/pulsar-client-cpp/
+export $PULSAR_PATH=<Path where you cloned pulsar repo>
+cd ${PULSAR_PATH}/pulsar-client-cpp/
 cmake .
 make
 ```
@@ -92,25 +93,30 @@ make
 #### Check
 Client library will be placed in
 ```
-pulsar/pulsar-client-cpp/lib/libpulsar.dylib
-pulsar/pulsar-client-cpp/lib/libpulsar.a
+${PULSAR_PATH}/pulsar-client-cpp/lib/libpulsar.dylib
+${PULSAR_PATH}/pulsar-client-cpp/lib/libpulsar.a
 ```
 
-Tools will be placed in:
+#### Tools will be placed in:
 
 ```
-pulsar/pulsar-client-cpp/perf/perfProducer
-pulsar/pulsar-client-cpp/perf/perfConsumer
+${PULSAR_PATH}/pulsar-client-cpp/perf/perfProducer
+${PULSAR_PATH}/pulsar-client-cpp/perf/perfConsumer
 ```
 
 ## Tests
-Tests are placed in 
+### Tests are placed in 
 ```
 # Source code
-pulsar/pulsar-client-cpp/tests/
+${PULSAR_PATH}/pulsar-client-cpp/tests/
 
-# Executable
-pulsar/pulsar-client-cpp/tests/main
+# Execution
+## Start standalone broker
+export PULSAR_STANDALONE_CONF=${PULSAR_PATH}/pulsar-client-cpp/tests/standalone.conf
+${PULSAR_PATH}/bin/pulsar standalone
+
+## Run the tests
+${PULSAR_PATH}/pulsar-client-cpp/tests/main
 ```
 
 ## Requirements for Contributors

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -106,7 +106,6 @@ ${PULSAR_PATH}/pulsar-client-cpp/perf/perfConsumer
 ```
 
 ## Tests
-### Tests are placed in 
 ```
 # Source code
 ${PULSAR_PATH}/pulsar-client-cpp/tests/

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -68,7 +68,8 @@ perf/perfConsumer
 ```shell
 # For openSSL
 brew install openssl
-export PATH=$PATH:/usr/local/opt/openssl/include/
+export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
+export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 
 # For Protobuf
 brew tap homebrew/versions

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -17,8 +17,8 @@ https://github.com/yahoo/pulsar/tree/master/pulsar-client-cpp/examples
 
 Pulsar C++ Client Library has been tested on:
 
-Linux
-Mac OS X
+* Linux
+* Mac OS X
 
 ## Compilation
 ### Compile on Ubuntu Server 16.04

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -48,13 +48,14 @@ cmake .
 make
 ```
 
-#### Client library will be placed in
+#### Checks
+##### Client library will be placed in
 ```
 lib/libpulsar.so
 lib/libpulsar.a
 ```
 
-#### Tools will be placed in
+##### Tools will be placed in
 
 ```
 perf/perfProducer
@@ -90,14 +91,14 @@ cmake .
 make
 ```
 
-#### Check
-Client library will be placed in
+#### Checks
+##### Client library will be placed in
 ```
 ${PULSAR_PATH}/pulsar-client-cpp/lib/libpulsar.dylib
 ${PULSAR_PATH}/pulsar-client-cpp/lib/libpulsar.a
 ```
 
-#### Tools will be placed in:
+##### Tools will be placed in:
 
 ```
 ${PULSAR_PATH}/pulsar-client-cpp/perf/perfProducer

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -1,29 +1,36 @@
 
-### Pulsar C++ client library
+# Pulsar C++ client library
 
 Examples for using the API to publish and consume messages can be found on
 https://github.com/yahoo/pulsar/tree/master/pulsar-client-cpp/examples
 
-#### Requirements
+## Requirements
 
  * CMake
- * Boost
+ * [Boost](http://www.boost.org/)
  * [Protocol Buffer 2.6](https://developers.google.com/protocol-buffers/)
  * [Log4CXX](https://logging.apache.org/log4cxx)
  * LibCurl
  * [GTest](https://github.com/google/googletest)
 
+## Platforms
 
-#### Compile on Ubuntu Server 16.04
+Pulsar C++ Client Library has been tested on:
 
-Install all dependencies:
+Linux
+Mac OS X
+
+## Compilation
+### Compile on Ubuntu Server 16.04
+
+#### Install all dependencies:
 
 ```shell
 apt-get install cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
                 libprotobuf-dev libboost-all-dev  libgtest-dev
 ```
 
-Compile and install Google Test:
+#### Compile and install Google Test:
 
 ```shell
 cd /usr/src/gtest
@@ -33,7 +40,7 @@ sudo cp *.a /usr/lib
 ```
 
 
-Compile Pulsar client library:
+#### Compile Pulsar client library:
 
 ```shell
 cd pulsar/pulsar-client-cpp
@@ -41,26 +48,70 @@ cmake .
 make
 ```
 
-Client library will be placed in
+#### Client library will be placed in
 ```
 lib/libpulsar.so
 lib/libpulsar.a
 ```
 
-Tools :
+#### Tools will be placed in
 
 ```
 perf/perfProducer
 perf/perfConsumer
 ```
 
-Tests:
+### Compile on Mac OS X
+
+#### Install all dependencies:
+```shell
+## For openSSL
+brew install openssl
+
+## For Protobuf
+brew tap homebrew/versions
+brew install protobuf260
+
+## For gtest
+cd $HOME
+git clone https://github.com/google/googletest.git
+cd googletest
+cmake .
+make 
+# Refer gtest documentation in case you get stuck somewhere
+export PATH=$HOME/googletest/build/googlemock/gtest/:$HOME/googletest/googletest/include/:$PATH
+```
+
+#### Compile Pulsar client library:
+```shell
+cd pulsar/pulsar-client-cpp/
+cmake .
+make
+```
+
+#### Check
+Client library will be placed in
+```
+pulsar/pulsar-client-cpp/lib/libpulsar.dylib
+pulsar/pulsar-client-cpp/lib/libpulsar.a
+```
+
+Tools will be placed in:
 
 ```
- 1. Start the standalone pulsar
-    export PULSAR_STANDALONE_CONF=$(pwd)/tests/standalone.conf
-    ../bin/pulsar standalone
-
- 2. Run tests
-    tests/main
+pulsar/pulsar-client-cpp/perf/perfProducer
+pulsar/pulsar-client-cpp/perf/perfConsumer
 ```
+
+## Tests
+Tests are placed in 
+```
+# Source code
+pulsar/pulsar-client-cpp/tests/
+
+# Executable
+pulsar/pulsar-client-cpp/tests/main
+```
+
+## Requirements for Contributors
+We welcome contributions from the open source community, kindly make sure your changes are backward compatible with gcc-4.4.7 and Boost 1.41.

--- a/pulsar-client-cpp/README.md
+++ b/pulsar-client-cpp/README.md
@@ -68,19 +68,21 @@ perf/perfConsumer
 ```shell
 # For openSSL
 brew install openssl
+export PATH=$PATH:/usr/local/opt/openssl/include/
 
 # For Protobuf
 brew tap homebrew/versions
 brew install protobuf260
+brew install boost
+brew install log4cxx
 
 # For gtest
 cd $HOME
 git clone https://github.com/google/googletest.git
 cd googletest
 cmake .
-make 
+make install
 ## Refer gtest documentation in case you get stuck somewhere
-export PATH=$HOME/googletest/build/googlemock/gtest/:$HOME/googletest/googletest/include/:$PATH
 ```
 
 #### Compile Pulsar client library:

--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -16,7 +16,8 @@
 
 file(GLOB PULSAR_SOURCES *.cc lz4/*.c checksum/*.cc)
 
-execute_process(COMMAND /bin/cat ../pom.xml COMMAND /bin/grep -Po "<?<version>[^<]+" COMMAND /bin/sed "s/.*>//g"  COMMAND /usr/bin/head -1 COMMAND /usr/bin/tr -d '\\\n' OUTPUT_VARIABLE PV)
+execute_process(COMMAND cat ../pom.xml COMMAND xmllint --format - COMMAND sed "s/xmlns=\".*\"//g" COMMAND xmllint --stream --pattern /project/version --debug - COMMAND grep -A 2 "matches pattern" COMMAND grep text COMMAND sed "s/.* [0-9] //g" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PV)
+
 set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -msse4.2 -mpclmul -D_PULSAR_VERSION_=\\\"${PV}\\\"")
 
 add_library(pulsarStatic STATIC ${PULSAR_SOURCES})


### PR DESCRIPTION
### Motivation

C++ Build won't compile on Mac, https://github.com/yahoo/pulsar/issues/198

### Modifications

- Explicitly specified GTEST_INCLUDE_PATH
- Fixed the commands used to get version details

### Result

Am able to build the c++ client on my mac
