### PR TITLE
Fixed license check mappings and exclusions

### DIFF
--- a/dashboard/conf/uwsgi.ini
+++ b/dashboard/conf/uwsgi.ini
@@ -1,3 +1,19 @@
+#
+# Copyright 2016 Yahoo Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # django.ini file
 [uwsgi]
 

--- a/pom.xml
+++ b/pom.xml
@@ -482,19 +482,26 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/*.versionsBackup</exclude>
             <exclude>**/circe/**</exclude>
             <exclude>pulsar-client-cpp/lib/checksum/int_types.h</exclude>
+            <exclude>pulsar-client-cpp/lib/checksum/gf2.hpp</exclude>
             <exclude>pulsar-client-cpp/lib/checksum/crc32c*</exclude>
             <exclude>pulsar-client-cpp/lib/lz4/lz4.*</exclude>
             <exclude>pulsar-client-cpp/.idea/*</exclude>
             <exclude>pulsar-client-cpp/lib/PulsarApi.pb.*</exclude>
             <exclude>pulsar-client-cpp/CMakeFiles/**</exclude>
-            <exclude>pulsar-client-cpp/travis-build.sh</exclude>
+            <exclude>pulsar-client-cpp/**/Makefile</exclude>
+            <exclude>pulsar-client-cpp/**/cmake_install.cmake</exclude>
             <exclude>**/*.pyc</exclude>
             <exclude>**/*.graffle</exclude>
             <exclude>**/*.hgrm</exclude>
+            <exclude>**/CMakeFiles/**</exclude>
+            <exclude>dashboard/django/stats/migrations/*.py</exclude>
+            
           </excludes>
           <mapping>
             <proto>JAVADOC_STYLE</proto>
             <conf>SCRIPT_STYLE</conf>
+            <ini>SCRIPT_STYLE</ini>
+            <cc>JAVADOC_STYLE</cc>
           </mapping>
         </configuration>
         <executions>

--- a/pulsar-client-cpp/travis-build.sh
+++ b/pulsar-client-cpp/travis-build.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
-
+#
 # Copyright 2016 Yahoo Inc.
 #
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 function usage() {
   echo "$0: <unpack location> <build directory> [all|dep|compile]";


### PR DESCRIPTION
### Motivation

Some of the files are not currently checked for license compliance (eg: `*.cc`) while other didn't have the proper headers.