### PR TITLE
add api to increase partitions of existing non-global partitioned-topic

### DIFF
--- a/docs/AdminTools.md
+++ b/docs/AdminTools.md
@@ -55,6 +55,7 @@
 			- [get retention](#get-retention)
 		- [Persistent](#persistent)
 			- [create partitioned topic](#create-partitioned-topic)
+			- [update partitioned topic](#update-partitioned-topic)
 			- [get partitioned topic](#get-partitioned-topic)
 			- [delete partitioned topic](#delete-partitioned-topic)
 			- [Delete topic](#delete-topic)
@@ -1405,6 +1406,36 @@ PUT /admin/persistent/{property}/{cluster}/{namespace}/{destination}/partitions
 admin.persistentTopics().createPartitionedTopic(persistentTopic, numPartitions)
 ```
 
+#### update partitioned topic
+
+
+It updates number of partitions of an existing non-global partitioned topic. It requires partitioned-topic to be already 
+exist and number of new partitions must be greater than existing number of partitions. Decrementing number of partitions
+requires deletion of topic which is not supported.  
+
+###### CLI
+
+
+```
+$ pulsar-admin persistent update-partitioned-topic --partitions 4 persistent://test-property/cl1/ns1/pt1
+```
+
+```
+N/A
+```
+
+###### REST
+
+```
+POST /admin/persistent/{property}/{cluster}/{namespace}/{destination}/partitions
+```
+
+###### Java
+
+```java
+admin.persistentTopics().updatePartitionedTopic(persistentTopic, numPartitions)
+```
+
 #### get partitioned topic
 
 It gives metadata of created partitioned topic.  
@@ -2401,27 +2432,27 @@ In your terminal, go to below directory to play with client tool.
 <table>
   <tbody>
   <tr>
-      <td colspan="2">```pulsar-client produce```</td>   
+      <td colspan="2">pulsar-client produce</td>   
     </tr>
     <tr>
       <th>options</th>
       <th>description</th>   
     </tr>
     <tr>
-      <td>```-f, --files```</td>
-      <td>```Comma separated file paths to send. Cannot be used with -m. Either -f or -m must be provided```</td>
+      <td>-f, --files</td>
+      <td>Comma separated file paths to send. Cannot be used with -m. Either -f or -m must be provided</td>
     </tr>
     <tr>
-      <td>```-m, --messages```</td>
-      <td>```Comma separted string messages to send. Cannot be used with -f. Either -m or -f must be provided```</td>
+      <td>-m, --message`</td>
+      <td>Comma separted string messages to send. Cannot be used with -f. Either -m or -f must be provided</td>
     </tr>
     <tr>
-      <td>```-n, --num-produce```</td>
-      <td>```Number of times to send message(s), Default: 1```</td>
+      <td>-n, --num-produce</td>
+      <td>Number of times to send message(s), Default: 1</td>
     </tr>
     <tr>
-      <td>```-r, --rate```</td>
-      <td>```Rate (in msg/sec) at which to produce. Value of 0 will produce messages as fast as possible, Default: 0.0```</td>
+      <td>-r, --rate</td>
+      <td>Rate (in msg/sec) at which to produce. Value of 0 will produce messages as fast as possible, Default: 0.0</td>
     </tr>
 <table>
 
@@ -2429,30 +2460,30 @@ In your terminal, go to below directory to play with client tool.
 <table>
   <tbody>
   <tr>
-      <td colspan="2">```pulsar-client consume```</td>   
+      <td colspan="2">pulsar-client consume</td>   
     </tr>
     <tr>
       <th>options</th>
       <th>description</th>   
     </tr>
     <tr>
-      <td>```--hex```</td>
-      <td>```Display binary messages in hex, Default: false```</td>
+      <td>--hex</td>
+      <td>Display binary messages in hex, Default: false</td>
     </tr>
     <tr>
-      <td>```-n, --num-messages```</td>
-      <td>```Number of messages to consume, Default: 1```</td>
+      <td>-n, --num-messages</td>
+      <td>Number of messages to consume, Default: 1</td>
     </tr>
     <tr>
-      <td>```-r, --rate```</td>
-      <td>```Rate (in msg/sec) at which to consume. Value of 0 will consume messages as fast as possible, Default: 0.0```</td>
+      <td>-r, --rate</td>
+      <td>Rate (in msg/sec) at which to consume. Value of 0 will consume messages as fast as possible, Default: 0.0</td>
     </tr>
     <tr>
-      <td>```-s, --subscription-name```</td>
-      <td>```Subscription name```</td>
+      <td>-s, --subscription-name</td>
+      <td>Subscription name</td>
     </tr>
     <tr>
-      <td>```-t, --subscription-type```</td>
-      <td>```Subscription type: Exclusive, Shared, Failover, Default: Exclusive```</td>
+      <td>-t, --subscription-type</td>
+      <td>Subscription type: Exclusive, Shared, Failover, Default: Exclusive</td>
     </tr>
 <table>

--- a/docs/AdminTools.md
+++ b/docs/AdminTools.md
@@ -1411,7 +1411,10 @@ admin.persistentTopics().createPartitionedTopic(persistentTopic, numPartitions)
 
 It updates number of partitions of an existing non-global partitioned topic. It requires partitioned-topic to be already 
 exist and number of new partitions must be greater than existing number of partitions. Decrementing number of partitions
-requires deletion of topic which is not supported.  
+requires deletion of topic which is not supported.
+Already created partitioned producers and consumers can't see newly created partitions and it requires to recreate them at
+application so, newly created producers and consumers can connect to newly added partitions as well. Therefore, it can 
+violate partition ordering at producers until all producers are restarted at application.
 
 ###### CLI
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -56,8 +56,10 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerOfflineBacklog;
+import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
@@ -79,6 +81,7 @@ import com.yahoo.pulsar.broker.web.RestException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import com.yahoo.pulsar.client.api.PulsarClientException;
+import com.yahoo.pulsar.client.util.FutureUtil;
 import com.yahoo.pulsar.common.api.Commands;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.KeyValue;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.MessageMetadata;
@@ -94,6 +97,8 @@ import com.yahoo.pulsar.common.policies.data.PersistentOfflineTopicStats;
 import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
 import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
 import com.yahoo.pulsar.common.policies.data.Policies;
+import com.yahoo.pulsar.common.util.Codec;
+
 import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 
 import io.netty.buffer.ByteBuf;
@@ -387,6 +392,35 @@ public class PersistentTopics extends AdminResource {
         } catch (Exception e) {
             log.error("[{}] Failed to create partitioned topic {}", clientAppId(), dn, e);
             throw new RestException(e);
+        }
+    }
+
+    @POST
+    @Path("/{property}/{cluster}/{namespace}/{destination}/partitions")
+    @ApiOperation(value = "Increment partitons of an existing partitioned topic.", notes = "It only increments partitions of existing non-global partitioned-topic")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 409, message = "Partitioned topic does not exist") })
+    public void updatePartitionedTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
+            int numPartitions) {
+        destination = decode(destination);
+        DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        validateAdminAccessOnProperty(dn.getProperty());
+        if (dn.isGlobal()) {
+            log.error("[{}] Update partitioned-topic is forbidden on global namespace {}", clientAppId(), dn);
+            throw new RestException(Status.FORBIDDEN, "Update forbidden on global namespace");
+        }
+        if (numPartitions <= 1) {
+            throw new RestException(Status.NOT_ACCEPTABLE, "Number of partitions should be more than 1");
+        }
+        try {
+            updatePartitionedTopic(dn, numPartitions).get();
+        } catch (Exception e) {
+            if (e.getCause() instanceof RestException) {
+                throw (RestException) e.getCause();
+            }
+            log.error("[{}] Failed to update partitioned topic {}", clientAppId(), dn, e.getCause());
+            throw new RestException(e.getCause());
         }
     }
 
@@ -1202,5 +1236,123 @@ public class PersistentTopics extends AdminResource {
         } catch (Exception e) {
             throw new RestException(Status.NOT_FOUND, "Replicator not found");
         }
+    }
+    
+    private CompletableFuture<Void> updatePartitionedTopic(DestinationName dn, int numPartitions) {
+        String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getProperty(), dn.getCluster(), dn.getNamespacePortion(),
+                domain(), dn.getEncodedLocalName());
+
+        CompletableFuture<Void> updatePartition = new CompletableFuture<>();
+        createSubscriptions(dn, numPartitions).thenAccept(res -> {
+            try {
+                byte[] data = jsonMapper().writeValueAsBytes(new PartitionedTopicMetadata(numPartitions));
+                globalZk().setData(path, data, -1, (rc, path1, ctx, stat) -> {
+                    if (rc == KeeperException.Code.OK.intValue()) {
+                        updatePartition.complete(null);
+                    } else {
+                        updatePartition.completeExceptionally(KeeperException.create(KeeperException.Code.get(rc),
+                                "failed to create update partitions"));
+                    }
+                }, null);
+            } catch (Exception e) {
+                updatePartition.completeExceptionally(e);
+            }
+        }).exceptionally(ex -> {
+            updatePartition.completeExceptionally(ex);
+            return null;
+        });
+
+        return updatePartition;
+    }
+
+    /**
+     * It creates subscriptions for new partitions of existing partitioned-topics
+     * 
+     * @param dn : topic-name: persistent://prop/cluster/ns/topic
+     * @param numPartitions : number partitions for the topics 
+     */
+    private CompletableFuture<Void> createSubscriptions(DestinationName dn, int numPartitions) {
+        String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getProperty(), dn.getCluster(), dn.getNamespacePortion(),
+                domain(), dn.getEncodedLocalName());
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        fetchPartitionedTopicMetadataAsync(pulsar(), path).thenAccept(partitionMetadata -> {
+            if (partitionMetadata.partitions <= 1) {
+                result.completeExceptionally(new RestException(Status.CONFLICT, "Topic is not partitioned topic"));
+                return;
+            }
+
+            if (partitionMetadata.partitions >= numPartitions) {
+                result.completeExceptionally(new RestException(Status.CONFLICT,
+                        "number of partitions must be more than existing " + partitionMetadata.partitions));
+                return;
+            }
+
+            // get list of cursors name of partition-1
+            final String ledgerName = dn.getPartition(1).getPersistenceNamingEncoding();
+            ((ManagedLedgerFactoryImpl) pulsar().getManagedLedgerFactory()).getMetaStore().getCursors(ledgerName,
+                    new MetaStoreCallback<List<String>>() {
+
+                        @Override
+                        public void operationComplete(List<String> cursors,
+                                org.apache.bookkeeper.mledger.impl.MetaStore.Stat stat) {
+                            List<CompletableFuture<Void>> topicCreationFuture = Lists.newArrayList();
+                            // create subscriptions for all new partition-topics
+                            cursors.forEach(cursor -> {
+                                String subName = Codec.decode(cursor);
+                                for (int i = partitionMetadata.partitions; i < numPartitions; i++) {
+                                    final String topicName = dn.getPartition(i).toString();
+                                    CompletableFuture<Void> future = new CompletableFuture<>();
+                                    pulsar().getBrokerService().getTopic(topicName).handle((topic, ex) -> {
+                                        if (ex != null) {
+                                            log.warn("[{}] Failed to create topic {}", clientAppId(), topicName);
+                                            future.completeExceptionally(ex);
+                                            return null;
+                                        } else {
+                                            topic.createSubscription(subName).handle((sub, e) -> {
+                                                if (e != null) {
+                                                    log.warn("[{}] Failed to create subsciption {} {}", clientAppId(),
+                                                            topicName, subName);
+                                                    future.completeExceptionally(e);
+                                                    return null;
+                                                } else {
+                                                    log.info("[{}] Successfully create subsciption {} {}",
+                                                            clientAppId(), topicName, subName);
+                                                    // close topic
+                                                    topic.close();
+                                                    future.complete(null);
+                                                    return null;
+                                                }
+                                            });
+                                            return null;
+                                        }
+                                    });
+                                    topicCreationFuture.add(future);
+                                }
+                            });
+                            // wait for all subscriptions to be created
+                            FutureUtil.waitForAll(topicCreationFuture).handle((res, e) -> {
+                                if (e != null) {
+                                    result.completeExceptionally(e);
+                                } else {
+                                    log.info("[{}] Successfully create new partitions {}", clientAppId(),
+                                            dn.toString());
+                                    result.complete(null);
+                                }
+                                return null;
+                            });
+                        }
+
+                        @Override
+                        public void operationFailed(MetaStoreException ex) {
+                            log.warn("[{}] Failed to get list of cursors of {}", clientAppId(), ledgerName);
+                            result.completeExceptionally(ex);
+                        }
+                    });
+        }).exceptionally(ex -> {
+            log.warn("[{}] Failed to get partition metadata for {}", clientAppId(), dn.toString());
+            result.completeExceptionally(ex);
+            return null;
+        });
+        return result;
     }
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -395,6 +395,21 @@ public class PersistentTopics extends AdminResource {
         }
     }
 
+    /**
+     * It updates number of partitions of an existing non-global partitioned topic. It requires partitioned-topic to be
+     * already exist and number of new partitions must be greater than existing number of partitions. Decrementing
+     * number of partitions requires deletion of topic which is not supported.
+     * 
+     * Already created partitioned producers and consumers can't see newly created partitions and it requires to
+     * recreate them at application so, newly created producers and consumers can connect to newly added partitions as
+     * well. Therefore, it can violate partition ordering at producers until all producers are restarted at application.
+     * 
+     * @param property
+     * @param cluster
+     * @param namespace
+     * @param destination
+     * @param numPartitions
+     */
     @POST
     @Path("/{property}/{cluster}/{namespace}/{destination}/partitions")
     @ApiOperation(value = "Increment partitons of an existing partitioned topic.", notes = "It only increments partitions of existing non-global partitioned-topic")

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
@@ -41,6 +41,8 @@ public interface Topic {
 
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId);
+    
+    CompletableFuture<PersistentSubscription> createSubscription(String subscriptionName);
 
     CompletableFuture<Void> unsubscribe(String subName);
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -358,7 +358,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             lock.readLock().unlock();
         }
 
-        CompletableFuture<Subscription> subscriptionFuture = isDurable ? //
+        CompletableFuture<? extends Subscription> subscriptionFuture = isDurable ? //
                 getDurableSubscription(subscriptionName) //
                 : getNonDurableSubscription(subscriptionName, startMessageId);
 
@@ -402,7 +402,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return future;
     }
 
-    private CompletableFuture<Subscription> getDurableSubscription(String subscriptionName) {
+    private CompletableFuture<? extends Subscription> getDurableSubscription(String subscriptionName) {
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
         ledger.asyncOpenCursor(Codec.encode(subscriptionName), new OpenCursorCallback() {
             @Override
@@ -425,7 +425,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return subscriptionFuture;
     }
 
-    private CompletableFuture<Subscription> getNonDurableSubscription(String subscriptionName, MessageId startMessageId) {
+    private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName, MessageId startMessageId) {
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
 
         Subscription subscription = subscriptions.computeIfAbsent(subscriptionName, name -> {
@@ -449,6 +449,12 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         }
 
         return subscriptionFuture;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public CompletableFuture<PersistentSubscription> createSubscription(String subscriptionName) {
+        return (CompletableFuture<PersistentSubscription>) getDurableSubscription(subscriptionName);
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
@@ -192,6 +192,38 @@ public interface PersistentTopics {
      * @return a future that can be used to track when the partitioned topic is created
      */
     CompletableFuture<Void> createPartitionedTopicAsync(String destination, int numPartitions);
+    
+    /**
+     * Update number of partitions of a non-global partitioned topic.
+     * <p>
+     * It requires partitioned-topic to be already exist and number of new partitions must be greater than existing
+     * number of partitions. Decrementing number of partitions requires deletion of topic which is not supported.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     * @param numPartitions
+     *            Number of new partitions of already exist partitioned-topic
+     * 
+     * @return a future that can be used to track when the partitioned topic is updated
+     */
+    void updatePartitionedTopic(String destination, int numPartitions) throws PulsarAdminException;
+
+    /**
+     * Update number of partitions of a non-global partitioned topic asynchronously.
+     * <p>
+     * It requires partitioned-topic to be already exist and number of new partitions must be greater than existing
+     * number of partitions. Decrementing number of partitions requires deletion of topic which is not supported.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     * @param numPartitions
+     *            Number of new partitions of already exist partitioned-topic
+     * 
+     * @return a future that can be used to track when the partitioned topic is updated
+     */
+    CompletableFuture<Void> updatePartitionedTopicAsync(String destination, int numPartitions);
 
     /**
      * Get metadata of a partitioned topic.

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
@@ -146,6 +146,27 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
     }
 
     @Override
+    public void updatePartitionedTopic(String destination, int numPartitions) throws PulsarAdminException {
+        try {
+            updatePartitionedTopicAsync(destination, numPartitions).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> updatePartitionedTopicAsync(String destination, int numPartitions) {
+        checkArgument(numPartitions > 1, "Number of partitions must be more than 1");
+        DestinationName ds = validateTopic(destination);
+        return asyncPostRequest(
+                persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("partitions"),
+                Entity.entity(numPartitions, MediaType.APPLICATION_JSON));
+    }
+    
+    @Override
     public PartitionedTopicMetadata getPartitionedTopicMetadata(String destination) throws PulsarAdminException {
         try {
             return getPartitionedTopicMetadataAsync(destination).get();

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
@@ -60,6 +60,7 @@ public class CmdPersistentTopics extends CmdBase {
         jcommander.addCommand("expire-messages", new ExpireMessages());
         jcommander.addCommand("expire-messages-all-subscriptions", new ExpireMessagesForAllSubscriptions());
         jcommander.addCommand("create-partitioned-topic", new CreatePartitionedCmd());
+        jcommander.addCommand("update-partitioned-topic", new UpdatePartitionedCmd());
         jcommander.addCommand("get-partitioned-topic-metadata", new GetPartitionedTopicMetadataCmd());
         jcommander.addCommand("delete-partitioned-topic", new DeletePartitionedCmd());
         jcommander.addCommand("peek-messages", new PeekMessages());
@@ -168,6 +169,24 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws Exception {
             String persistentTopic = validatePersistentTopic(params);
             persistentTopics.createPartitionedTopic(persistentTopic, numPartitions);
+        }
+    }
+
+    @Parameters(commandDescription = "Update existing non-global partitioned topic. \n"
+            + "\t\tNew updating number of partitions must be greater than existing number of partitions.")
+    private class UpdatePartitionedCmd extends CliCommand {
+
+        @Parameter(description = "persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-p",
+                "--partitions" }, description = "Number of partitions for the topic", required = true)
+        private int numPartitions;
+
+        @Override
+        void run() throws Exception {
+            String persistentTopic = validatePersistentTopic(params);
+            persistentTopics.updatePartitionedTopic(persistentTopic, numPartitions);
         }
     }
 


### PR DESCRIPTION
### Motivation

Addressing #291.

### Modifications

- It provides REST/Admin API to increment number of partitions of existing non-global topic.
- It creates new subscriptions under new partitioned-topics and updates partitioned-topics metadata in zk.
- It doesn't restart connected producers and consumers as partitioned-metadata lookup only happens when client creates partitioned producer and consumer and reconnection doesn't help to see new partitioned-metadata. So, client-app can restart producer/consumer to see the partitioned-metadata change.

### Result

pulsar can support incrementing of partitions 
