### PR TITLE
Release ping/pong command buffer

### DIFF
--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
@@ -66,6 +66,7 @@ import com.yahoo.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.RecyclableDuplicateByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.buffer.UnpooledHeapByteBuf;
 import io.netty.util.Recycler;
@@ -531,18 +532,34 @@ public class Commands {
         return res;
     }
 
-    private final static ByteBuf cmdPing = serializeWithSize(
-            BaseCommand.newBuilder().setType(Type.PING).setPing(CommandPing.getDefaultInstance()));
+    private final static ByteBuf cmdPing;
 
-    static ByteBuf newPing() {
-        return RecyclableDuplicateByteBuf.create(cmdPing).retain();
+    static {
+        ByteBuf serializedCmdPing = serializeWithSize(
+                   BaseCommand.newBuilder()
+                       .setType(Type.PING)
+                       .setPing(CommandPing.getDefaultInstance()));
+        cmdPing = Unpooled.copiedBuffer(serializedCmdPing);
+        serializedCmdPing.release();
     }
 
-    private final static ByteBuf cmdPong = serializeWithSize(
-            BaseCommand.newBuilder().setType(Type.PONG).setPong(CommandPong.getDefaultInstance()));
+    static ByteBuf newPing() {
+    	return RecyclableDuplicateByteBuf.create(cmdPing);
+    }
+
+    private final static ByteBuf cmdPong;
+
+    static {
+        ByteBuf serializedCmdPong = serializeWithSize(
+                   BaseCommand.newBuilder()
+                       .setType(Type.PONG)
+                       .setPong(CommandPong.getDefaultInstance()));
+        cmdPong = Unpooled.copiedBuffer(serializedCmdPong);
+        serializedCmdPong.release();
+    }
 
     static ByteBuf newPong() {
-        return RecyclableDuplicateByteBuf.create(cmdPong).retain();
+    	return RecyclableDuplicateByteBuf.create(cmdPong);
     }
 
     private static ByteBuf serializeWithSize(BaseCommand.Builder cmdBuilder) {


### PR DESCRIPTION
### Motivation

cmdPing and cmdPong are static ByteBuf which ideally does not required to be ref counted. We are wrapping it with another byteBuf which is released by netty. However, the original cmd buffer ref count increases to int max and server throws the following exception. This causes clients to close connection and reconnect and this cycle repeats until broker restart:

```
c.y.pulsar.broker.service.ServerCnx  - [-] Got exception: refCnt: 2147483647, increment: 1
io.netty.util.IllegalReferenceCountException: refCnt: 2147483647, increment: 1
        at io.netty.buffer.AbstractReferenceCountedByteBuf.retain(AbstractReferenceCountedByteBuf.java:66) ~[netty-all-4.0.39.Final.jar:4.0.39.Final]
        at io.netty.buffer.AbstractRecyclableDerivedByteBuf.init(AbstractRecyclableDerivedByteBuf.java:27) ~[pulsar-common-1.15.7.jar:4.0.39.Final]
        at io.netty.buffer.RecyclableDuplicateByteBuf.init(RecyclableDuplicateByteBuf.java:59) ~[pulsar-common-1.15.7.jar:4.0.39.Final]
        at io.netty.buffer.RecyclableDuplicateByteBuf.create(RecyclableDuplicateByteBuf.java:42) ~[pulsar-common-1.15.7.jar:4.0.39.Final]
        at com.yahoo.pulsar.common.api.Commands.newPong(Commands.java:416) ~[pulsar-common-1.15.7.jar:na]
        at com.yahoo.pulsar.common.api.PulsarHandler.handlePing(PulsarHandler.java:77) ~[pulsar-common-1.15.7.jar:na]
        at com.yahoo.pulsar.common.api.PulsarDecoder.channelRead(PulsarDecoder.java:183) ~[pulsar-common-1.15.7.jar:na]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366) [netty-all-4.0.39.Final.jar:4.0.39.Final]
```
### Modifications

Release the command buffer before returning.

### Result

Command buffer will not reach int max ref count and fail ping request.