### PR TITLE
Added REST and CLI tool to expose ManagedLedger metadata

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -110,4 +110,10 @@ public interface AsyncCallbacks {
         public void resetFailed(ManagedLedgerException exception, Object ctx);
     }
 
+    public interface ManagedLedgerInfoCallback {
+        public void getInfoComplete(ManagedLedgerInfo info, Object ctx);
+
+        public void getInfoFailed(ManagedLedgerException exception, Object ctx);
+    }
+
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -15,6 +15,7 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 
 import com.google.common.annotations.Beta;
@@ -77,6 +78,30 @@ public interface ManagedLedgerFactory {
      *            opaque context
      */
     public void asyncOpen(String name, ManagedLedgerConfig config, OpenLedgerCallback callback, Object ctx);
+
+    /**
+     * Get the current metadata info for a managed ledger
+     *
+     * @param name
+     *            the unique name that identifies the managed ledger
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    public ManagedLedgerInfo getManagedLedgerInfo(String name) throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Asynchronously get the current metadata info for a managed ledger
+     *
+     * @param name
+     *            the unique name that identifies the managed ledger
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    public void asyncGetManagedLedgerInfo(String name, ManagedLedgerInfoCallback callback, Object ctx);
 
     /**
      * Releases all the resources maintained by the ManagedLedgerFactory

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.List;
+import java.util.Map;
+
+public class ManagedLedgerInfo {
+    /** Z-Node version */
+    public int version;
+    public String creationDate;
+    public String modificationDate;
+
+    public List<LedgerInfo> ledgers;
+
+    public Map<String, CursorInfo> cursors;
+
+    public static class LedgerInfo {
+        public long ledgerId;
+        public Long entries;
+        public Long size;
+        public Long timestamp;
+    }
+
+    public static class CursorInfo {
+        /** Z-Node version */
+        public int version;
+        public String creationDate;
+        public String modificationDate;
+
+        // If the ledger id is -1, then the mark-delete position is
+        // the one from the (ledgerId, entryId) snapshot below
+        public long cursorsLedgerId;
+
+        // Last snapshot of the mark-delete position
+        public PositionInfo markDelete;
+        public List<MessageRangeInfo> individualDeletedMessages;
+    }
+
+    public static class PositionInfo {
+        public long ledgerId;
+        public long entryId;
+
+        @Override
+        public String toString() {
+            return String.format("%d:%d", ledgerId, entryId);
+        }
+    }
+
+    public static class MessageRangeInfo {
+        // Starting of the range (not included)
+        public PositionInfo from = new PositionInfo();
+
+        // End of the range (included)
+        public PositionInfo to = new PositionInfo();
+
+        @Override
+        public String toString() {
+            return String.format("(%s, %s]", from, to);
+        }
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -17,9 +17,15 @@ package org.apache.bookkeeper.mledger.impl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -30,15 +36,28 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryMXBean;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo.CursorInfo;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo.LedgerInfo;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo.MessageRangeInfo;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo.PositionInfo;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.ManagedLedgerInitializeLedgerCallback;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.State;
+import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
+import org.apache.bookkeeper.mledger.impl.MetaStore.Stat;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
+import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -290,6 +309,133 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         entryCacheManager.clear();
     }
 
+    @Override
+    public ManagedLedgerInfo getManagedLedgerInfo(String name) throws InterruptedException, ManagedLedgerException {
+        class Result {
+            ManagedLedgerInfo info = null;
+            ManagedLedgerException e = null;
+        }
+        final Result r = new Result();
+        final CountDownLatch latch = new CountDownLatch(1);
+        asyncGetManagedLedgerInfo(name, new ManagedLedgerInfoCallback() {
+            @Override
+            public void getInfoComplete(ManagedLedgerInfo info, Object ctx) {
+                r.info = info;
+                latch.countDown();
+            }
+
+            @Override
+            public void getInfoFailed(ManagedLedgerException exception, Object ctx) {
+                r.e = exception;
+                latch.countDown();
+            }
+        }, null);
+
+        latch.await();
+
+        if (r.e != null) {
+            throw r.e;
+        }
+        return r.info;
+    }
+
+    @Override
+    public void asyncGetManagedLedgerInfo(String name, ManagedLedgerInfoCallback callback, Object ctx) {
+        store.getManagedLedgerInfo(name, new MetaStoreCallback<MLDataFormats.ManagedLedgerInfo>() {
+            @Override
+            public void operationComplete(MLDataFormats.ManagedLedgerInfo pbInfo, Stat stat) {
+                ManagedLedgerInfo info = new ManagedLedgerInfo();
+                info.version = stat.getVersion();
+                info.creationDate = DATE_FORMAT.format(Instant.ofEpochMilli(stat.getCreationTimestamp()));
+                info.modificationDate = DATE_FORMAT.format(Instant.ofEpochMilli(stat.getModificationTimestamp()));
+
+                info.ledgers = new ArrayList<>(pbInfo.getLedgerInfoCount());
+                for (int i = 0; i < pbInfo.getLedgerInfoCount(); i++) {
+                    MLDataFormats.ManagedLedgerInfo.LedgerInfo pbLedgerInfo = pbInfo.getLedgerInfo(i);
+                    LedgerInfo ledgerInfo = new LedgerInfo();
+                    ledgerInfo.ledgerId = pbLedgerInfo.getLedgerId();
+                    ledgerInfo.entries = pbLedgerInfo.hasEntries() ? pbLedgerInfo.getEntries() : null;
+                    ledgerInfo.size = pbLedgerInfo.hasSize() ? pbLedgerInfo.getSize() : null;
+                    info.ledgers.add(ledgerInfo);
+                }
+
+                store.getCursors(name, new MetaStoreCallback<List<String>>() {
+                    @Override
+                    public void operationComplete(List<String> cursorsList, Stat stat) {
+                        // Get the info for each cursor
+                        info.cursors = new ConcurrentSkipListMap<>();
+                        List<CompletableFuture<Void>> cursorsFutures = new ArrayList<>();
+
+                        for (String cursorName : cursorsList) {
+                            CompletableFuture<Void> cursorFuture = new CompletableFuture<>();
+                            cursorsFutures.add(cursorFuture);
+                            store.asyncGetCursorInfo(name, cursorName,
+                                    new MetaStoreCallback<MLDataFormats.ManagedCursorInfo>() {
+                                        @Override
+                                        public void operationComplete(ManagedCursorInfo pbCursorInfo, Stat stat) {
+                                            CursorInfo cursorInfo = new CursorInfo();
+                                            cursorInfo.version = stat.getVersion();
+                                            cursorInfo.creationDate = DATE_FORMAT
+                                                    .format(Instant.ofEpochMilli(stat.getCreationTimestamp()));
+                                            cursorInfo.modificationDate = DATE_FORMAT
+                                                    .format(Instant.ofEpochMilli(stat.getModificationTimestamp()));
+
+                                            cursorInfo.cursorsLedgerId = pbCursorInfo.getCursorsLedgerId();
+
+                                            if (pbCursorInfo.hasMarkDeleteLedgerId()) {
+                                                cursorInfo.markDelete = new PositionInfo();
+                                                cursorInfo.markDelete.ledgerId = pbCursorInfo.getMarkDeleteLedgerId();
+                                                cursorInfo.markDelete.entryId = pbCursorInfo.getMarkDeleteEntryId();
+                                            }
+
+                                            if (pbCursorInfo.getIndividualDeletedMessagesCount() > 0) {
+                                                cursorInfo.individualDeletedMessages = new ArrayList<>();
+                                                for (int i = 0; i < pbCursorInfo
+                                                        .getIndividualDeletedMessagesCount(); i++) {
+                                                    MessageRange range = pbCursorInfo.getIndividualDeletedMessages(i);
+                                                    MessageRangeInfo rangeInfo = new MessageRangeInfo();
+                                                    rangeInfo.from.ledgerId = range.getLowerEndpoint().getLedgerId();
+                                                    rangeInfo.from.entryId = range.getLowerEndpoint().getEntryId();
+                                                    rangeInfo.to.ledgerId = range.getUpperEndpoint().getLedgerId();
+                                                    rangeInfo.to.entryId = range.getUpperEndpoint().getEntryId();
+                                                    cursorInfo.individualDeletedMessages.add(rangeInfo);
+                                                }
+                                            }
+
+                                            info.cursors.put(cursorName, cursorInfo);
+                                            cursorFuture.complete(null);
+                                        }
+
+                                        @Override
+                                        public void operationFailed(MetaStoreException e) {
+                                            cursorFuture.completeExceptionally(e);
+                                        }
+                                    });
+                        }
+
+                        Futures.waitForAll(cursorsFutures).thenRun(() -> {
+                            // Completed all the cursors info
+                            callback.getInfoComplete(info, ctx);
+                        }).exceptionally((ex) -> {
+                            callback.getInfoFailed(new ManagedLedgerException(ex), ctx);
+                            return null;
+                        });
+                    }
+
+                    @Override
+                    public void operationFailed(MetaStoreException e) {
+                        callback.getInfoFailed(e, ctx);
+                    }
+                });
+            }
+
+            @Override
+            public void operationFailed(MetaStoreException e) {
+                callback.getInfoFailed(e, ctx);
+            }
+        });
+    }
+
     public MetaStore getMetaStore() {
         return store;
     }
@@ -311,4 +457,6 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     }
 
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerFactoryImpl.class);
+    
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.nio.charset.Charset;
+
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo.CursorInfo;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo.MessageRangeInfo;
+import org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper.ZNodeProtobufFormat;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Charsets;
+
+public class ManagedLedgerFactoryTest extends MockedBookKeeperTestCase {
+
+    private static final Charset Encoding = Charsets.UTF_8;
+
+    @Factory(dataProvider = "protobufFormat")
+    public ManagedLedgerFactoryTest(ZNodeProtobufFormat protobufFormat) {
+        super();
+        this.protobufFormat = protobufFormat;
+    }
+
+    @Test(timeOut = 20000)
+    public void testGetManagedLedgerInfoWithClose() throws Exception {
+        ManagedLedgerConfig conf = new ManagedLedgerConfig();
+        conf.setMaxEntriesPerLedger(1);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("testGetManagedLedgerInfo", conf);
+        ManagedCursor c1 = ledger.openCursor("c1");
+
+        PositionImpl p1 = (PositionImpl) ledger.addEntry("entry1".getBytes());
+        PositionImpl p2 = (PositionImpl) ledger.addEntry("entry2".getBytes());
+        PositionImpl p3 = (PositionImpl) ledger.addEntry("entry3".getBytes());
+        ledger.addEntry("entry4".getBytes());
+
+        c1.delete(p2);
+        c1.delete(p3);
+
+        ledger.close();
+
+        ManagedLedgerInfo info = factory.getManagedLedgerInfo("testGetManagedLedgerInfo");
+
+        assertEquals(info.ledgers.size(), 4);
+
+        assertEquals(info.ledgers.get(0).ledgerId, 3);
+        assertEquals(info.ledgers.get(1).ledgerId, 5);
+        assertEquals(info.ledgers.get(2).ledgerId, 6);
+        assertEquals(info.ledgers.get(3).ledgerId, 7);
+
+        assertEquals(info.cursors.size(), 1);
+
+        CursorInfo cursorInfo = info.cursors.get("c1");
+        assertEquals(cursorInfo.markDelete.ledgerId, 3);
+        assertEquals(cursorInfo.markDelete.entryId, -1);
+
+        if (protobufFormat == ZNodeProtobufFormat.Binary) {
+            assertEquals(cursorInfo.individualDeletedMessages.size(), 1);
+
+            MessageRangeInfo mri = cursorInfo.individualDeletedMessages.get(0);
+            assertEquals(mri.from.ledgerId, p1.getLedgerId());
+            assertEquals(mri.from.entryId, p1.getEntryId());
+            assertEquals(mri.to.ledgerId, p3.getLedgerId());
+            assertEquals(mri.to.entryId, p3.getEntryId());
+        } else {
+            assertNull(cursorInfo.individualDeletedMessages);
+        }
+    }
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -16,6 +16,7 @@
 package com.yahoo.pulsar.broker.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.yahoo.pulsar.common.util.Codec.decode;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -41,14 +42,19 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
 
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerOfflineBacklog;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -87,7 +93,6 @@ import com.yahoo.pulsar.common.policies.data.PersistentOfflineTopicStats;
 import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
 import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
 import com.yahoo.pulsar.common.policies.data.Policies;
-import static com.yahoo.pulsar.common.util.Codec.decode;
 import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 
 import io.netty.buffer.ByteBuf;
@@ -527,6 +532,34 @@ public class PersistentTopics extends AdminResource {
         validateAdminOperationOnDestination(dn, authoritative);
         PersistentTopic topic = getTopicReference(dn);
         return topic.getInternalStats();
+    }
+
+    @GET
+    @Path("{property}/{cluster}/{namespace}/{destination}/internal-info")
+    @ApiOperation(value = "Get the internal stats for the topic.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic does not exist") })
+    public void getManagedLedgerInfo(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
+            @Suspended AsyncResponse asyncResponse) {
+        destination = decode(destination);
+        DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        validateAdminAccessOnProperty(dn.getProperty());
+
+        String managedLedger = dn.getPersistenceNamingEncoding();
+        pulsar().getManagedLedgerFactory().asyncGetManagedLedgerInfo(managedLedger, new ManagedLedgerInfoCallback() {
+            @Override
+            public void getInfoComplete(ManagedLedgerInfo info, Object ctx) {
+                asyncResponse.resume((StreamingOutput) output -> {
+                    jsonMapper().writer().writeValue(output, info);
+                });
+            }
+
+            @Override
+            public void getInfoFailed(ManagedLedgerException exception, Object ctx) {
+                asyncResponse.resume(exception);
+            }
+        }, null);
     }
 
     @GET

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.omg.CosNaming.NamingContextPackage.NotFound;
 
+import com.google.gson.JsonObject;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.ConflictException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.NotAllowedException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
@@ -398,6 +399,36 @@ public interface PersistentTopics {
      * @return a future that can be used to track when the internal topic statistics are returned
      */
     CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String destination);
+
+    /**
+     * Get a JSON representation of the topic metadata stored in ZooKeeper
+     *
+     * @param destination
+     *            Destination name
+     * @return the topic internal metadata
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    JsonObject getInternalInfo(String destination) throws PulsarAdminException;
+
+    /**
+     * Get a JSON representation of the topic metadata stored in ZooKeeper
+     *
+     * @param destination
+     *            Destination name
+     * @return a future to receive the topic internal metadata
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    CompletableFuture<JsonObject> getInternalInfoAsync(String destination);
 
     /**
      * Get the stats for the partitioned topic

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
@@ -21,9 +21,12 @@ import java.util.concurrent.TimeUnit;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.CommaParameterSplitter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.yahoo.pulsar.client.admin.PersistentTopics;
 import com.yahoo.pulsar.client.admin.PulsarAdmin;
 import com.yahoo.pulsar.client.admin.PulsarAdminException;
-import com.yahoo.pulsar.client.admin.PersistentTopics;
 import com.yahoo.pulsar.client.api.Message;
 import com.yahoo.pulsar.client.impl.MessageIdImpl;
 
@@ -49,6 +52,7 @@ public class CmdPersistentTopics extends CmdBase {
         jcommander.addCommand("unsubscribe", new DeleteSubscription());
         jcommander.addCommand("stats", new GetStats());
         jcommander.addCommand("stats-internal", new GetInternalStats());
+        jcommander.addCommand("info-internal", new GetInternalInfo());
         jcommander.addCommand("partitioned-stats", new GetPartitionedStats());
         jcommander.addCommand("skip", new Skip());
         jcommander.addCommand("skip-all", new SkipAll());
@@ -245,6 +249,20 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             print(persistentTopics.getInternalStats(persistentTopic));
+        }
+    }
+
+    @Parameters(commandDescription = "Get the internal metadata info for the topic")
+    private class GetInternalInfo extends CliCommand {
+        @Parameter(description = "persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            JsonObject result = persistentTopics.getInternalInfo(persistentTopic);
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            System.out.println(gson.toJson(result));
         }
     }
 

--- a/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -359,6 +359,9 @@ public class PulsarAdminToolTest {
         topics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1");
 
+        topics.run(split("info-internal persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).getInternalInfo("persistent://myprop/clust/ns1/ds1");
+
         topics.run(split("partitioned-stats persistent://myprop/clust/ns1/ds1 --per-partition"));
         verify(mockTopics).getPartitionedStats("persistent://myprop/clust/ns1/ds1", true);
 

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/ObjectMapperFactory.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/ObjectMapperFactory.java
@@ -15,8 +15,10 @@
  */
 package com.yahoo.pulsar.common.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import io.netty.util.concurrent.FastThreadLocal;
 
@@ -26,6 +28,7 @@ public class ObjectMapperFactory {
         // forward compatibility for the properties may go away in the future
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        mapper.setSerializationInclusion(Include.NON_NULL);
         return mapper;
     }
 


### PR DESCRIPTION
### Motivation

After enabling binary format for ManagedLedger metadata, we need a way to inspect 
the metadata, parsing the binary protobuf format.

### Modifications

Added REST, Java and CLI API to get the metadata dump. Any broker can answer the request, even if the ManagedLedger is not loaded at all. 

New added command is: 

```shell
$ bin/pulsar-admin persistent info-internal persistent://sample/standalone/ns1/my-topic
```

Output: 

```json
{
  "version": 8,
  "creationDate": "2017-03-13 21:00:56.594-0700",
  "modificationDate": "2017-03-13 23:14:20.308-0700",
  "ledgers": [
    {
      "ledgerId": 8
    }
  ],
  "cursors": {
    "sub": {
      "version": 8,
      "creationDate": "2017-03-13 21:00:56.844-0700",
      "modificationDate": "2017-03-13 23:15:21.236-0700",
      "cursorsLedgerId": -1,
      "markDelete": {
        "ledgerId": 8,
        "entryId": -1
      }
    }
  }
}
```