### PR TITLE
Avoid printing unit test info logs by default for pulsar-storm

### DIFF
--- a/pulsar-storm/pom.xml
+++ b/pulsar-storm/pom.xml
@@ -74,6 +74,12 @@
       <artifactId>storm-core</artifactId>
       <version>${storm.version}</version>
       <scope>provided</scope>
+      <exclusions>
+      	<exclusion>
+      		<groupId>ch.qos.logback</groupId>
+      		<artifactId>logback-classic</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

To reduce the build log file in Travis, we should turn off info logs in pulsar-storm module, as it's already in other modules.

### Modification

Since storm is already pulling `logback-classic`, we have 2 slf4j logger implementation in the classpath during the test. We need to remove logback.