### PR TITLE
Exclude netty individual jars from binary distribution

### DIFF
--- a/all/src/assemble/bin.xml
+++ b/all/src/assemble/bin.xml
@@ -61,6 +61,18 @@
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
+
+      <excludes>
+        <!-- All these dependencies are already included in netty-all -->
+        <exclude>io.netty:netty-common</exclude>
+        <exclude>io.netty:netty-buffer</exclude>
+        <exclude>io.netty:netty-codec-http</exclude>
+        <exclude>io.netty:netty-codec</exclude>
+        <exclude>io.netty:netty-transport</exclude>
+        <exclude>io.netty:netty-handler</exclude>
+        <exclude>io.netty:netty-transport-native-epoll</exclude>
+        <exclude>io.netty:netty-codec-http</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
### Motivation

Maven assembly plugin is including individual Netty jars, even though we have a dependency exclusion. These packages are conflicting with the `netty-all` package that we are already including.

### Modifications

Setup exclusion in the maven assembly configuration.

Fix #277 
