### PR TITLE
connect dispatcher again on reset cursor complete

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
@@ -41,7 +41,14 @@ public interface Dispatcher {
     boolean canUnsubscribe(Consumer consumer);
 
     /**
-     * disconnect all consumers and mark dispatcher closed to stop new incoming requests
+     * mark dispatcher closed to stop new incoming requests and disconnect all consumers
+     * 
+     * @return
+     */
+    CompletableFuture<Void> close();
+    
+    /**
+     * disconnect all consumers
      * 
      * @return
      */
@@ -57,4 +64,5 @@ public interface Dispatcher {
     void redeliverUnacknowledgedMessages(Consumer consumer);
 
     void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions);
+
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
@@ -45,12 +45,12 @@ public interface Dispatcher {
      * 
      * @return
      */
-    CompletableFuture<Void> disconnect();
+    CompletableFuture<Void> disconnectAllConsumers();
 
     /**
      * mark dispatcher open to serve new incoming requests
      */
-    void connect();
+    void reset();
 
     SubType getType();
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
@@ -40,7 +40,17 @@ public interface Dispatcher {
 
     boolean canUnsubscribe(Consumer consumer);
 
+    /**
+     * disconnect all consumers and mark dispatcher closed to stop new incoming requests
+     * 
+     * @return
+     */
     CompletableFuture<Void> disconnect();
+
+    /**
+     * mark dispatcher open to serve new incoming requests
+     */
+    void connect();
 
     SubType getType();
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -214,7 +214,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
     }
 
     @Override
-    public synchronized CompletableFuture<Void> disconnect() {
+    public synchronized CompletableFuture<Void> disconnectAllConsumers() {
         closeFuture = new CompletableFuture<>();
         if (consumerList.isEmpty()) {
             closeFuture.complete(null);
@@ -228,7 +228,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
     }
 
     @Override
-    public synchronized void connect() {
+    public synchronized void reset() {
         closeFuture = null;
     }
     

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -83,6 +83,10 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
 
     @Override
     public synchronized void addConsumer(Consumer consumer) {
+        if (closeFuture != null) {
+            log.warn("[{}] Dispatcher is already closed. Closing consumer ", name, consumer);
+            consumer.disconnect();
+        }
         if (consumerList.isEmpty()) {
             if (havePendingRead || havePendingReplayRead) {
                 // There is a pending read from previous run. We must wait for it to complete and then rewind
@@ -223,6 +227,11 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
         return closeFuture;
     }
 
+    @Override
+    public synchronized void connect() {
+        closeFuture = null;
+    }
+    
     @Override
     public SubType getType() {
         return SubType.Shared;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
@@ -60,6 +61,11 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
     private static final int MaxReadBatchSize = 100;
     private int readBatchSize;
     private final Backoff readFailureBackoff = new Backoff(15, TimeUnit.SECONDS, 1, TimeUnit.MINUTES);
+    private static final int FALSE = 0;
+    private static final int TRUE = 1;
+    private static final AtomicIntegerFieldUpdater<PersistentDispatcherSingleActiveConsumer> IS_CLOSED_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(PersistentDispatcherSingleActiveConsumer.class, "isClosed");
+    private volatile int isClosed = FALSE;
 
     public PersistentDispatcherSingleActiveConsumer(ManagedCursor cursor, SubType subscriptionType, int partitionIndex,
             PersistentTopic topic) {
@@ -99,7 +105,7 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
 
     @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
-        if (closeFuture != null) {
+        if (IS_CLOSED_UPDATER.get(this) == TRUE) {
             log.warn("[{}] Dispatcher is already closed. Closing consumer ", this.topic.getName(), consumer);
             consumer.disconnect();
         }
@@ -153,6 +159,12 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
         return (consumers.size() == 1) && Objects.equals(consumer, ACTIVE_CONSUMER_UPDATER.get(this));
     }
 
+    @Override
+    public CompletableFuture<Void> close() {
+        IS_CLOSED_UPDATER.set(this, TRUE);
+        return disconnectAllConsumers();
+    }
+    
     /**
      * Disconnect all consumers on this dispatcher (server side close). This triggers channelInactive on the inbound
      * handler which calls dispatcher.removeConsumer(), where the closeFuture is completed
@@ -176,8 +188,8 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
     }
 
     @Override
-    public synchronized void reset() {
-        closeFuture = null;
+    public void reset() {
+        IS_CLOSED_UPDATER.set(this, FALSE);
     }
     
     @Override

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -99,6 +99,10 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
 
     @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
+        if (closeFuture != null) {
+            log.warn("[{}] Dispatcher is already closed. Closing consumer ", this.topic.getName(), consumer);
+            consumer.disconnect();
+        }
         if (subscriptionType == SubType.Exclusive && !consumers.isEmpty()) {
             throw new ConsumerBusyException("Exclusive consumer is already connected");
         }
@@ -171,6 +175,11 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
         return closeFuture;
     }
 
+    @Override
+    public synchronized void connect() {
+        closeFuture = null;
+    }
+    
     @Override
     public synchronized void readEntriesComplete(final List<Entry> entries, Object obj) {
         Consumer readConsumer = (Consumer) obj;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -160,7 +160,7 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
      * @return
      */
     @Override
-    public synchronized CompletableFuture<Void> disconnect() {
+    public synchronized CompletableFuture<Void> disconnectAllConsumers() {
         closeFuture = new CompletableFuture<>();
 
         if (!consumers.isEmpty()) {
@@ -176,7 +176,7 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
     }
 
     @Override
-    public synchronized void connect() {
+    public synchronized void reset() {
         closeFuture = null;
     }
     

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -16,17 +16,25 @@
 package com.yahoo.pulsar.client.impl;
 
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableMap;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -38,16 +46,18 @@ import com.yahoo.pulsar.broker.service.Topic;
 import com.yahoo.pulsar.client.api.Consumer;
 import com.yahoo.pulsar.client.api.ConsumerConfiguration;
 import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.api.MessageListener;
 import com.yahoo.pulsar.client.api.Producer;
 import com.yahoo.pulsar.client.api.ProducerConfiguration;
 import com.yahoo.pulsar.client.api.ProducerConsumerBase;
 import com.yahoo.pulsar.client.api.PulsarClient;
+import com.yahoo.pulsar.client.api.PulsarClientException;
 import com.yahoo.pulsar.client.api.SubscriptionType;
 import com.yahoo.pulsar.client.impl.HandlerBase.State;
 import com.yahoo.pulsar.common.api.PulsarHandler;
 import com.yahoo.pulsar.common.naming.DestinationName;
 import com.yahoo.pulsar.common.naming.NamespaceBundle;
-import com.yahoo.pulsar.common.naming.NamespaceBundle;
+import com.yahoo.pulsar.common.policies.data.RetentionPolicies;
 import com.yahoo.pulsar.common.util.collections.ConcurrentLongHashMap;
 
 public class BrokerClientIntegrationTest extends ProducerConsumerBase {
@@ -337,5 +347,125 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         batchProducer.close();
         log.info("-- Exiting {} test --", methodName);
     }
-    
+
+    @Test(timeOut = 10000)
+    public void testResetCursor() throws Exception {
+        final RetentionPolicies policy = new RetentionPolicies(60, 52 * 1024);
+        final DestinationName destName = DestinationName.get("persistent://my-property/use/my-ns/unacked-topic");
+        final int warmup = 20;
+        final int testSize = 150;
+        final List<Message> received = new ArrayList<Message>();
+        final ConsumerConfiguration consConfig = new ConsumerConfiguration();
+        final String subsId = "sub";
+
+        final NavigableMap<Long, TimestampEntryCount> publishTimeIdMap = new ConcurrentSkipListMap<>();
+
+        consConfig.setSubscriptionType(SubscriptionType.Shared);
+        consConfig.setMessageListener((MessageListener) (Consumer consumer, Message msg) -> {
+            try {
+                synchronized (received) {
+                    received.add(msg);
+                }
+                consumer.acknowledge(msg);
+                long publishTime = ((MessageImpl) msg).getPublishTime();
+                System.out.println(" publish time is " + publishTime + "," + msg.getMessageId());
+                TimestampEntryCount timestampEntryCount = publishTimeIdMap.computeIfAbsent(publishTime,
+                        (k) -> new TimestampEntryCount(publishTime));
+                timestampEntryCount.incrementAndGet();
+            } catch (final PulsarClientException e) {
+                System.out.println("Failed to ack!");
+            }
+        });
+
+        admin.namespaces().setRetention(destName.getNamespace(), policy);
+
+        Consumer consumer = pulsarClient.subscribe(destName.toString(), subsId, consConfig);
+        final Producer producer = pulsarClient.createProducer(destName.toString());
+
+        log.info("warm up started for " + destName.toString());
+        // send warmup msgs
+        byte[] msgBytes = new byte[1000];
+        for (Integer i = 0; i < warmup; i++) {
+            producer.send(msgBytes);
+        }
+        log.info("warm up finished.");
+
+        // sleep to ensure receiving of msgs
+        for (int n = 0; n < 10 && received.size() < warmup; n++) {
+            Thread.sleep(100);
+        }
+
+        // validate received msgs
+        Assert.assertEquals(received.size(), warmup);
+        received.clear();
+
+        // publish testSize num of msgs
+        System.out.println("Sending more messages.");
+        for (Integer n = 0; n < testSize; n++) {
+            producer.send(msgBytes);
+            Thread.sleep(1);
+        }
+        log.info("Sending more messages done.");
+
+        Thread.sleep(3000);
+
+        long begints = publishTimeIdMap.firstEntry().getKey();
+        long endts = publishTimeIdMap.lastEntry().getKey();
+        // find reset timestamp
+        long timestamp = (endts - begints) / 2 + begints;
+        timestamp = publishTimeIdMap.floorKey(timestamp);
+
+        NavigableMap<Long, TimestampEntryCount> expectedMessages = new ConcurrentSkipListMap<>();
+        expectedMessages.putAll(publishTimeIdMap.tailMap(timestamp, true));
+
+        received.clear();
+
+        log.info("reset cursor to " + timestamp + " for topic " + destName.toString() + " for subs " + subsId);
+        System.out.println("issuing admin operation on " + admin.getServiceUrl().toString());
+        List<String> subList = admin.persistentTopics().getSubscriptions(destName.toString());
+        for (String subs : subList) {
+            log.info("got sub " + subs);
+        }
+        consumer.close();
+        publishTimeIdMap.clear();
+        // reset the cursor to this timestamp
+        Assert.assertTrue(subList.contains(subsId));
+        admin.persistentTopics().resetCursor(destName.toString(), subsId, timestamp);
+
+        consumer = pulsarClient.subscribe(destName.toString(), subsId, consConfig);
+        Thread.sleep(3000);
+        int totalExpected = 0;
+        for (TimestampEntryCount tec : expectedMessages.values()) {
+            totalExpected += tec.numMessages;
+        }
+        // validate that replay happens after the timestamp
+        Assert.assertTrue(publishTimeIdMap.firstEntry().getKey() >= timestamp);
+        consumer.unsubscribe();
+        producer.close();
+        // validate that expected and received counts match
+        int totalReceived = 0;
+        for (TimestampEntryCount tec : publishTimeIdMap.values()) {
+            totalReceived += tec.numMessages;
+        }
+        Assert.assertEquals(totalReceived, totalExpected, "did not receive all messages on replay after reset");
+    }
+
+    private static class TimestampEntryCount {
+        private final long timestamp;
+        private int numMessages;
+
+        public TimestampEntryCount(long ts) {
+            this.numMessages = 0;
+            this.timestamp = ts;
+        }
+
+        public int incrementAndGet() {
+            return ++numMessages;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation

Reset-cursor disconnects consumers and closes [Dispatcher](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L214) that will not allow [message-dispatching](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L469) (because `closeFuture!=null`) even after reset-cursor completes.

### Modifications

Reset cursor:
- Disconnects dispatcher before reset cursor and connects dispatcher back once reset-cursor gets completed.

### Result

Reset-cursor will not block message-dispatching for newly added consumers.
