### PR TITLE
Add topic loading throttling

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -105,6 +105,9 @@ maxUnackedMessagesPerConsumer=50000
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000
 
+# Max number of concurrent topic loading request broker allows to control number of zk-operations
+maxConcurrentTopicLoadRequest=5000
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -91,6 +91,9 @@ public class ServiceConfiguration implements PulsarConfiguration{
     // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
     @FieldContext(dynamic = true)
     private int maxConcurrentLookupRequest = 10000;
+    // Max number of concurrent topic loading request broker allows to control number of zk-operations
+    @FieldContext(dynamic = true)
+    private int maxConcurrentTopicLoadRequest = 5000;
 
     /***** --- TLS --- ****/
     // Enable TLS
@@ -432,6 +435,14 @@ public class ServiceConfiguration implements PulsarConfiguration{
 
     public void setMaxConcurrentLookupRequest(int maxConcurrentLookupRequest) {
         this.maxConcurrentLookupRequest = maxConcurrentLookupRequest;
+    }
+
+    public int getMaxConcurrentTopicLoadRequest() {
+        return maxConcurrentTopicLoadRequest;
+    }
+
+    public void setMaxConcurrentTopicLoadRequest(int maxConcurrentTopicLoadRequest) {
+        this.maxConcurrentTopicLoadRequest = maxConcurrentTopicLoadRequest;
     }
 
     public boolean isTlsEnabled() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerServiceException.java
@@ -108,6 +108,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TooManyRequestsException extends BrokerServiceException {
+        public TooManyRequestsException(String msg) {
+            super(msg);
+        }
+    }
+
     public static PulsarApi.ServerError getClientErrorCode(Throwable t) {
         if (t instanceof ServerMetadataException) {
             return PulsarApi.ServerError.MetadataError;
@@ -117,6 +123,8 @@ public class BrokerServiceException extends Exception {
             return PulsarApi.ServerError.ConsumerBusy;
         } else if (t instanceof UnsupportedVersionException) {
             return PulsarApi.ServerError.UnsupportedVersionError;
+        } else if (t instanceof TooManyRequestsException) {
+            return PulsarApi.ServerError.TooManyRequests;
         } else if (t instanceof ServiceUnitNotReadyException || t instanceof TopicFencedException
                 || t instanceof SubscriptionFencedException) {
             return PulsarApi.ServerError.ServiceNotReady;

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
@@ -724,7 +724,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         try {
             Consumer consumer = pulsarClient.subscribe(topicName, "mysub", new ConsumerConfiguration());
             fail("It should fail as throttling should not receive any request");
-        } catch (com.yahoo.pulsar.client.api.PulsarClientException.TooManyLookupRequestException e) {
+        } catch (com.yahoo.pulsar.client.api.PulsarClientException.TooManyRequestsException e) {
             // ok as throttling set to 0
         }
     }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceThrottlingTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceThrottlingTest.java
@@ -123,7 +123,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
             consumer = pulsarClient.subscribe(topicName, "mysub", consumerConfig);
             consumer.close();
             fail("It should fail as throttling should not receive any request");
-        } catch (com.yahoo.pulsar.client.api.PulsarClientException.TooManyLookupRequestException e) {
+        } catch (com.yahoo.pulsar.client.api.PulsarClientException.TooManyRequestsException e) {
             // ok as throttling set to 0
         }
     }
@@ -178,7 +178,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
             executor.execute(() -> {
                 try {
                     successfulConsumers.add(pulsarClient.subscribe(topicName, "mysub", consumerConfig));
-                } catch (PulsarClientException.TooManyLookupRequestException e) {
+                } catch (PulsarClientException.TooManyRequestsException e) {
                     // ok
                 } catch (Exception e) {
                     fail("it shouldn't failed");
@@ -236,7 +236,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
             executor.execute(() -> {
                 try {
                     consumers.add(pulsarClient.subscribe(topicName, "mysub", consumerConfig));
-                } catch (PulsarClientException.TooManyLookupRequestException e) {
+                } catch (PulsarClientException.TooManyRequestsException e) {
                     // ok
                 } catch (Exception e) {
                     fail("it shouldn't failed");

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -484,6 +484,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         clientConf.setStatsInterval(0, TimeUnit.SECONDS);
         clientConf.setMaxNumberOfRejectedRequestPerConnection(0);
         stopBroker();
+        final int maxConccurentLookupRequest = pulsar.getConfiguration().getMaxConcurrentLookupRequest();
         pulsar.getConfiguration().setMaxConcurrentLookupRequest(1);
         startBroker();
         String lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
@@ -518,6 +519,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         }
         // connection must be closed
         assertFalse(cnx.channel().isActive());
+        pulsar.getConfiguration().setMaxConcurrentLookupRequest(maxConccurentLookupRequest);
         pulsarClient.close();
         pulsarClient2.close();
     }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
@@ -60,8 +60,8 @@ public class PulsarClientException extends IOException {
         }
     }
 
-    public static class TooManyLookupRequestException extends LookupException {
-        public TooManyLookupRequestException(String msg) {
+    public static class TooManyRequestsException extends LookupException {
+        public TooManyRequestsException(String msg) {
             super(msg);
         }
     }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ClientCnx.java
@@ -358,7 +358,7 @@ public class ClientCnx extends PulsarHandler {
             if (log.isDebugEnabled()) {
                 log.debug("{} Failed to add lookup-request into pending queue", requestId);
             }
-            future.completeExceptionally(new PulsarClientException.TooManyLookupRequestException(
+            future.completeExceptionally(new PulsarClientException.TooManyRequestsException(
                     "Failed due to too many pending lookup requests"));
         }
         return future;
@@ -457,7 +457,7 @@ public class ClientCnx extends PulsarHandler {
         case ServiceNotReady:
             return new PulsarClientException.LookupException(errorMsg);
         case TooManyRequests:
-            return new PulsarClientException.TooManyLookupRequestException(errorMsg);    
+            return new PulsarClientException.TooManyRequestsException(errorMsg);    
         case ProducerBlockedQuotaExceededError:
             return new PulsarClientException.ProducerBlockedQuotaExceededError(errorMsg);
         case ProducerBlockedQuotaExceededException:


### PR DESCRIPTION
### Motivation

Addressing #300 : At the time of broker cold-restart, clients make broker to load all the topics concurrently which can create back pressure at zk and may increase zk latency. So, broker should have a way to throttle number of concurrent topic loading.

### Modifications

- Introduce dynamic throttling limit to control concurrent topic loading.
- above that limit broker rejects producer/consumer create request so, producer and consumer can do retry with backoff

### Result

It will help broker to control number of zk operations on cold-restart.
