### PR TITLE
Check zk-version before removing ownership node

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnedBundle.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnedBundle.java
@@ -40,6 +40,7 @@ public class OwnedBundle {
     private static final AtomicIntegerFieldUpdater<OwnedBundle> IS_ACTIVE_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(OwnedBundle.class, "isActive");
     private volatile int isActive = TRUE;
+    private volatile int version = -1;
 
     /**
      * constructor
@@ -147,5 +148,13 @@ public class OwnedBundle {
 
     public void setActive(boolean active) {
         IS_ACTIVE_UPDATER.set(this, active ? TRUE : FALSE);
+    }
+    
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
     }
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnershipCache.java
@@ -102,7 +102,7 @@ public class OwnershipCache {
      * The <code>NamespaceBundleFactory</code> to construct <code>NamespaceBundles</code>
      */
     private final NamespaceBundleFactory bundleFactory;
-    
+
     private class OwnedServiceUnitCacheLoader implements AsyncCacheLoader<String, OwnedBundle> {
 
         @SuppressWarnings("deprecation")

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -28,7 +28,6 @@ import static org.testng.Assert.fail;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.apache.zookeeper.KeeperException;
@@ -43,6 +42,7 @@ import com.yahoo.pulsar.broker.PulsarService;
 import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.broker.cache.LocalZooKeeperCacheService;
 import com.yahoo.pulsar.broker.service.BrokerService;
+import com.yahoo.pulsar.client.api.PulsarClientException;
 import com.yahoo.pulsar.common.naming.NamespaceBundle;
 import com.yahoo.pulsar.common.naming.NamespaceBundleFactory;
 import com.yahoo.pulsar.common.naming.NamespaceName;
@@ -258,7 +258,16 @@ public class OwnershipCacheTest {
         // case 1: no one owns the namespace
         assertFalse(cache.getOwnerAsync(bundle).get().isPresent());
 
-        cache.removeOwnership(bundle).get();
+        try {
+            // this broker doesn't own any bundle
+            cache.removeOwnership(bundle).get();
+        } catch (Exception e) {
+            // Ok
+            if (!(e.getCause() instanceof PulsarClientException)) {
+                fail("Should have failed with IllegalArgumentException instead " + e.getCause().getMessage());
+            }
+
+        }
         assertTrue(cache.getOwnedBundles().isEmpty());
 
         // case 2: this broker owns the namespace
@@ -280,4 +289,38 @@ public class OwnershipCacheTest {
         }
     }
 
+    /**
+     * It verifies that ownership-cache fails to remove ownership node if it has invalid version.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testRemoveOwnershipWithBadVersion() throws Exception {
+        OwnershipCache cache = new OwnershipCache(this.pulsar, bundleFactory);
+        NamespaceName testNs = new NamespaceName("pulsar/test/ns-7");
+        NamespaceBundle bundle = bundleFactory.getFullBundle(testNs);
+        // case 1: no one owns the namespace
+        assertFalse(cache.getOwnerAsync(bundle).get().isPresent());
+
+        assertTrue(cache.getOwnedBundles().isEmpty());
+
+        // case 2: this broker owns the namespace
+        NamespaceEphemeralData data1 = cache.tryAcquiringOwnership(bundle).get();
+        assertEquals(data1.getNativeUrl(), selfBrokerUrl);
+
+        // corrupt version
+        cache.getOwnedBundle(bundle).setVersion(20);
+
+        try {
+            cache.removeOwnership(bundle).get();
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Ok
+            if (!(e.getCause() instanceof KeeperException.BadVersionException)) {
+                fail("Should have failed with BadVersionException instead " + e.getCause().getMessage());
+            }
+        }
+    }
+    
+    
 }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -315,10 +315,7 @@ public class OwnershipCacheTest {
             cache.removeOwnership(bundle).get();
             fail("Should have failed");
         } catch (Exception e) {
-            // Ok
-            if (!(e.getCause() instanceof KeeperException.BadVersionException)) {
-                fail("Should have failed with BadVersionException instead " + e.getCause().getMessage());
-            }
+            assertEquals(e.getCause().getClass(), KeeperException.BadVersionException.class);
         }
     }
     


### PR DESCRIPTION
### Motivation

Right now, broker deletes Ownership znode without passing zk-version which may cause to delete znode even if that broker doesn't own it which can happen in n/w partition usecase.

### Modifications

Deletes ownership zk-node with previously read version.

### Result

It will prevent broker to delete ownership znode if broker doesn't own it which can also prevent split-brain issue for a given bundle as well.
