### PR TITLE
If there is an error in reading from ZK, DiscoveryService should fail when reading partitions metadata

### DIFF
--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java
@@ -39,7 +39,6 @@ import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
 import com.yahoo.pulsar.discovery.service.server.ServiceConfig;
 import com.yahoo.pulsar.discovery.service.web.ZookeeperCacheLoader;
 import com.yahoo.pulsar.zookeeper.GlobalZooKeeperCache;
-import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 import com.yahoo.pulsar.zookeeper.ZooKeeperClientFactory;
 
 /**
@@ -98,23 +97,21 @@ public class BrokerDiscoveryProvider implements Closeable {
             final String path = path(PARTITIONED_TOPIC_PATH_ZNODE, destination.getProperty(), destination.getCluster(),
                     destination.getNamespacePortion(), "persistent", destination.getEncodedLocalName());
             // gets the number of partitions from the zk cache
-            globalZkCache.getDataAsync(path, new Deserializer<PartitionedTopicMetadata>() {
-                @Override
-                public PartitionedTopicMetadata deserialize(String key, byte[] content) throws Exception {
-                    return getThreadLocal().readValue(content, PartitionedTopicMetadata.class);
-                }
-            }).thenAccept(metadata -> {
-                // if the partitioned topic is not found in zk, then the topic
-                // is not partitioned
-                if (metadata.isPresent()) {
-                    metadataFuture.complete(metadata.get());
-                } else {
-                    metadataFuture.complete(new PartitionedTopicMetadata());
-                }
-            }).exceptionally(ex -> {
-                metadataFuture.complete(new PartitionedTopicMetadata());
-                return null;
-            });
+            globalZkCache
+                    .getDataAsync(path,
+                            (key, content) -> getThreadLocal().readValue(content, PartitionedTopicMetadata.class))
+                    .thenAccept(metadata -> {
+                        // if the partitioned topic is not found in zk, then the topic
+                        // is not partitioned
+                        if (metadata.isPresent()) {
+                            metadataFuture.complete(metadata.get());
+                        } else {
+                            metadataFuture.complete(new PartitionedTopicMetadata());
+                        }
+                    }).exceptionally(ex -> {
+                        metadataFuture.completeExceptionally(ex);
+                        return null;
+                    });
         } catch (Exception e) {
             metadataFuture.completeExceptionally(e);
         }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java
@@ -32,6 +32,7 @@ import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -209,7 +210,12 @@ public abstract class ZooKeeperCache implements Watcher {
         getDataAsync(path, this, deserializer).thenAccept(data -> {
             future.complete(data.map(e -> e.getKey()));
         }).exceptionally(ex -> {
-            future.complete(Optional.empty());
+            if (ex.getCause() instanceof NoNodeException) {
+                future.complete(Optional.empty());
+            } else {
+                future.completeExceptionally(ex.getCause());
+            }
+
             return null;
         });
         return future;


### PR DESCRIPTION
### Motivation

The lookup for the partitioned topic metadata should not silently succeed when the discovery service is failing at getting the info from ZK.

### Modifications

Fixed the ZK cache to throw exception instead of `Optional.empty()` on any error different from a ZK `NoNodeException`.

