### PR TITLE
fix Intermittent test failures in ProxyPublishConsumeTest.socketTest

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -16,10 +16,12 @@
  */
 package com.yahoo.pulsar.websocket.proxy;
 
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.net.URI;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -110,12 +112,21 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         } catch (Throwable t) {
             log.error(t.getMessage());
         } finally {
+            ExecutorService executor = newFixedThreadPool(1);
             try {
-                consumeClient.stop();
-                produceClient.stop();
+                executor.submit(() -> {
+                    try {
+                        consumeClient.stop();
+                        produceClient.stop();
+                        log.info("proxy clients are stopped successfully");
+                    } catch (Exception e) {
+                        log.error(e.getMessage());
+                    }
+                }).get(2, TimeUnit.SECONDS);
             } catch (Exception e) {
-                log.error(e.getMessage());
+                log.error("failed to close clients ", e);
             }
+            executor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
### Motivation

#237 sometime `WebSocketClient.stop()` gets stuck and it cause the test-case failure. So, wait for 2-seconds for clients to be closed and then ignore it.

```
at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1037)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328)
    at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277)
    at org.eclipse.jetty.io.ManagedSelector$CloseEndPoints.await(ManagedSelector.java:725)
    at org.eclipse.jetty.io.ManagedSelector.doStop(ManagedSelector.java:114)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:89)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:143)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:161)
    at org.eclipse.jetty.io.SelectorManager.doStop(SelectorManager.java:290)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:89)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:143)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:161)
    at org.eclipse.jetty.websocket.client.io.ConnectionManager.doStop(ConnectionManager.java:160)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:89)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:143)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:161)
    at org.eclipse.jetty.websocket.client.WebSocketClient.doStop(WebSocketClient.java:288)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:89)
    at com.yahoo.pulsar.websocket.proxy.ProxyPublishConsumeTest.socketTest(ProxyPublishConsumeTest.java:105)
```