### PR TITLE
Add lookup throttling in cpp-client

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -100,6 +100,20 @@ class ClientConfiguration {
     int getMessageListenerThreads() const;
 
     /**
+     * Number of concurrent lookup-requests allowed on each broker-connection to prevent overload on broker.
+     * <i>(default: 5000)</i> It should be configured with higher value only in case of it requires to produce/subscribe on
+     * thousands of topic using created {@link PulsarClient}
+     *
+     * @param concurrentLookupRequest
+     */
+    ClientConfiguration& setConcurrentLookupRequest(int concurrentLookupRequest);
+
+    /**
+     * @return Get configured total allowed concurrent lookup-request.
+     */
+    int getConcurrentLookupRequest() const;
+
+    /**
      * Initialize the log configuration
      *
      * @param logConfFilePath  path of the configuration file

--- a/pulsar-client-cpp/include/pulsar/Result.h
+++ b/pulsar-client-cpp/include/pulsar/Result.h
@@ -54,6 +54,7 @@ enum Result {
 
     ResultConsumerNotInitialized,  /// Consumer is not initialized
     ResultProducerNotInitialized,  /// Producer is not initialized
+    ResultTooManyLookupRequestException, /// Too Many concurrent LookupRequest
 
     ResultInvalidTopicName,         /// Invalid topic name
     ResultInvalidUrl,  /// Client Initialized with Invalid Broker Url (VIP Url passed to Client Constructor)

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.cc
@@ -125,15 +125,15 @@ namespace pulsar {
             LookupDataResultPromisePtr promise) {
         if (data) {
             if(data->isRedirect()) {
-                LOG_DEBUG("Lookup request is for " << destinationName << " redirected to " << data->getBrokerUrl());
+                LOG_DEBUG("PartitionMetadataLookup request is for " << destinationName << " redirected to " << data->getBrokerUrl());
                 Future<Result, ClientConnectionWeakPtr> future = cnxPool_.getConnectionAsync(data->getBrokerUrl());
                 future.addListener(boost::bind(&BinaryProtoLookupService::sendPartitionMetadataLookupRequest, this, destinationName, _1, _2, promise));
             } else {
-                LOG_DEBUG("Lookup response for " << destinationName << ", lookup-broker-url " << data->getBrokerUrl());
+                LOG_DEBUG("PartitionMetadataLookup response for " << destinationName << ", lookup-broker-url " << data->getBrokerUrl());
                 promise->setValue(data);
             }
         } else {
-            LOG_DEBUG("Lookup failed for " << destinationName << ", result " << result);
+            LOG_DEBUG("PartitionMetadataLookup failed for " << destinationName << ", result " << result);
             promise->setFailed(result);
         }
     }

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -35,6 +35,7 @@ struct ClientConfiguration::Impl {
     int ioThreads;
     int operationTimeoutSeconds;
     int messageListenerThreads;
+    int concurrentLookupRequest;
     std::string logConfFilePath;
     bool useTls;
     std::string tlsTrustCertsFilePath;
@@ -43,6 +44,7 @@ struct ClientConfiguration::Impl {
              ioThreads(1),
              operationTimeoutSeconds(30),
              messageListenerThreads(1),
+             concurrentLookupRequest(5000),
              logConfFilePath() {}
 };
 
@@ -129,6 +131,15 @@ bool ClientConfiguration::isTlsAllowInsecureConnection() const {
     return impl_->tlsAllowInsecureConnection;
 }
     
+ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int concurrentLookupRequest) {
+    impl_->concurrentLookupRequest = concurrentLookupRequest;
+    return *this;
+}
+
+int ClientConfiguration::getConcurrentLookupRequest() const {
+    return impl_->concurrentLookupRequest;
+}
+
 ClientConfiguration& ClientConfiguration::setLogConfFilePath(const std::string& logConfFilePath) {
     impl_->logConfFilePath = logConfFilePath;
     return *this;

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -267,6 +267,9 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     bool havePendingPingRequest_;
     DeadlineTimerPtr keepAliveTimer_;
 
+    uint32_t maxPendingLookupRequest_;
+    uint32_t numOfPendingLookupRequest_;
+
     friend class PulsarFriend;
 
     bool isTlsAllowInsecureConnection_;

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -170,6 +170,21 @@ void resendMessage(Result r, const Message& msg, Producer &producer) {
     ASSERT_EQ(ResultOk, client.close());
 }
 
+TEST(BasicEndToEndTest, testLookupThrottling) {
+    ClientConfiguration config;
+    config.setConcurrentLookupRequest(0);
+    Client client(lookupUrl, config);
+
+    Producer producer;
+    Result result = client.createProducer("persistent://prop/unit/ns1/my-topic-1", producer);
+    ASSERT_EQ(ResultTooManyLookupRequestException, result);
+
+    Consumer consumer1;
+    result = client.subscribe("persistent://prop/unit/ns1/my-topic-1", "my-sub-name", consumer1);
+    ASSERT_EQ(ResultTooManyLookupRequestException, result);
+
+}
+
     TEST(BasicEndToEndTest, testNonExistingTopic)
 {
     Client client(lookupUrl);


### PR DESCRIPTION
### Motivation

Sometimes, It is useful to throttle at client in order to avoid large number of concurrent lookup-requests going to broker while creating producers/consumers.

### Modifications

Add client side lookup throttling while creating producer and consumer.

### Result

Client can have capability to restrict number of concurrent lookup request to broker in order to throttle while creating producer/consumer.