### PR TITLE
Travis Build - install xmllint and enforce backward compatibility with gcc4.4

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -21,6 +21,8 @@ set(Boost_NO_BOOST_CMAKE ON)
 
 set (CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
 
+execute_process(COMMAND gcc -dumpversion OUTPUT_VARIABLE GCC_DUMP_VERSION)
+
 find_package(Boost REQUIRED COMPONENTS program_options filesystem regex thread system)
 find_package(OpenSSL REQUIRED)
 find_package(ZLIB REQUIRED)
@@ -61,6 +63,8 @@ set(CLIENT_LIBS
   ${COMMON_LIBS}
   pulsar
 )
+
+message( STATUS "GCC_DUMP_VERSION: " ${GCC_DUMP_VERSION} )
 
 add_subdirectory(lib)
 add_subdirectory(perf)

--- a/pulsar-client-cpp/travis-build.sh
+++ b/pulsar-client-cpp/travis-build.sh
@@ -54,7 +54,8 @@ exec_cmd() {
 
 if [ "$3" = "all" -o "$3" = "dep" ]; then
   # Install dependant packages
-  exec_cmd "apt-get install -y cmake libssl-dev libcurl4-openssl-dev liblog4cxx10-dev libprotobuf-dev libboost1.55-all-dev libgtest-dev";
+  exec_cmd "apt-get update && apt-get install -y cmake gcc-4.4 cpp-4.4 gcc-4.4-base libssl-dev libcurl4-openssl-dev liblog4cxx10-dev libprotobuf-dev libboost1.55-all-dev libgtest-dev libxml2-utils";
+  exec_cmd "unlink `which gcc` && ln -s `which gcc-4.4` `which gcc`"
   exec_cmd "pushd $1/ && wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz && popd";
   exec_cmd "pushd /usr/src/gtest && cmake . && make && cp *.a /usr/lib && popd";
   exec_cmd "pushd $1/ && tar xvfz $1/protobuf-2.6.1.tar.gz && pushd $1/protobuf-2.6.1 && ./configure && make && make install && popd && popd";


### PR DESCRIPTION
### Motivation

a. Fix C++ build - Need to install xmllint in, Travis default build env ( Ubuntu 14.04 ).
b. enforce backward compatibility with gcc4.4

### Modifications

Added a print message in CMakeList.txt
Added libxml2 and gcc4.4 to travis_build.sh

### Result

C++ compilation should succeed in master