### PR TITLE
Resolve compatibility with previous version of C++ client

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Auth.h
+++ b/pulsar-client-cpp/include/pulsar/Auth.h
@@ -26,9 +26,28 @@
 #pragma GCC visibility push(default)
 
 namespace pulsar {
-    
-    typedef std::map<std::string, std::string> ParamMap;
-    
+
+#ifdef PULSAR_ENABLE_DEPRECATED_METHOD
+    // This is deprecated.
+    enum AuthType {
+        AuthNone,
+        AuthYcaV1
+    };
+    // This is deprecated.
+    class AuthData {
+       public:
+          virtual ~AuthData();
+
+          virtual AuthType getType() const = 0;
+
+          virtual Result getAuthData(std::string& authDataContent) const = 0;
+
+       protected:
+          AuthData();
+    };
+    typedef boost::shared_ptr<AuthData> AuthDataPtr;
+#endif
+
     class AuthenticationDataProvider {
     public:
         virtual ~AuthenticationDataProvider();
@@ -43,33 +62,51 @@ namespace pulsar {
     protected:
         AuthenticationDataProvider();
     };
-    
+
     typedef boost::shared_ptr<AuthenticationDataProvider> AuthenticationDataPtr;
-    
+
     class Authentication {
     public:
         virtual ~Authentication();
         virtual const std::string getAuthMethodName() const = 0;
-        virtual Result getAuthData(AuthenticationDataPtr& authDataContent) const = 0;
-        
+        virtual Result getAuthData(AuthenticationDataPtr& authDataContent) const {
+            authDataContent = authData_;
+            return ResultOk;
+        }
+#ifdef PULSAR_ENABLE_DEPRECATED_METHOD
+        // This is deprecated.
+        virtual Result getAuthData(std::string& authDataContent) const {
+            return ResultOk;
+        }
+#endif
     protected:
         Authentication();
+        AuthenticationDataPtr authData_;
     };
-    
+
     typedef boost::shared_ptr<Authentication> AuthenticationPtr;
-    
+    typedef std::map<std::string, std::string> ParamMap;
+
     class Auth {
     public:
+#ifdef PULSAR_ENABLE_DEPRECATED_METHOD
+        // This is deprecated.
+        static AuthDataPtr Disabled();
+        // This is deprecated.
+        static AuthDataPtr YcaV1(const std::string& ycaAppId);
+#else
         static AuthenticationPtr Disabled();
+#endif
         static AuthenticationPtr create(const std::string& dynamicLibPath);
         static AuthenticationPtr create(const std::string& dynamicLibPath, const std::string& authParamsString);
         static AuthenticationPtr create(const std::string& dynamicLibPath, ParamMap& params);
+
     protected:
         static bool isShutdownHookRegistered_;
         static std::vector<void *> loadedLibrariesHandles_;
         static void release_handles();
     };
-    
+
 }
 // namespace pulsar
 

--- a/pulsar-client-cpp/lib/Auth.cc
+++ b/pulsar-client-cpp/lib/Auth.cc
@@ -31,98 +31,91 @@
 DECLARE_LOG_OBJECT()
 
 namespace pulsar {
-    
+
     AuthenticationDataProvider::AuthenticationDataProvider(){
-        
+
     }
-    
+
     AuthenticationDataProvider::~AuthenticationDataProvider() {
-        
+
     }
-    
+
     bool AuthenticationDataProvider::hasDataForTls() {
         return false;
     }
-    
+
     std::string AuthenticationDataProvider::getTlsCertificates() {
         return "none";
     }
-    
+
     std::string AuthenticationDataProvider::getTlsPrivateKey() {
         return "none";
     }
-    
+
     bool AuthenticationDataProvider::hasDataForHttp() {
         return false;
     }
-    
+
     std::string AuthenticationDataProvider::getHttpAuthType() {
         return "none";
     }
-    
+
     std::string AuthenticationDataProvider::getHttpHeaders() {
         return "none";
     }
-    
+
     bool AuthenticationDataProvider::hasDataFromCommand(){
         return false;
     }
-    
+
     std::string AuthenticationDataProvider::getCommandData() {
         return "none";
     }
-    
-    
+
+
     Authentication::Authentication() {
     }
-    
+
     Authentication::~Authentication() {
     }
-    
+
     class AuthDisabledData : public AuthenticationDataProvider {
     public:
         AuthDisabledData(ParamMap& params){
         }
     };
-    
+
     class AuthDisabled : public Authentication {
     public:
         AuthDisabled(AuthenticationDataPtr& authData) {
             authData_ = authData;
         }
-        
+
         static AuthenticationPtr create(ParamMap& params) {
             AuthenticationDataPtr authData = AuthenticationDataPtr(new AuthDisabledData(params));
             return AuthenticationPtr(new AuthDisabled(authData));
         }
-        
+
         const std::string getAuthMethodName() const {
             return "none";
         }
-        
-        Result getAuthData(AuthenticationDataPtr& authDataContent) const {
-            authDataContent = authData_;
-            return ResultOk;
-        }
-    private:
-        AuthenticationDataPtr authData_;
     };
-    
-    
+
+
     AuthenticationPtr Auth::Disabled() {
         ParamMap params;
         return AuthDisabled::create(params);
     }
-    
+
     AuthenticationPtr Auth::create(const std::string& dynamicLibPath) {
         ParamMap params;
         return Auth::create(dynamicLibPath, params);
     }
-    
+
     boost::mutex mutex;
     std::vector<void*> Auth::loadedLibrariesHandles_;
     bool Auth::isShutdownHookRegistered_ = false;
-    
+
     void Auth::release_handles() {
         boost::lock_guard<boost::mutex> lock(mutex);
         for (std::vector<void*>::iterator ite = Auth::loadedLibrariesHandles_.begin(); ite != Auth::loadedLibrariesHandles_.end();
@@ -131,7 +124,7 @@ namespace pulsar {
         }
         loadedLibrariesHandles_.clear();
     }
-    
+
     AuthenticationPtr Auth::create(const std::string& dynamicLibPath, const std::string& authParamsString) {
         ParamMap paramMap;
         if(!authParamsString.empty()) {
@@ -147,7 +140,7 @@ namespace pulsar {
         }
         return Auth::create(dynamicLibPath, paramMap);
     }
-    
+
     AuthenticationPtr Auth::create(const std::string& dynamicLibPath, ParamMap& params) {
         {
             boost::lock_guard<boost::mutex> lock(mutex);
@@ -169,5 +162,5 @@ namespace pulsar {
         }
         return boost::shared_ptr<Authentication>(auth);
     }
-    
+
 }

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -130,7 +130,7 @@ ClientConfiguration& ClientConfiguration::setTlsAllowInsecureConnection(bool all
 bool ClientConfiguration::isTlsAllowInsecureConnection() const {
     return impl_->tlsAllowInsecureConnection;
 }
-    
+
 ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int concurrentLookupRequest) {
     impl_->concurrentLookupRequest = concurrentLookupRequest;
     return *this;


### PR DESCRIPTION
### Motivation

The  compatibility with previous versions was lost due to past versions .

### Modifications

I readded some classes and methods for compatibility  with previous versions.

### Result

Previous versions clients can be compiled with latest version's header.