### PR TITLE
Enable ML binary format from broker configuration

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -21,6 +21,8 @@ public class ManagedLedgerFactoryConfig {
     private long maxCacheSize = 128 * MB;
     private double cacheEvictionWatermark = 0.90;
 
+    private boolean useProtobufBinaryFormatInZK = false;
+
     public long getMaxCacheSize() {
         return maxCacheSize;
     }
@@ -48,6 +50,14 @@ public class ManagedLedgerFactoryConfig {
     public ManagedLedgerFactoryConfig setCacheEvictionWatermark(double cacheEvictionWatermark) {
         this.cacheEvictionWatermark = cacheEvictionWatermark;
         return this;
+    }
+
+    public boolean useProtobufBinaryFormatInZK() {
+        return useProtobufBinaryFormatInZK;
+    }
+
+    public void setUseProtobufBinaryFormatInZK(boolean useProtobufBinaryFormatInZK) {
+        this.useProtobufBinaryFormatInZK = useProtobufBinaryFormatInZK;
     }
 
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -170,7 +170,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private final ScheduledExecutorService scheduledExecutor;
     private final OrderedSafeExecutor executor;
-    private final ManagedLedgerFactoryImpl factory;
+    final ManagedLedgerFactoryImpl factory;
     protected final ManagedLedgerMBeanImpl mbean;
 
     /**

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -47,6 +47,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
+import org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper.ZNodeProtobufFormat;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -56,6 +57,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
@@ -65,6 +67,12 @@ import com.google.common.collect.Sets;
 public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
     private static final Charset Encoding = Charsets.UTF_8;
+    
+    @Factory(dataProvider = "protobufFormat")
+    public ManagedCursorTest(ZNodeProtobufFormat protobufFormat) {
+        super();
+        this.protobufFormat = protobufFormat;
+    }
 
     @Test(timeOut = 20000)
     void readFromEmptyLedger() throws Exception {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBinaryFormatConversion.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBinaryFormatConversion.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertEquals;
+
+import java.nio.charset.Charset;
+
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Charsets;
+
+public class ManagedLedgerBinaryFormatConversion extends MockedBookKeeperTestCase {
+
+    private static final Charset Encoding = Charsets.UTF_8;
+
+    @DataProvider(name = "gracefulClose")
+    public static Object[][] protobufFormat() {
+        return new Object[][] { { false }, { true } };
+    }
+
+    @Test(timeOut = 20000, dataProvider = "gracefulClose")
+    void textToBinary(boolean gracefulClose) throws Exception {
+        ManagedLedgerFactoryConfig textConf = new ManagedLedgerFactoryConfig();
+        textConf.setUseProtobufBinaryFormatInZK(false);
+        ManagedLedgerFactory textFactory = new ManagedLedgerFactoryImpl(bkc, zkc, textConf);
+        ManagedLedger ledger = textFactory.open("my_test_ledger");
+
+        ManagedCursor c1 = ledger.openCursor("c1");
+        ledger.addEntry("test-0".getBytes(Encoding));
+        Position p1 = ledger.addEntry("test-1".getBytes(Encoding));
+        ledger.addEntry("test-2".getBytes(Encoding));
+
+        c1.delete(p1);
+
+        if (gracefulClose) {
+            ledger.close();
+        }
+
+        // Reopen with binary format
+        ManagedLedgerFactoryConfig binaryConf = new ManagedLedgerFactoryConfig();
+        binaryConf.setUseProtobufBinaryFormatInZK(true);
+        ManagedLedgerFactory binaryFactory = new ManagedLedgerFactoryImpl(bkc, zkc, binaryConf);
+        ledger = binaryFactory.open("my_test_ledger");
+        c1 = ledger.openCursor("c1");
+
+        // The 'p1' entry was already deleted
+        assertEquals(c1.getNumberOfEntriesInBacklog(), 2);
+
+        textFactory.shutdown();
+        binaryFactory.shutdown();
+    }
+
+    @Test(timeOut = 20000, dataProvider = "gracefulClose")
+    void binaryToText(boolean gracefulClose) throws Exception {
+        ManagedLedgerFactoryConfig binaryConf = new ManagedLedgerFactoryConfig();
+        binaryConf.setUseProtobufBinaryFormatInZK(true);
+        ManagedLedgerFactory binaryFactory = new ManagedLedgerFactoryImpl(bkc, zkc, binaryConf);
+        ManagedLedger ledger = binaryFactory.open("my_test_ledger");
+        ManagedCursor c1 = ledger.openCursor("c1");
+
+        ledger.addEntry("test-0".getBytes(Encoding));
+        Position p1 = ledger.addEntry("test-1".getBytes(Encoding));
+        ledger.addEntry("test-2".getBytes(Encoding));
+
+        c1.delete(p1);
+
+        if (gracefulClose) {
+            ledger.close();
+        }
+
+        // Reopen with binary format
+
+        ManagedLedgerFactoryConfig textConf = new ManagedLedgerFactoryConfig();
+        textConf.setUseProtobufBinaryFormatInZK(false);
+        ManagedLedgerFactory textFactory = new ManagedLedgerFactoryImpl(bkc, zkc, textConf);
+        ledger = textFactory.open("my_test_ledger");
+        c1 = ledger.openCursor("c1");
+
+        // The 'p1' entry was already deleted
+        assertEquals(c1.getNumberOfEntriesInBacklog(), 2);
+
+        textFactory.shutdown();
+        binaryFactory.shutdown();
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -59,6 +59,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.Version;
+import org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper.ZNodeProtobufFormat;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.util.Pair;
@@ -69,6 +70,7 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
@@ -86,6 +88,12 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerTest.class);
 
     private static final Charset Encoding = Charsets.UTF_8;
+
+    @Factory(dataProvider = "protobufFormat")
+    public ManagedLedgerTest(ZNodeProtobufFormat protobufFormat) {
+        super();
+        this.protobufFormat = protobufFormat;
+    }
 
     @Test
     public void managedLedgerApi() throws Exception {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -21,7 +21,9 @@ import java.util.concurrent.Executors;
 
 import org.apache.bookkeeper.client.MockBookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper.ZNodeProtobufFormat;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.MockZooKeeper;
@@ -29,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 
 /**
  * A class runs several bookie servers for testing.
@@ -50,6 +53,8 @@ public abstract class MockedBookKeeperTestCase {
 
     protected OrderedSafeExecutor executor;
     protected ExecutorService cachedExecutor;
+    
+    protected ZNodeProtobufFormat protobufFormat = ZNodeProtobufFormat.Text;
 
     public MockedBookKeeperTestCase() {
         // By default start a 3 bookies cluster
@@ -58,6 +63,11 @@ public abstract class MockedBookKeeperTestCase {
 
     public MockedBookKeeperTestCase(int numBookies) {
         this.numBookies = numBookies;
+    }
+    
+    @DataProvider(name = "protobufFormat")
+    public static Object[][] protobufFormat() {
+        return new Object[][] { { ZNodeProtobufFormat.Text }, { ZNodeProtobufFormat.Binary } };
     }
 
     @BeforeMethod
@@ -73,7 +83,9 @@ public abstract class MockedBookKeeperTestCase {
 
         executor = new OrderedSafeExecutor(2, "test");
         cachedExecutor = Executors.newCachedThreadPool();
-        factory = new ManagedLedgerFactoryImpl(bkc, zkc);
+        ManagedLedgerFactoryConfig conf = new ManagedLedgerFactoryConfig();
+        conf.setUseProtobufBinaryFormatInZK(protobufFormat == ZNodeProtobufFormat.Binary);
+        factory = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
     }
 
     @AfterMethod


### PR DESCRIPTION
### Motivation

First part of changes needed for #281. Tool to access the data will come in separate PR.

### Modifications

Added config switch to enable protobuf binary format for ManagedLedger and ManagedCursor z-nodes.
