### PR TITLE
Corrected test case ProxyAuthenticationTest and ProxyPublishConsumeWi…

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -44,7 +44,7 @@ import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
 public class ProxyAuthenticationTest extends ProducerConsumerBase {
     protected String methodName;
-    private static final int TEST_PORT = 6080;
+    private static final int TEST_PORT = PortManager.nextFreePort();
     private static final String CONSUME_URI = "ws://localhost:" + TEST_PORT
             + "/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
     private static final String PRODUCE_URI = "ws://localhost:" + TEST_PORT

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.spy;
 import java.net.URI;
 import java.util.concurrent.Future;
 
+import org.apache.bookkeeper.test.PortManager;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -39,9 +40,10 @@ import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
 public class ProxyPublishConsumeTest extends ProducerConsumerBase {
     protected String methodName;
-    private static final String CONSUME_URI = "ws://localhost:6080/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
-    private static final String PRODUCE_URI = "ws://localhost:6080/ws/producer/persistent/my-property/use/my-ns/my-topic/";
-    private static final int TEST_PORT = 6080;
+    private static final int TEST_PORT = PortManager.nextFreePort();
+    private static final String CONSUME_URI = "ws://localhost:" + TEST_PORT + "/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
+    private static final String PRODUCE_URI = "ws://localhost:" + TEST_PORT + "/ws/producer/persistent/my-property/use/my-ns/my-topic/";
+
     private ProxyServer proxyServer;
     private WebSocketService service;
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
@@ -29,6 +29,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
+import org.apache.bookkeeper.test.PortManager;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
@@ -50,12 +51,13 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 public class ProxyPublishConsumeTls extends ProducerConsumerBase {
     protected String methodName;
-    private static final String CONSUME_URI = "wss://localhost:6090/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
-    private static final String PRODUCE_URI = "wss://localhost:6090/ws/producer/persistent/my-property/use/my-ns/my-topic/";
+    private static final int TEST_PORT = PortManager.nextFreePort();
+    private static final int TLS_TEST_PORT = PortManager.nextFreePort();
+    private static final String CONSUME_URI = "wss://localhost:" + TLS_TEST_PORT + "/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
+    private static final String PRODUCE_URI = "wss://localhost:" + TLS_TEST_PORT + "/ws/producer/persistent/my-property/use/my-ns/my-topic/";
     private static final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
-    private static final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
-    private static final int TEST_PORT = 6080;
-    private static final int TLS_TEST_PORT = 6090;
+    private static final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";    
+    
     private ProxyServer proxyServer;
     private WebSocketService service;
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeWithoutZKTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyPublishConsumeWithoutZKTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.spy;
 import java.net.URI;
 import java.util.concurrent.Future;
 
+import org.apache.bookkeeper.test.PortManager;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -39,9 +40,9 @@ import com.yahoo.pulsar.websocket.service.WebSocketServiceStarter;
 
 public class ProxyPublishConsumeWithoutZKTest extends ProducerConsumerBase {
     protected String methodName;
-    private static final String CONSUME_URI = "ws://localhost:6080/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
-    private static final String PRODUCE_URI = "ws://localhost:6080/ws/producer/persistent/my-property/use/my-ns/my-topic/";
-    private static final int TEST_PORT = 6080;
+    private static final int TEST_PORT = PortManager.nextFreePort();
+    private static final String CONSUME_URI = "ws://localhost:" + TEST_PORT + "/ws/consumer/persistent/my-property/use/my-ns/my-topic/my-sub";
+    private static final String PRODUCE_URI = "ws://localhost:" + TEST_PORT + "/ws/producer/persistent/my-property/use/my-ns/my-topic/";
     private ProxyServer proxyServer;
     private WebSocketService service;
 


### PR DESCRIPTION
…thoutZKTest

### Motivation

Possible fix for #237
Can't replicate the timeout error but have seen the test case fail if the port is used by some other process

### Modifications

Removed hardcoding for port 6080 and used the next free available port

### Result

Hopefully the intermittent test case failures will reduce.