### PR TITLE
close http-connection on internal server error from broker

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/web/WebService.java
@@ -152,6 +152,9 @@ public class WebService implements AutoCloseable {
             context.addFilter(holder, MATCH_ALL, EnumSet.allOf(DispatcherType.class));
             log.info("Enabling ApiVersionFilter");
         }
+        
+        FilterHolder responseFilter = new FilterHolder(new ResponseHandlerFilter(pulsar));
+        context.addFilter(responseFilter, MATCH_ALL, EnumSet.allOf(DispatcherType.class));
 
         handlers.add(context);
     }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HttpClient.java
@@ -21,15 +21,13 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import org.asynchttpclient.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +70,9 @@ public class HttpClient implements Closeable {
         confBuilder.setConnectTimeout(connectTimeoutInSeconds * 1000);
         confBuilder.setReadTimeout(readTimeoutInSeconds * 1000);
         confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", getPulsarClientVersion()));
+        confBuilder.setKeepAliveStrategy((request, httpRequest, httpResponse) -> {
+            return !httpResponse.getStatus().equals(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        });
 
         if ("https".equals(url.getProtocol())) {
             try {


### PR DESCRIPTION
### Motivation

By default [AsyncHttpClient](https://github.com/yahoo/pulsar/blob/master/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HttpClient.java#L70) has [Keep-alive](https://github.com/AsyncHttpClient/async-http-client/blob/master/client/src/main/resources/ahc-default.properties#L20) enabled and it get connected to the bad-broker then client repeatedly fails to perform lookup requests. In that case, connection should be closed and client should be able to connect with other broker to get the request served.

eg: sometimes broker is not able to create zk-session and it keeps failing to authenticate client-request so, client should be redirected to other broker by closing client-side connection on broker's `InternalServerError`
```
WARN  c.y.p.b.a.AuthorizationManager       - Client  with Role - my-role failed to get permissions for destination - persistent://property/cluster/ns/topic-1
org.apache.zookeeper.KeeperException$SessionExpiredException: KeeperErrorCode = Session expired for /admin/policies/property/cluster/ns
:
at com.yahoo.pulsar.broker.admin.PersistentTopics.getPartitionedMetadata(PersistentTopics.java:359) [pulsar-broker-1.15.7.jar:na]
```

### Modifications

add `KeepAliveStrategy` in `httpClient` to disable keep-alive after `internalServerError`.

### Result

`AsyncHttpClient` should close the connection on `InternalServerError`
