### PR TITLE
Include timezone in datetime printed in stats

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -105,7 +105,7 @@ import io.swagger.annotations.ApiResponses;
 public class PersistentTopics extends AdminResource {
     private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
 
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 
     private static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
     private static final int PARTITIONED_TOPIC_WAIT_SYNC_TIME_MS = 1000;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -124,7 +124,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     
     private static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
 
-    public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+    public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 
     // Timestamp of when this topic was last seen active
     private volatile long lastActive;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
@@ -1103,7 +1103,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         return pendingMessages.size();
     }
 
-    private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+    private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ")
             .withZone(ZoneId.systemDefault());
 
     private PulsarApi.CompressionType convertCompressionType(CompressionType compressionType) {

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -195,7 +195,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         return parts.get(8);
     }
 
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerHandler.class);
 


### PR DESCRIPTION
### Motivation

The date time fields exposed in stats are being formatted without a timezone. Typically we consider that date to be in UTC, but it really depends on the system settings.

### Modifications

Format the dates with the TZ info (eg: +0000 when using UTC and -0800 for PST)

### Result

Remove ambiguity on the date so that humans and tools can better parse the date.
