### PR TITLE
Handle unknown exception on authorization check

### DIFF
--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/authorization/AuthorizationManager.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/authorization/AuthorizationManager.java
@@ -53,13 +53,13 @@ public class AuthorizationManager {
         return checkAuthorization(destination, role, AuthAction.produce);
     }
     
-    public boolean canProduce(DestinationName destination, String role) {
+    public boolean canProduce(DestinationName destination, String role) throws Exception {
         try {
             return canProduceAsync(destination, role).get();
         } catch (Exception e) {
             log.warn("Producer-client  with Role - {} failed to get permissions for destination - {}", role,
                     destination, e);
-            return false;
+            throw e;
         }
     }
 
@@ -76,13 +76,13 @@ public class AuthorizationManager {
         return checkAuthorization(destination, role, AuthAction.consume);
     }
     
-    public boolean canConsume(DestinationName destination, String role) {
+    public boolean canConsume(DestinationName destination, String role) throws Exception {
         try {
             return canConsumeAsync(destination, role).get();
         } catch (Exception e) {
             log.warn("Consumer-client  with Role - {} failed to get permissions for destination - {}", role,
                     destination, e);
-            return false;
+            throw e;
         }
     }
 
@@ -94,8 +94,9 @@ public class AuthorizationManager {
      * @param destination
      * @param role
      * @return
+     * @throws Exception 
      */
-    public boolean canLookup(DestinationName destination, String role) {
+    public boolean canLookup(DestinationName destination, String role) throws Exception {
         return canProduce(destination, role) || canConsume(destination, role);
     }
 
@@ -156,12 +157,12 @@ public class AuthorizationManager {
             }).exceptionally(ex -> {
                 log.warn("Client  with Role - {} failed to get permissions for destination - {}", role, destination,
                         ex);
-                permissionFuture.complete(false);
+                permissionFuture.completeExceptionally(ex);
                 return null;
             });
         } catch (Exception e) {
             log.warn("Client  with Role - {} failed to get permissions for destination - {}", role, destination, e);
-            permissionFuture.complete(false);
+            permissionFuture.completeExceptionally(e);
         }
         return permissionFuture;
     }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -1083,7 +1083,7 @@ public class PersistentTopics extends AdminResource {
                     metadataFuture.complete(new PartitionedTopicMetadata());
                 }
             }).exceptionally(ex -> {
-                metadataFuture.complete(new PartitionedTopicMetadata());
+                metadataFuture.completeExceptionally(ex);
                 return null;
             });
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -994,8 +994,13 @@ public class PersistentTopics extends AdminResource {
 
         try {
             checkConnect(dn);
-        } catch (RestException e) {
+        } catch (WebApplicationException e) {
             validateAdminAccessOnProperty(dn.getProperty());
+        } catch (Exception e) {
+            // unknown error marked as internal server error
+            log.warn("Unexpected error while authorizing lookup. destination={}, role={}. Error: {}", destination,
+                    clientAppId(), e.getMessage(), e);
+            throw new RestException(e);
         }
 
         String path = path(PARTITIONED_TOPIC_PATH_ZNODE, property, cluster, namespace, domain(),
@@ -1024,6 +1029,12 @@ public class PersistentTopics extends AdminResource {
                     throw new PulsarClientException(String.format("Authorization failed %s on cluster %s with error %s",
                             clientAppId, dn.toString(), authException.getMessage()));
                 }
+            } catch (Exception ex) {
+                // unknown error marked as internal server error
+                log.warn("Failed to authorize {} on cluster {} with unexpected exception {}", clientAppId,
+                        dn.toString(), ex.getMessage(), ex);
+                throw new PulsarClientException(String.format("Authorization failed %s on cluster %s with error %s",
+                        clientAppId, dn.toString(), ex.getMessage()));
             }
             String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getProperty(), dn.getCluster(),
                     dn.getNamespacePortion(), "persistent", dn.getEncodedLocalName());

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/lookup/DestinationLookup.java
@@ -80,8 +80,7 @@ public class DestinationLookup extends PulsarWebResource {
         } catch (Throwable t) {
             // Validation checks failed with unknown error
             log.error("Validation check failed: {}", t.getMessage(), t);
-            asyncResponse.resume(new RestException(Status.SERVICE_UNAVAILABLE, String.format(
-                    "Failed to validate Cluster configuration : cluster=%s  emsg=%s", cluster, t.getMessage())));
+            asyncResponse.resume(new RestException(t));
             return;
         }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
@@ -417,8 +417,15 @@ public class Consumer {
 
     public void checkPermissions() {
         DestinationName destination = DestinationName.get(subscription.getDestination());
-        if (cnx.getBrokerService().getAuthorizationManager() != null
-                && !cnx.getBrokerService().getAuthorizationManager().canConsume(destination, appId)) {
+        if (cnx.getBrokerService().getAuthorizationManager() != null) {
+            try {
+                if (cnx.getBrokerService().getAuthorizationManager().canConsume(destination, appId)) {
+                    return;
+                }
+            } catch (Exception e) {
+                log.warn("[{}] Get unexpected error while autorizing [{}]  {}", appId, subscription.getDestination(),
+                        e.getMessage(), e);
+            }
             log.info("[{}] is not allowed to consume from Destination" + " [{}] anymore", appId,
                     subscription.getDestination());
             disconnect();

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Producer.java
@@ -350,9 +350,16 @@ public class Producer {
 
     public void checkPermissions() {
         DestinationName destination = DestinationName.get(topic.getName());
-        if (cnx.getBrokerService().getAuthorizationManager() != null
-                && !cnx.getBrokerService().getAuthorizationManager().canProduce(destination, appId)) {
-            log.info("[{}] is not allowed to consume from destination [{}] anymore", appId, topic.getName());
+        if (cnx.getBrokerService().getAuthorizationManager() != null) {
+            try {
+                if (cnx.getBrokerService().getAuthorizationManager().canProduce(destination, appId)) {
+                    return;
+                }
+            } catch (Exception e) {
+                log.warn("[{}] Get unexpected error while autorizing [{}]  {}", appId, topic.getName(), e.getMessage(),
+                        e);
+            }
+            log.info("[{}] is not allowed to produce from destination [{}] anymore", appId, topic.getName());
             disconnect();
         }
     }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/web/PulsarWebResource.java
@@ -561,11 +561,11 @@ public abstract class PulsarWebResource {
         return validationFuture;
     }
 
-    protected void checkConnect(DestinationName destination) {
+    protected void checkConnect(DestinationName destination) throws RestException, Exception {
         checkAuthorization(pulsar(), destination, clientAppId());
     }
     
-    protected static void checkAuthorization(PulsarService pulsarService, DestinationName destination, String role) {
+    protected static void checkAuthorization(PulsarService pulsarService, DestinationName destination, String role) throws RestException, Exception{
         if (!pulsarService.getConfiguration().isAuthorizationEnabled()) {
             // No enforcing of authorization policies
             return;
@@ -579,11 +579,6 @@ public abstract class PulsarWebResource {
         } catch (RestException e) {
             // Let it through
             throw e;
-        } catch (Exception e) {
-            // unknown error marked as internal server error
-            log.warn("Error in authorizing lookup. destination={}, role={}. Error: {}", destination, role,
-                    e.getMessage(), e);
-            throw new RestException(e);
         }
     }
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/auth/AuthorizationTest.java
@@ -54,7 +54,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    void simple() throws PulsarAdminException {
+    void simple() throws Exception {
         AuthorizationManager auth = pulsar.getBrokerService().getAuthorizationManager();
 
         assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my-role"), false);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/BrokerServiceLookupTest.java
@@ -210,6 +210,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         
         // enable authorization: so, broker can validate cluster and redirect if finds different cluster
         pulsar.getConfiguration().setAuthorizationEnabled(true);
+        // restart broker with authorization enabled: it initialize AuthorizationManager
+        stopBroker();
+        startBroker();
         
         LoadManager loadManager2 = spy(pulsar2.getLoadManager());
         Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/websocket/proxy/ProxyAuthorizationTest.java
@@ -73,7 +73,7 @@ public class ProxyAuthorizationTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void test() throws PulsarAdminException {
+    public void test() throws Exception {
         AuthorizationManager auth = service.getAuthorizationManager();
 
         assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my-role"), false);

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java
@@ -122,7 +122,7 @@ public class BrokerDiscoveryProvider implements Closeable {
     }
 
     protected static void checkAuthorization(DiscoveryService service, DestinationName destination, String role)
-            throws IllegalAccessException {
+            throws Exception {
         if (!service.getConfiguration().isAuthorizationEnabled()
                 || service.getConfiguration().getSuperUserRoles().contains(role)) {
             // No enforcing of authorization policies


### PR DESCRIPTION
### Motivation

Right now, topic/PartitionMetadata lookup gives 401(unauthorized) error-code instead of 500(internalServerError) even if request fails with unknown-exception (eg. zk_session is not available). It may lead incorrect error-handling at client side.

### Modifications

Return 500 if request fails with unknown exception.

### Result

Broker returns correct error-code on lookup failure.
