### PR TITLE
close binary-proto-lookup connection after connection-lifetime

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
@@ -42,6 +42,7 @@ public class ClientConfiguration implements Serializable {
     private int numIoThreads = 1;
     private int numListenerThreads = 1;
     private int connectionsPerBroker = 1;
+    private long lookupConnectionLifetimeInSecond = 600;
 
     private boolean useTcpNoDelay = true;
 
@@ -220,6 +221,30 @@ public class ClientConfiguration implements Serializable {
     }
 
     /**
+     * 
+     * @return lifetime of the persistent-connection used for the binary-proto lookup
+     */
+    public long getLookupConnectionLifetimeInSecond() {
+        return lookupConnectionLifetimeInSecond;
+    }
+
+    /**
+     * Sets lifetime of the persistent-connection (with broker) used for the binary-proto lookup <i>(default: 10
+     * mins)</i>
+     * <p>
+     * Setting time to -1 will not force connection to be closed after default-lifetime duration. Client creates a
+     * separate dedicated connection with broker for a given service-lookup url, if this url is same as broker's
+     * brokerServiceUrl then client shares the same created lookup-connection for producer/consumer connection also. So,
+     * in that case {@link #setLookupConnectionLifetimeInSecond(long)} should be configured -1 to avoid
+     * producer/consumer disruption due to disconnection/reconnection.
+     * 
+     * @param lookupConnectionLifetimeInSecond
+     */
+    public void setLookupConnectionLifetimeInSecond(long lookupConnectionLifetimeInSecond) {
+        this.lookupConnectionLifetimeInSecond = lookupConnectionLifetimeInSecond;
+    }
+
+    /**
      * @return whether TCP no-delay should be set on the connections
      */
     public boolean isUseTcpNoDelay() {
@@ -322,8 +347,8 @@ public class ClientConfiguration implements Serializable {
 
     /**
      * Number of concurrent lookup-requests allowed on each broker-connection to prevent overload on broker.
-     * <i>(default: 5000)</i> It should be configured with higher value only in case of it requires to produce/subscribe on
-     * thousands of topic using created {@link PulsarClient}
+     * <i>(default: 5000)</i> It should be configured with higher value only in case of it requires to produce/subscribe
+     * on thousands of topic using created {@link PulsarClient}
      * 
      * @param concurrentLookupRequest
      */

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -338,6 +338,7 @@ public class ClientCnx extends PulsarHandler {
                 if (!writeFuture.isSuccess()) {
                     log.warn("{} Failed to send request {} to broker: {}", ctx.channel(), requestId,
                             writeFuture.cause().getMessage());
+                    getAndRemovePendingLookupRequest(requestId);
                     future.completeExceptionally(writeFuture.cause());
                 }
             });
@@ -377,6 +378,7 @@ public class ClientCnx extends PulsarHandler {
         ctx.writeAndFlush(cmd).addListener(writeFuture -> {
             if (!writeFuture.isSuccess()) {
                 log.warn("{} Failed to send request to broker: {}", ctx.channel(), writeFuture.cause().getMessage());
+                pendingRequests.remove(requestId);
                 future.completeExceptionally(writeFuture.cause());
             }
         });

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -61,6 +61,8 @@ public class ClientCnx extends PulsarHandler {
 
     private final CompletableFuture<Void> connectionFuture = new CompletableFuture<Void>();
     private final Semaphore pendingLookupRequestSemaphore;
+    // Timestamp of when this connection used for lookup
+    protected volatile long lastLookupRequestTime;
 
     enum State {
         None, SentConnectFrame, Ready
@@ -258,6 +260,7 @@ public class ClientCnx extends PulsarHandler {
     private boolean addPendingLookupRequests(long requestId, CompletableFuture<LookupDataResult> future) {
         if (pendingLookupRequestSemaphore.tryAcquire()) {
             pendingLookupRequests.put(requestId, future);
+            lastLookupRequestTime = System.nanoTime();
             return true;
         }
         return false;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConnectionPool.java
@@ -24,6 +24,9 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
@@ -55,6 +58,7 @@ public class ConnectionPool implements Closeable {
     private final Bootstrap bootstrap;
     private final EventLoopGroup eventLoopGroup;
     private final int maxConnectionsPerHosts;
+    private final ScheduledExecutorService scheduler;
 
     private static final int MaxMessageSize = 5 * 1024 * 1024;
     public static final String TLS_HANDLER = "tls";
@@ -62,6 +66,7 @@ public class ConnectionPool implements Closeable {
     public ConnectionPool(final PulsarClientImpl client, EventLoopGroup eventLoopGroup) {
         this.eventLoopGroup = eventLoopGroup;
         this.maxConnectionsPerHosts = client.getConfiguration().getConnectionsPerBroker();
+        this.scheduler = Executors.newScheduledThreadPool(1);
 
         pool = new ConcurrentHashMap<>();
         bootstrap = new Bootstrap();
@@ -111,22 +116,36 @@ public class ConnectionPool implements Closeable {
     private static final Random random = new Random();
 
     public CompletableFuture<ClientCnx> getConnection(final InetSocketAddress address) {
+        return getConnection(address, -1);
+    }
+
+    /**
+     * 
+     * @param address
+     *            remote client address 
+     * @param connectionLifetimeInSecond
+     *            connection lifetime (in second): if it's > 0 then created connection will be automatically closed
+     *            after given connectionLifetimeInSecond
+     * @return
+     */
+    public CompletableFuture<ClientCnx> getConnection(final InetSocketAddress address,
+            long connectionLifetimeInSecond) {
         if (maxConnectionsPerHosts == 0) {
             // Disable pooling
-            return createConnection(address, -1);
+            return createConnection(address, -1, connectionLifetimeInSecond);
         }
 
         final int randomKey = signSafeMod(random.nextInt(), maxConnectionsPerHosts);
 
         return pool.computeIfAbsent(address, a -> new ConcurrentHashMap<>()) //
-                .computeIfAbsent(randomKey, k -> createConnection(address, randomKey));
+                .computeIfAbsent(randomKey, k -> createConnection(address, randomKey, connectionLifetimeInSecond));
     }
 
-    private CompletableFuture<ClientCnx> createConnection(InetSocketAddress address, int connectionKey) {
+    private CompletableFuture<ClientCnx> createConnection(InetSocketAddress address, int connectionKey,
+            long connectionLifetimeInSecond) {
         if (log.isDebugEnabled()) {
             log.debug("Connection for {} not found in cache", address);
         }
-
         final CompletableFuture<ClientCnx> cnxFuture = new CompletableFuture<ClientCnx>();
 
         // Trigger async connect to broker
@@ -170,6 +189,15 @@ public class ConnectionPool implements Closeable {
                 cnx.ctx().close();
                 return null;
             });
+
+            // close the connection after connection-lifetime completes
+            if (connectionLifetimeInSecond > 0) {
+                scheduler.schedule(() -> {
+                    if (cnx != null && cnx.channel().isActive()) {
+                        cnx.channel().disconnect();
+                    }
+                }, connectionLifetimeInSecond, TimeUnit.SECONDS);
+            }
         });
 
         return cnxFuture;
@@ -178,6 +206,7 @@ public class ConnectionPool implements Closeable {
     @Override
     public void close() throws IOException {
         eventLoopGroup.shutdownGracefully();
+        scheduler.shutdown();
     }
 
     private void cleanupConnection(InetSocketAddress address, int connectionKey,


### PR DESCRIPTION
### Motivation

[PulsarClient](https://github.com/yahoo/pulsar/blob/master/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConnectionPool.java#L121) creates a separate dedicated connection with broker for a given service-lookup url. So, in case of broker's cold-restart, all clients may end-up creating lookup-connection to same one broker and this connection will be persisted for entire lifetime of the client, which may create lookup-overload on that one broker. So, lookup connection should not be persistent and it should be closed after sometime.

### Modifications

- disconnect lookup connection after x seconds (default = 10 min)

### Result

Lookup connection will not be persistent and it will avoid one broker to be overloaded with lookup requests.
