### PR TITLE
Fix in ConsumerBase.java to return failed future - #249

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/ConsumeBaseExceptionTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/ConsumeBaseExceptionTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.pulsar.client.impl;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.yahoo.pulsar.client.api.Consumer;
+import com.yahoo.pulsar.client.api.ConsumerConfiguration;
+import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.api.ProducerConsumerBase;
+import com.yahoo.pulsar.client.api.PulsarClientException;
+
+public class ConsumeBaseExceptionTest extends ProducerConsumerBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        producerBaseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testClosedConsumer() throws PulsarClientException {
+        Consumer consumer = null;
+        consumer = pulsarClient.subscribe("persistent://prop/cluster/ns/topicName", "my-subscription");
+        consumer.close();
+        Assert.assertTrue(consumer.receiveAsync().isCompletedExceptionally());
+
+        try {
+            consumer.receiveAsync().exceptionally(e -> {
+                Assert.assertTrue(e instanceof PulsarClientException.AlreadyClosedException);
+                return null;
+            }).get();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testListener() throws PulsarClientException {
+        Consumer consumer = null;
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setMessageListener((Consumer c, Message msg) -> {
+        });
+        consumer = pulsarClient.subscribe("persistent://prop/cluster/ns/topicName", "my-subscription", conf);
+        Assert.assertTrue(consumer.receiveAsync().isCompletedExceptionally());
+
+        try {
+            consumer.receiveAsync().exceptionally(e -> {
+                Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
+                return null;
+            }).get();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+}

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerBase.java
@@ -96,7 +96,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
     public CompletableFuture<Message> receiveAsync() {
 
         if (listener != null) {
-            FutureUtil.failedFuture(new PulsarClientException.InvalidConfigurationException(
+            return FutureUtil.failedFuture(new PulsarClientException.InvalidConfigurationException(
                     "Cannot use receive() when a listener has been set"));
         }
 
@@ -106,10 +106,10 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
             break; // Ok
         case Closing:
         case Closed:
-            FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Consumer already closed"));
+            return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Consumer already closed"));
         case Failed:
         case Uninitialized:
-            FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
+            return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
         }
 
         return internalReceiveAsync();


### PR DESCRIPTION
### Motivation

Fix for Issue #249  

### Modifications

Added return statements

### Result

Failed futures will be returned if the consumer is not ready