### PR TITLE
close client connectionon  tooManyRequest and internal-server error

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -1030,11 +1030,11 @@ public class PersistentTopics extends AdminResource {
                             clientAppId, dn.toString(), authException.getMessage()));
                 }
             } catch (Exception ex) {
-                // unknown error marked as internal server error
+                // throw without wrapping to PulsarClientException that considers: unknown error marked as internal
+                // server error 
                 log.warn("Failed to authorize {} on cluster {} with unexpected exception {}", clientAppId,
                         dn.toString(), ex.getMessage(), ex);
-                throw new PulsarClientException(String.format("Authorization failed %s on cluster %s with error %s",
-                        clientAppId, dn.toString(), ex.getMessage()));
+                throw ex;
             }
             String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getProperty(), dn.getCluster(),
                     dn.getNamespacePortion(), "persistent", dn.getEncodedLocalName());

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -140,9 +140,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     private final static String producerNameGeneratorPath = "/counters/producer-name";
 
-    public static final String LOOKUP_THROTTLING_PATH = "/loadbalance/settings/throttling";
-    public static final String THROTTLING_LOOKUP_REQUEST_KEY = "maxConcurrentLookupRequest";
-
     private final BacklogQuotaManager backlogQuotaManager;
 
     private final int keepAliveIntervalSeconds;
@@ -206,7 +203,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         this.backlogQuotaChecker = Executors
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-backlog-quota-checker"));
         this.authenticationService = new AuthenticationService(pulsar.getConfiguration());
-
         this.dynamicConfigurationCache = new ZooKeeperDataCache<Map<String, String>>(pulsar().getLocalZkCache()) {
             @Override
             public Map<String, String> deserialize(String key, byte[] content) throws Exception {
@@ -855,7 +851,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     public AuthenticationService getAuthenticationService() {
         return authenticationService;
     }
-    
 
     public List<PersistentTopic> getAllTopicsFromNamespaceBundle(String namespace, String bundle) {
         return multiLayerTopicsMap.get(namespace).get(bundle).values();

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -140,6 +140,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     private final static String producerNameGeneratorPath = "/counters/producer-name";
 
+    public static final String LOOKUP_THROTTLING_PATH = "/loadbalance/settings/throttling";
+    public static final String THROTTLING_LOOKUP_REQUEST_KEY = "maxConcurrentLookupRequest";
+
     private final BacklogQuotaManager backlogQuotaManager;
 
     private final int keepAliveIntervalSeconds;
@@ -203,7 +206,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         this.backlogQuotaChecker = Executors
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-backlog-quota-checker"));
         this.authenticationService = new AuthenticationService(pulsar.getConfiguration());
-        
+
         this.dynamicConfigurationCache = new ZooKeeperDataCache<Map<String, String>>(pulsar().getLocalZkCache()) {
             @Override
             public Map<String, String> deserialize(String key, byte[] content) throws Exception {
@@ -853,6 +856,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         return authenticationService;
     }
     
+
     public List<PersistentTopic> getAllTopicsFromNamespaceBundle(String namespace, String bundle) {
         return multiLayerTopicsMap.get(namespace).get(bundle).values();
     }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
@@ -728,5 +728,4 @@ public class BrokerServiceTest extends BrokerTestBase {
             // ok as throttling set to 0
         }
     }
-
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ClientConfiguration.java
@@ -49,6 +49,7 @@ public class ClientConfiguration implements Serializable {
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
     private int concurrentLookupRequest = 5000;
+    private int maxNumberOfRejectedRequestPerConnection = 50;
 
     /**
      * @return the authentication provider to be used
@@ -330,4 +331,25 @@ public class ClientConfiguration implements Serializable {
     public void setConcurrentLookupRequest(int concurrentLookupRequest) {
         this.concurrentLookupRequest = concurrentLookupRequest;
     }
+
+    /**
+     * Get configured max number of reject-request in a time-frame (30 seconds) after which connection will be closed
+     * 
+     * @return
+     */
+    public int getMaxNumberOfRejectedRequestPerConnection() {
+        return maxNumberOfRejectedRequestPerConnection;
+    }
+
+    /**
+     * Set max number of broker-rejected requests in a certain time-frame (30 seconds) after which current connection
+     * will be closed and client creates a new connection that give chance to connect a different broker <i>(default:
+     * 50)</i>
+     * 
+     * @param maxNumberOfRejectedRequestPerConnection
+     */
+    public void setMaxNumberOfRejectedRequestPerConnection(int maxNumberOfRejectedRequestPerConnection) {
+        this.maxNumberOfRejectedRequestPerConnection = maxNumberOfRejectedRequestPerConnection;
+    }
+
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BinaryProtoLookupService.java
@@ -144,7 +144,8 @@ class BinaryProtoLookupService implements LookupService {
                                     lookupDataResult.redirect, lookupDataResult.partitions, e.getMessage())));
                 }
             }).exceptionally((e) -> {
-                log.warn("[{}] failed to get Partitioned metadata : {}", destination.toString(), e.getMessage(), e);
+                log.warn("[{}] failed to get Partitioned metadata : {}", destination.toString(),
+                        e.getCause().getMessage(), e);
                 partitionFuture.completeExceptionally(e);
                 return null;
             });

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -21,6 +21,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ import com.yahoo.pulsar.common.util.collections.ConcurrentLongHashMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.Promise;
 
 public class ClientCnx extends PulsarHandler {
@@ -61,6 +63,12 @@ public class ClientCnx extends PulsarHandler {
 
     private final CompletableFuture<Void> connectionFuture = new CompletableFuture<Void>();
     private final Semaphore pendingLookupRequestSemaphore;
+    private final EventLoopGroup eventLoopGroup;
+    private static final AtomicIntegerFieldUpdater<ClientCnx> NUMBER_OF_REJECTED_REQUESTS_UPDATER = AtomicIntegerFieldUpdater
+            .newUpdater(ClientCnx.class, "numberOfRejectRequests");
+    private volatile int numberOfRejectRequests = 0;
+    private final int maxNumberOfRejectedRequestPerConnection;
+    private final int rejectedRequestResetTimeSec = 60;
 
     enum State {
         None, SentConnectFrame, Ready
@@ -70,8 +78,10 @@ public class ClientCnx extends PulsarHandler {
         super(30, TimeUnit.SECONDS);
         this.pendingLookupRequestSemaphore = new Semaphore(pulsarClient.getConfiguration().getConcurrentLookupRequest(),
                 true);
-        authentication = pulsarClient.getConfiguration().getAuthentication();
-        state = State.None;
+        this.authentication = pulsarClient.getConfiguration().getAuthentication();
+        this.eventLoopGroup = pulsarClient.eventLoopGroup();
+        this.maxNumberOfRejectedRequestPerConnection = pulsarClient.getConfiguration().getMaxNumberOfRejectedRequestPerConnection();
+        this.state = State.None;
     }
 
     @Override
@@ -109,7 +119,7 @@ public class ClientCnx extends PulsarHandler {
 
         // Fail out all the pending ops
         pendingRequests.forEach((key, future) -> future.completeExceptionally(e));
-        pendingLookupRequests.forEach((key, future) -> getAndRemovePendingLookupRequest(key).completeExceptionally(e));
+        pendingLookupRequests.forEach((key, future) -> future.completeExceptionally(e));
 
         // Notify all attached producers/consumers so they have a chance to reconnect
         producers.forEach((id, producer) -> producer.connectionClosed(this));
@@ -212,6 +222,7 @@ public class ClientCnx extends PulsarHandler {
             // Complete future with exception if : Result.response=fail/null
             if (!lookupResult.hasResponse() || CommandLookupTopicResponse.LookupType.Failed.equals(lookupResult.getResponse())) {
                 if (lookupResult.hasError()) {
+                    checkServerError(lookupResult.getError(), lookupResult.getMessage());
                     requestFuture.completeExceptionally(
                             getPulsarClientException(lookupResult.getError(), lookupResult.getMessage()));
                 } else {
@@ -240,6 +251,7 @@ public class ClientCnx extends PulsarHandler {
             // Complete future with exception if : Result.response=fail/null
             if (!lookupResult.hasResponse() || CommandPartitionedTopicMetadataResponse.LookupType.Failed.equals(lookupResult.getResponse())) {
                 if (lookupResult.hasError()) {
+                    checkServerError(lookupResult.getError(), lookupResult.getMessage());
                     requestFuture.completeExceptionally(
                             getPulsarClientException(lookupResult.getError(), lookupResult.getMessage()));
                 } else {
@@ -338,6 +350,7 @@ public class ClientCnx extends PulsarHandler {
                 if (!writeFuture.isSuccess()) {
                     log.warn("{} Failed to send request {} to broker: {}", ctx.channel(), requestId,
                             writeFuture.cause().getMessage());
+                    getAndRemovePendingLookupRequest(requestId);
                     future.completeExceptionally(writeFuture.cause());
                 }
             });
@@ -377,12 +390,42 @@ public class ClientCnx extends PulsarHandler {
         ctx.writeAndFlush(cmd).addListener(writeFuture -> {
             if (!writeFuture.isSuccess()) {
                 log.warn("{} Failed to send request to broker: {}", ctx.channel(), writeFuture.cause().getMessage());
+                pendingRequests.remove(requestId);
                 future.completeExceptionally(writeFuture.cause());
             }
         });
         return future;
     }
 
+    /**
+     * check serverError and take appropriate action
+     * <ul>
+     * <li>InternalServerError: close connection immediately</li>
+     * <li>TooManyRequest: received error count is more than maxNumberOfRejectedRequestPerConnection in
+     * #rejectedRequestResetTimeSec</li>
+     * </ul>
+     * 
+     * @param error
+     * @param errMsg
+     */
+    private void checkServerError(ServerError error, String errMsg) {
+        if (ServerError.ServiceNotReady.equals(error)) {
+            log.error("{} Close connection becaues received internal-server error {}", ctx.channel(), errMsg);
+            ctx.close();
+        } else if (ServerError.TooManyRequests.equals(error)) {
+            long rejectedRequests = NUMBER_OF_REJECTED_REQUESTS_UPDATER.getAndIncrement(this);
+            if (rejectedRequests == 0) {
+                // schedule timer
+                eventLoopGroup.schedule(() -> NUMBER_OF_REJECTED_REQUESTS_UPDATER.set(ClientCnx.this, 0),
+                        rejectedRequestResetTimeSec, TimeUnit.SECONDS);
+            } else if (rejectedRequests >= maxNumberOfRejectedRequestPerConnection) {
+                log.error("{} Close connection becaues received {} rejected request in {} seconds ", ctx.channel(),
+                        NUMBER_OF_REJECTED_REQUESTS_UPDATER.get(ClientCnx.this), rejectedRequestResetTimeSec);
+                ctx.close();
+            }
+        }
+    }
+    
     void registerConsumer(final long consumerId, final ConsumerImpl consumer) {
         consumers.put(consumerId, consumer);
     }


### PR DESCRIPTION
### Motivation

Client creates a dedicated binary-proto lookup connection with one broker and there could be a possibility
- Broker is in bad state: it always gives InternalServerError 
- Broker is overloaded by lookup-request from other clients
In that case, client should close the existing connection and try to recreate which may end up with new connection with other broker and do successful lookup.

### Modifications

check serverError and take appropriate action
- InternalServerError: close connection immediately
- TooManyRequest: received error count is more than maxNumberOfRejectedRequestPerConnection in certain time-frame

### Result

Client can recreate connection with different broker if it is not able to getting successful response from one particular broker.


**NOTE**
I  have created this PR on top of #181 changes as it requires ServerSide throttling.
So, this PR depends on #181 and we need to merge #181 first.