### PR TITLE
reduce collection instances while generating metrics

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/NamespaceStats.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/NamespaceStats.java
@@ -15,13 +15,9 @@
  */
 package com.yahoo.pulsar.broker.stats;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import com.google.common.collect.Maps;
-import com.yahoo.pulsar.common.policies.data.PersistentSubscriptionStats;
-import com.yahoo.pulsar.common.policies.data.ReplicatorStats;
 
 public class NamespaceStats {
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -168,7 +168,7 @@ abstract class AbstractMetrics {
         return createMetrics(dimensionMap);
     }
 
-    protected void populateBucketEntries(Map<String, List<Double>> map, String mkey, double[] boundaries,
+    protected void populateBucketEntries(Map<String, Double> map, String mkey, double[] boundaries,
             long[] bucketValues) {
 
         // bucket values should be one more that the boundaries to have the last element as OVERFLOW
@@ -192,9 +192,10 @@ abstract class AbstractMetrics {
             value = (bucketValues == null) ? 0.0D : (double) bucketValues[i];
 
             if (!map.containsKey(bucketKey)) {
-                map.put(bucketKey, Lists.newArrayList(value));
+                map.put(bucketKey, value);
             } else {
-                map.get(bucketKey).add(value);
+                Double val = map.get(bucketKey);
+                map.put(bucketKey, val + value);
             }
         }
     }
@@ -207,6 +208,15 @@ abstract class AbstractMetrics {
         }
     }
 
+    protected void populateAggregationMapWithSum(Map<String, Double> map, String mkey, double value) {
+        if (!map.containsKey(mkey)) {
+            map.put(mkey, value);
+        } else {
+            Double val = map.get(mkey);
+            map.put(mkey, val + value);
+        }
+    }
+    
     protected void populateMaxMap(Map<String, Long> map, String mkey, long value) {
         Long existingValue = map.get(mkey);
         if (existingValue == null || value > existingValue) {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -191,12 +191,8 @@ abstract class AbstractMetrics {
 
             value = (bucketValues == null) ? 0.0D : (double) bucketValues[i];
 
-            if (!map.containsKey(bucketKey)) {
-                map.put(bucketKey, value);
-            } else {
-                Double val = map.get(bucketKey);
-                map.put(bucketKey, val + value);
-            }
+            Double val = map.getOrDefault(bucketKey, 0.0);
+            map.put(bucketKey, val + value);
         }
     }
 
@@ -209,12 +205,8 @@ abstract class AbstractMetrics {
     }
 
     protected void populateAggregationMapWithSum(Map<String, Double> map, String mkey, double value) {
-        if (!map.containsKey(mkey)) {
-            map.put(mkey, value);
-        } else {
-            Double val = map.get(mkey);
-            map.put(mkey, val + value);
-        }
+        Double val = map.getOrDefault(mkey, 0.0);
+        map.put(mkey, val + value);
     }
     
     protected void populateMaxMap(Map<String, Long> map, String mkey, long value) {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/metrics/ManagedLedgerCacheMetrics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/metrics/ManagedLedgerCacheMetrics.java
@@ -31,12 +31,14 @@ import io.netty.buffer.PooledByteBufAllocator;
 
 public class ManagedLedgerCacheMetrics extends AbstractMetrics {
 
+    private List<Metrics> metrics;
     public ManagedLedgerCacheMetrics(PulsarService pulsar) {
         super(pulsar);
+        this.metrics = Lists.newArrayList();
     }
 
     @Override
-    public List<Metrics> generate() {
+    public synchronized List<Metrics> generate() {
 
         // get the ML cache stats bean
 
@@ -87,7 +89,9 @@ public class ManagedLedgerCacheMetrics extends AbstractMetrics {
         m.put("brk_ml_cache_pool_active_allocations_normal", activeAllocationsNormal);
         m.put("brk_ml_cache_pool_active_allocations_huge", activeAllocationsHuge);
 
-        return Lists.newArrayList(m);
+        metrics.clear();
+        metrics.add(m);
+        return metrics;
 
     }
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.stats;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.pulsar.broker.service.BrokerTestBase;
+import com.yahoo.pulsar.broker.stats.metrics.ManagedLedgerMetrics;
+import com.yahoo.pulsar.client.api.Producer;
+
+import junit.framework.Assert;
+
+/**
+ */
+public class ManagedLedgerMetricsTest extends BrokerTestBase {
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testManagedLedgerMetrics() throws Exception {
+        ManagedLedgerMetrics metrics = new ManagedLedgerMetrics(pulsar);
+
+        final String addEntryRateKey = "brk_ml_AddEntryMessagesRate";
+        List<Metrics> list1 = metrics.generate();
+        Assert.assertTrue(list1.isEmpty());
+
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        for (Entry<String, ManagedLedgerImpl> ledger : ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+                .getManagedLedgers().entrySet()) {
+            ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
+            stats.refreshStats(1, TimeUnit.SECONDS);
+        }
+
+        List<Metrics> list2 = metrics.generate();
+        Assert.assertEquals(list2.get(0).getMetrics().get(addEntryRateKey), 10.0D);
+
+        for (int i = 0; i < 5; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+        for (Entry<String, ManagedLedgerImpl> ledger : ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+                .getManagedLedgers().entrySet()) {
+            ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
+            stats.refreshStats(1, TimeUnit.SECONDS);
+        }
+        List<Metrics> list3 = metrics.generate();
+        Assert.assertEquals(list3.get(0).getMetrics().get(addEntryRateKey), 5.0D);
+
+    }
+
+}


### PR DESCRIPTION
### Motivation

Broker allocates multiple new collections on every managedLedgerStats request. If stats is being called very frequently then it will trigger gc more often. So, reduce creation of collections in stats-generation.

### Modifications

Reuse stats collections to avoid creation of new collections.

### Result

reduce frequent gc.
