### PR TITLE
Derive direct memory used count from netty counter

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
@@ -68,7 +68,6 @@ public class BookieClientsStatsGeneratorTest extends BrokerTestBase {
         );
         int allocateMemory = 17777216;
         long directMemory1 = JvmMetrics.getJvmDirectMemoryUsed();
-        assertEquals(directMemory1, 0);
         ByteBuf buf2 = allocator.directBuffer(allocateMemory, allocateMemory);
         long directMemory2 = JvmMetrics.getJvmDirectMemoryUsed();
         assertEquals(directMemory2, directMemory1 + allocateMemory);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
@@ -26,6 +26,10 @@ import org.testng.annotations.Test;
 
 import com.yahoo.pulsar.broker.service.BrokerTestBase;
 import com.yahoo.pulsar.broker.stats.BookieClientStatsGenerator;
+import com.yahoo.pulsar.broker.stats.metrics.JvmMetrics;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 
 /**
  */
@@ -48,5 +52,35 @@ public class BookieClientsStatsGeneratorTest extends BrokerTestBase {
         // should not generate any NPE or other exceptions..
         Map<String, Map<String, PendingBookieOpsStats>> stats = BookieClientStatsGenerator.generate(super.getPulsar());
         assertEquals((boolean) stats.isEmpty(), true);
+    }
+    
+    @Test
+    public void testJvmDirectMemoryUsedMetric() throws Exception {
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator( //
+                true, // preferDirect
+                0, // nHeapArenas,
+                1, // nDirectArena
+                8192, // pageSize
+                11, // maxOrder
+                64, // tinyCacheSize
+                32, // smallCacheSize
+                8 // normalCacheSize
+        );
+        int allocateMemory = 17777216;
+        long directMemory1 = JvmMetrics.getJvmDirectMemoryUsed();
+        assertEquals(directMemory1, 0);
+        ByteBuf buf2 = allocator.directBuffer(allocateMemory, allocateMemory);
+        long directMemory2 = JvmMetrics.getJvmDirectMemoryUsed();
+        assertEquals(directMemory2, directMemory1 + allocateMemory);
+        ByteBuf buf3 = allocator.directBuffer(allocateMemory, allocateMemory);
+        long directMemory3 = JvmMetrics.getJvmDirectMemoryUsed();
+        assertEquals(directMemory3, directMemory2 + allocateMemory);
+        buf3.release();
+        directMemory3 = JvmMetrics.getJvmDirectMemoryUsed();
+        assertEquals(directMemory3, directMemory2);
+        buf2.release();
+        directMemory2 = JvmMetrics.getJvmDirectMemoryUsed();
+        assertEquals(directMemory2, directMemory1);
+        
     }
 }


### PR DESCRIPTION
### Motivation

As mentioned at #222 : `JvmMetrics` doesn't return correct jvm_direct_memory_used

### Modifications

Get the directMemoryUsed count from Netty-`PlatformDependent` counter.

### Result

`JvmMetrics` provides correct directMemoryUsed metric.
