### PR TITLE
Fix typo in ConsumerHandler

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -162,8 +162,8 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             conf.setAckTimeout(Integer.parseInt(queryParams.get("ackTimeoutMillis")), TimeUnit.MILLISECONDS);
         }
 
-        if (queryParams.containsKey("suscriptionType")) {
-            conf.setSubscriptionType(SubscriptionType.valueOf(queryParams.get("suscriptionType")));
+        if (queryParams.containsKey("subscriptionType")) {
+            conf.setSubscriptionType(SubscriptionType.valueOf(queryParams.get("subscriptionType")));
         }
 
         if (queryParams.containsKey("receiverQueueSize")) {


### PR DESCRIPTION
### Motivation

There is a typo in com.yahoo.pulsar.websocket.ConsumerHandler.

### Modifications

Correct the name of query parameter: `suscriptionType` -> `subscriptionType`

### Result

Enable WebSocket client to specify SubscriptionType using the correct query parameter.