### PR TITLE
Extending ZK version wrapper to include ctime and mtime

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -95,7 +95,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private final ConcurrentLongHashMap<CompletableFuture<LedgerHandle>> ledgerCache = new ConcurrentLongHashMap<>();
     private final NavigableMap<Long, LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
-    private Stat ledgersStat;
+    private volatile Stat ledgersStat;
 
     private final ManagedCursorContainer cursors = new ManagedCursorContainer();
     private final ManagedCursorContainer activeCursors = new ManagedCursorContainer();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -56,7 +56,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.VoidCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
-import org.apache.bookkeeper.mledger.impl.MetaStore.Version;
+import org.apache.bookkeeper.mledger.impl.MetaStore.Stat;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.util.CallbackMutex;
@@ -95,7 +95,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private final ConcurrentLongHashMap<CompletableFuture<LedgerHandle>> ledgerCache = new ConcurrentLongHashMap<>();
     private final NavigableMap<Long, LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
-    private Version ledgersVersion;
+    private Stat ledgersStat;
 
     private final ManagedCursorContainer cursors = new ManagedCursorContainer();
     private final ManagedCursorContainer activeCursors = new ManagedCursorContainer();
@@ -195,7 +195,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         NUMBER_OF_ENTRIES_UPDATER.set(this, 0);
         ENTRIES_ADDED_COUNTER_UPDATER.set(this, 0);
         STATE_UPDATER.set(this, State.None);
-        this.ledgersVersion = null;
+        this.ledgersStat = null;
         this.mbean = new ManagedLedgerMBeanImpl(this);
         this.entryCache = factory.getEntryCacheManager().getEntryCache(this);
         this.waitingCursors = Queues.newConcurrentLinkedQueue();
@@ -212,8 +212,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         // Fetch the list of existing ledgers in the managed ledger
         store.getManagedLedgerInfo(name, new MetaStoreCallback<ManagedLedgerInfo>() {
             @Override
-            public void operationComplete(ManagedLedgerInfo mlInfo, Version version) {
-                ledgersVersion = version;
+            public void operationComplete(ManagedLedgerInfo mlInfo, Stat stat) {
+                ledgersStat = stat;
                 for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
                     ledgers.put(ls.getLedgerId(), ls);
                 }
@@ -286,8 +286,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         final MetaStoreCallback<Void> storeLedgersCb = new MetaStoreCallback<Void>() {
             @Override
-            public void operationComplete(Void v, Version version) {
-                ledgersVersion = version;
+            public void operationComplete(Void v, Stat stat) {
+                ledgersStat = stat;
                 initializeCursors(callback);
             }
 
@@ -320,7 +320,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
                         ManagedLedgerInfo mlInfo = ManagedLedgerInfo.newBuilder().addAllLedgerInfo(ledgers.values())
                                 .build();
-                        store.asyncUpdateLedgerIds(name, mlInfo, ledgersVersion, storeLedgersCb);
+                        store.asyncUpdateLedgerIds(name, mlInfo, ledgersStat, storeLedgersCb);
                     }));
                 }, null);
     }
@@ -331,7 +331,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         store.getCursors(name, new MetaStoreCallback<List<String>>() {
             @Override
-            public void operationComplete(List<String> consumers, Version v) {
+            public void operationComplete(List<String> consumers, Stat s) {
                 // Load existing cursors
                 final AtomicInteger cursorCount = new AtomicInteger(consumers.size());
                 if (log.isDebugEnabled()) {
@@ -621,7 +621,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         // ledger from BK) don't, we end up having a loose ledger leaked but the state will be consistent.
         store.asyncRemoveCursor(ManagedLedgerImpl.this.name, consumerName, new MetaStoreCallback<Void>() {
             @Override
-            public void operationComplete(Void result, Version version) {
+            public void operationComplete(Void result, Stat stat) {
                 cursor.asyncDeleteCursorLedger();
                 cursors.removeCursor(consumerName);
 
@@ -951,13 +951,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
             final MetaStoreCallback<Void> cb = new MetaStoreCallback<Void>() {
                 @Override
-                public void operationComplete(Void v, Version version) {
+                public void operationComplete(Void v, Stat stat) {
                     if (log.isDebugEnabled()) {
-                        log.debug("[{}] Updating of ledgers list after create complete. version={}", name, version);
+                        log.debug("[{}] Updating of ledgers list after create complete. version={}", name, stat);
                     }
-                    ledgersVersion = version;
+                    ledgersStat = stat;
                     ledgersListMutex.unlock();
-                    updateLedgersIdsComplete(version);
+                    updateLedgersIdsComplete(stat);
                     synchronized (ManagedLedgerImpl.this) {
                         mbean.addLedgerSwitchLatencySample(System.nanoTime() - lastLedgerCreationInitiationTimestamp,
                                 TimeUnit.NANOSECONDS);
@@ -1013,12 +1013,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         ManagedLedgerInfo mlInfo = ManagedLedgerInfo.newBuilder().addAllLedgerInfo(ledgers.values()).build();
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Updating ledgers ids with new ledger. version={}", name, ledgersVersion);
+            log.debug("[{}] Updating ledgers ids with new ledger. version={}", name, ledgersStat);
         }
-        store.asyncUpdateLedgerIds(name, mlInfo, ledgersVersion, callback);
+        store.asyncUpdateLedgerIds(name, mlInfo, ledgersStat, callback);
     }
 
-    public synchronized void updateLedgersIdsComplete(Version version) {
+    public synchronized void updateLedgersIdsComplete(Stat stat) {
         STATE_UPDATER.set(this, State.LedgerOpened);
         lastLedgerCreatedTimestamp = System.currentTimeMillis();
 
@@ -1436,12 +1436,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 log.debug("[{}] Updating of ledgers list after trimming", name);
             }
             ManagedLedgerInfo mlInfo = ManagedLedgerInfo.newBuilder().addAllLedgerInfo(ledgers.values()).build();
-            store.asyncUpdateLedgerIds(name, mlInfo, ledgersVersion, new MetaStoreCallback<Void>() {
+            store.asyncUpdateLedgerIds(name, mlInfo, ledgersStat, new MetaStoreCallback<Void>() {
                 @Override
-                public void operationComplete(Void result, Version version) {
+                public void operationComplete(Void result, Stat stat) {
                     log.info("[{}] End TrimConsumedLedgers. ledgers={} totalSize={}", name, ledgers.size(),
                             TOTAL_SIZE_UPDATER.get(ManagedLedgerImpl.this));
-                    ledgersVersion = version;
+                    ledgersStat = stat;
                     ledgersListMutex.unlock();
                     trimmerMutex.unlock();
 
@@ -1593,7 +1593,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private void deleteMetadata(DeleteLedgerCallback callback, Object ctx) {
         store.removeManagedLedger(name, new MetaStoreCallback<Void>() {
             @Override
-            public void operationComplete(Void result, Version version) {
+            public void operationComplete(Void result, Stat stat) {
                 log.info("[{}] Successfully deleted managed ledger", name);
                 factory.close(ManagedLedgerImpl.this);
                 callback.deleteLedgerComplete(ctx);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
@@ -144,7 +144,7 @@ public class ManagedLedgerOfflineBacklog {
         store.getManagedLedgerInfo(managedLedgerName,
                 new MetaStore.MetaStoreCallback<MLDataFormats.ManagedLedgerInfo>() {
                     @Override
-                    public void operationComplete(MLDataFormats.ManagedLedgerInfo mlInfo, MetaStore.Version version) {
+                    public void operationComplete(MLDataFormats.ManagedLedgerInfo mlInfo, MetaStore.Stat version) {
                         for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ls : mlInfo.getLedgerInfoList()) {
                             ledgers.put(ls.getLedgerId(), ls);
                         }
@@ -227,7 +227,7 @@ public class ManagedLedgerOfflineBacklog {
 
         store.getCursors(managedLedgerName, new MetaStore.MetaStoreCallback<List<String>>() {
             @Override
-            public void operationComplete(List<String> cursors, MetaStore.Version v) {
+            public void operationComplete(List<String> cursors, MetaStore.Stat v) {
                 // Load existing cursors
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Found {} cursors", managedLedgerName, cursors.size());
@@ -333,7 +333,7 @@ public class ManagedLedgerOfflineBacklog {
                             new MetaStore.MetaStoreCallback<MLDataFormats.ManagedCursorInfo>() {
                                 @Override
                                 public void operationComplete(MLDataFormats.ManagedCursorInfo info,
-                                        MetaStore.Version version) {
+                                        MetaStore.Stat version) {
                                     long cursorLedgerId = info.getCursorsLedgerId();
                                     if (log.isDebugEnabled()) {
                                         log.debug("[{}] Cursor {} meta-data read ledger id {}", managedLedgerName,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
@@ -26,15 +26,18 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
  */
 public interface MetaStore {
 
-    public static interface Version {
+    public static interface Stat {
+        int getVersion();
+        long getCreationTimestamp();
+        long getModificationTimestamp();
     }
 
     public static interface UpdateLedgersIdsCallback {
-        void updateLedgersIdsComplete(MetaStoreException status, Version version);
+        void updateLedgersIdsComplete(MetaStoreException status, Stat stat);
     }
 
     public static interface MetaStoreCallback<T> {
-        void operationComplete(T result, Version version);
+        void operationComplete(T result, Stat stat);
 
         void operationFailed(MetaStoreException e);
     }
@@ -63,7 +66,7 @@ public interface MetaStore {
      * @param ctx
      *            opaque context object
      */
-    void asyncUpdateLedgerIds(String ledgerName, ManagedLedgerInfo mlInfo, Version version,
+    void asyncUpdateLedgerIds(String ledgerName, ManagedLedgerInfo mlInfo, Stat version,
             MetaStoreCallback<Void> callback);
 
     /**
@@ -98,7 +101,7 @@ public interface MetaStore {
      *            the callback
      * @throws MetaStoreException
      */
-    void asyncUpdateCursorInfo(String ledgerName, String cursorName, ManagedCursorInfo info, Version version,
+    void asyncUpdateCursorInfo(String ledgerName, String cursorName, ManagedCursorInfo info, Stat version,
             MetaStoreCallback<Void> callback);
 
     /**

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -58,7 +58,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
-import org.apache.bookkeeper.mledger.impl.MetaStore.Version;
+import org.apache.bookkeeper.mledger.impl.MetaStore.Stat;
 import org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper.ZNodeProtobufFormat;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
@@ -1473,7 +1473,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         final MetaStore store = factory.getMetaStore();
         store.getManagedLedgerInfo("my_test_ledger", new MetaStoreCallback<ManagedLedgerInfo>() {
             @Override
-            public void operationComplete(ManagedLedgerInfo result, Version version) {
+            public void operationComplete(ManagedLedgerInfo result, Stat version) {
                 // Update the list
                 ManagedLedgerInfo.Builder info = ManagedLedgerInfo.newBuilder(result);
                 info.clearLedgerInfo();
@@ -1482,7 +1482,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
                 store.asyncUpdateLedgerIds("my_test_ledger", info.build(), version, new MetaStoreCallback<Void>() {
                     @Override
-                    public void operationComplete(Void result, Version version) {
+                    public void operationComplete(Void result, Stat version) {
                         counter.countDown();
                     }
 
@@ -1725,7 +1725,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     @Test
     public void testBackwardCompatiblityForMeta() throws Exception {
         final ManagedLedgerInfo[] storedMLInfo = new ManagedLedgerInfo[3];
-        final Version[] versions = new Version[1];
+        final Stat[] versions = new Stat[1];
 
         ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(bkc, bkc.getZkHandle());
         ManagedLedgerConfig conf = new ManagedLedgerConfig();
@@ -1745,7 +1745,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         // obtain the ledger info
         store.getManagedLedgerInfo("backward_test_ledger", new MetaStoreCallback<ManagedLedgerInfo>() {
             @Override
-            public void operationComplete(ManagedLedgerInfo result, Version version) {
+            public void operationComplete(ManagedLedgerInfo result, Stat version) {
                 storedMLInfo[0] = result;
                 versions[0] = version;
                 l1.countDown();
@@ -1774,7 +1774,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         CountDownLatch l2 = new CountDownLatch(1);
         store.asyncUpdateLedgerIds("backward_test_ledger", storedMLInfo[1], versions[0], new MetaStoreCallback<Void>() {
             @Override
-            public void operationComplete(Void result, Version version) {
+            public void operationComplete(Void result, Stat version) {
                 l2.countDown();
             }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeperTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeperTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
-import org.apache.bookkeeper.mledger.impl.MetaStore.Version;
+import org.apache.bookkeeper.mledger.impl.MetaStore.Stat;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
@@ -58,7 +58,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
 
         store.removeManagedLedger("non-existing", new MetaStoreCallback<Void>() {
             @Override
-            public void operationComplete(Void result, Version version) {
+            public void operationComplete(Void result, Stat version) {
                 counter.countDown();
             }
 
@@ -89,7 +89,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                 latch.countDown();
             }
 
-            public void operationComplete(ManagedLedgerInfo result, Version version) {
+            public void operationComplete(ManagedLedgerInfo result, Stat version) {
                 fail("Operation should have failed");
             }
         });
@@ -113,7 +113,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                 latch.countDown();
             }
 
-            public void operationComplete(ManagedCursorInfo result, Version version) {
+            public void operationComplete(ManagedCursorInfo result, Stat version) {
                 fail("Operation should have failed");
             }
         });
@@ -135,7 +135,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                 latch.countDown();
             }
 
-            public void operationComplete(ManagedLedgerInfo result, Version version) {
+            public void operationComplete(ManagedLedgerInfo result, Stat version) {
                 fail("Operation should have failed");
             }
         });
@@ -157,7 +157,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                 fail("should have succeeded");
             }
 
-            public void operationComplete(Void result, Version version) {
+            public void operationComplete(Void result, Stat version) {
                 // Update again using the version
                 zkc.failNow(Code.CONNECTIONLOSS);
 
@@ -169,7 +169,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                     }
 
                     @Override
-                    public void operationComplete(Void result, Version version) {
+                    public void operationComplete(Void result, Stat version) {
                         fail("should have failed");
                     }
                 });
@@ -192,7 +192,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                 fail("should have succeeded");
             }
 
-            public void operationComplete(ManagedLedgerInfo mlInfo, Version version) {
+            public void operationComplete(ManagedLedgerInfo mlInfo, Stat version) {
                 // Update again using the version
                 zkc.failNow(Code.BADVERSION);
 
@@ -203,7 +203,7 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
                     }
 
                     @Override
-                    public void operationComplete(Void result, Version version) {
+                    public void operationComplete(Void result, Stat version) {
                         fail("should have failed");
                     }
                 });


### PR DESCRIPTION
### Motivation

To represent all the information related to a managed ledger and cursor z-nodes, without recurring to log in with `zoosh`, we need to collect more information about the z-nodes themselves.

In particular, two very useful data points are the creation and last modification times of a particular z-node.

Changes in this PR will be used in subsequent PR to add a REST interface to expose ML internal data.

### Modifications

Extended the original `Version` opaque interface in `MetaStore` with a new `Stat` interface that gets populated when doing ZK get/set operations.
