### PR TITLE
Fix #199: Do not stop to replicate when producer throws exception

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
@@ -169,7 +169,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     @Test
     public void testConcurrentReplicator() throws Exception {
 
-        log.info("--- Starting ReplicatorTest::testConfigChange ---");
+        log.info("--- Starting ReplicatorTest::testConcurrentReplicator ---");
 
         final DestinationName dest = DestinationName.get(String.format("persistent://pulsar/global/ns1/topic-%d", 0));
         ClientConfiguration conf = new ClientConfiguration();
@@ -344,7 +344,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     @Test(enabled = false)
     public void testReplicationOverrides() throws Exception {
 
-        log.info("--- Starting ReplicatorTest::testReplication ---");
+        log.info("--- Starting ReplicatorTest::testReplicationOverrides ---");
 
         // This test is to verify that the config change on global namespace is successfully applied in broker during
         // runtime.

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
@@ -652,7 +652,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         });
     }
 
-    @Test
+    @Test(priority = 5)
     public void testReplicatorProducerClosing() throws Exception {
         log.info("--- Starting ReplicatorTest::testDeleteReplicatorFailure ---");
         final String topicName = "persistent://pulsar/global/ns/repltopicbatch";

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTestBase.java
@@ -77,6 +77,8 @@ public class ReplicatorTestBase {
 
     ExecutorService executor = new ThreadPoolExecutor(5, 20, 30, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
 
+    static final int TIME_TO_CHECK_BACKLOG_QUOTA = 5;
+
     // Default frequency
     public int getBrokerServicePurgeInactiveFrequency() {
         return 60;
@@ -111,6 +113,7 @@ public class ReplicatorTestBase {
         config1.setBrokerServicePurgeInactiveFrequencyInSeconds(
                 inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
         config1.setBrokerServicePort(PortManager.nextFreePort());
+        config1.setBacklogQuotaCheckIntervalInSeconds(TIME_TO_CHECK_BACKLOG_QUOTA);
         pulsar1 = new PulsarService(config1);
         pulsar1.start();
         ns1 = pulsar1.getBrokerService();
@@ -135,6 +138,7 @@ public class ReplicatorTestBase {
         config2.setBrokerServicePurgeInactiveFrequencyInSeconds(
                 inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
         config2.setBrokerServicePort(PortManager.nextFreePort());
+        config2.setBacklogQuotaCheckIntervalInSeconds(TIME_TO_CHECK_BACKLOG_QUOTA);
         pulsar2 = new PulsarService(config2);
         pulsar2.start();
         ns2 = pulsar2.getBrokerService();


### PR DESCRIPTION
### Motivation

This closes #199 

### Modifications

When the replication producer catches an exception,
rewind cursor and continue readMoreEntries (if possible) rather than return immediately.

An unit test for simulating #199 is also added. 

### Result

Replicator will continue to replicate even when producer exception.