### PR TITLE
Avoid triggering startReplProducer on newAddProducer as it may flips replicator state wrongly

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -193,7 +193,7 @@ public class PersistentReplicator implements ReadEntriesCallback, DeleteCallback
                         // BackOff before retrying
                         brokerService.executor().schedule(this::startProducer, waitTimeMs, TimeUnit.MILLISECONDS);
                     } else {
-                        log.warn("[{}][{} -> {}] Failed to create remote producer. Replicator state: ", topicName,
+                        log.warn("[{}][{} -> {}] Failed to create remote producer. Replicator state: {}", topicName,
                                 localCluster, remoteCluster, STATE_UPDATER.get(this), ex);
                     }
                     return null;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -617,7 +617,7 @@ public class PersistentReplicator implements ReadEntriesCallback, DeleteCallback
             return closeProducerAsync();
         } else {
             // If there's already a reconnection happening, signal to close it whenever it's ready
-            STATE_UPDATER.set(this, State.Stopped);
+            STATE_UPDATER.set(this, State.Stopping);
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -237,9 +237,6 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(), USAGE_COUNT_UPDATER.get(this));
             }
-
-            // Start replication producers if not already
-            startReplProducers();
         } finally {
             lock.readLock().unlock();
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -237,6 +237,9 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(), USAGE_COUNT_UPDATER.get(this));
             }
+
+            // Start replication producers if not already
+            startReplProducers();
         } finally {
             lock.readLock().unlock();
         }


### PR DESCRIPTION
### Motivation

On Race condition when `replicationCluster` in namespace-policy gets changed multiple times subsequently (repl-cluster added then removed) : replication producer couldn't close successfully.

1. New repl-cluster added: Adds [Replicator](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java#L657) in `replicators` and it tries to create `Producer` async.
2. Before `Producer` created repl-cluster deleted:  It closes the [cursor](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java#L680) and flips [replicator](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java#L620)'s `state=stopped`  as `Producer` is not created yet and when producer will be created it will be closed if state is [stopped](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java#L180)
3. However, in between if any other producer gets created then it tries to [start replicators again](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java#L242) which flips replicator's state to `starting` and when producer will be created in step-2 it gets following exception:
` Error reading entries at null. Retrying to read in 67.938s. (Cursor was already closed) (7)`

### Modifications

Broker should not try to startReplicator again on newProducer-creation as it flips the state of replicator.

### Result

It will avoid flipping up replicator's state wrongly and replicator's producer can be closed on replicator removal.
