### PR TITLE
Fixed circular dependency in slf4j loggers for pulsar-storm unit tests

### DIFF
--- a/pulsar-storm/pom.xml
+++ b/pulsar-storm/pom.xml
@@ -79,6 +79,10 @@
       		<groupId>ch.qos.logback</groupId>
       		<artifactId>logback-classic</artifactId>
       	</exclusion>
+      	<exclusion>
+      		<groupId>org.slf4j</groupId>
+      		<artifactId>log4j-over-slf4j</artifactId>
+      	</exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
### Motivation

Change in #259 caused to pull both the log4j implementation and logger bridge : 

```
Caused by: java.lang.IllegalStateException: Detected both 
log4j-over-slf4j.jar AND slf4j-log4j12.jar 
on the class path, preempting StackOverflowError. See also 
http://www.slf4j.org/codes.html#log4jDelegationLoop for more details.
```