### PR TITLE
Atomically Set State when Closing Producer

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HandlerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HandlerBase.java
@@ -17,6 +17,7 @@ package com.yahoo.pulsar.client.impl;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.UnaryOperator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,6 +144,10 @@ abstract class HandlerBase {
 
     protected void setState(State s) {
         STATE_UPDATER.set(this, s);
+    }
+
+    protected State getAndUpdateState(final UnaryOperator<State> updater) {
+        return STATE_UPDATER.getAndUpdate(this, updater);
     }
 
     protected ClientCnx getClientCnx() {

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
@@ -384,7 +384,14 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
 
     @Override
     public CompletableFuture<Void> closeAsync() {
-        if (getState() == State.Closing || getState() == State.Closed) {
+        final State currentState = getAndUpdateState(state -> {
+            if (state == State.Closed) {
+                return state;
+            }
+            return State.Closing;
+        });
+
+        if (currentState == State.Closed || currentState == State.Closing) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
@@ -410,8 +410,6 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
             return CompletableFuture.completedFuture(null);
         }
 
-        setState(State.Closing);
-
         Timeout timeout = sendTimeout;
         if (timeout != null) {
             timeout.cancel();

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
@@ -395,7 +395,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
             return CompletableFuture.completedFuture(null);
         }
 
-        if (!isConnected()) {
+        if (getClientCnx() == null || currentState != State.Ready) {
             log.info("[{}] [{}] Closed Producer (not connected)", topic, producerName);
             synchronized (this) {
                 setState(State.Closed);


### PR DESCRIPTION
### Motivation

It has been observed that it is possible for [`ProducerImpl` to throw a null pointer exception](https://github.com/yahoo/pulsar/blob/5a28f6324d4b2ac9b2ba078de4135c23ce636b57/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java#L422) in `closeAsync` if two or more threads observe that the state is not closed or closing before the state is updated. This has been observed when running [this test](https://github.com/yahoo/pulsar/blob/5a28f6324d4b2ac9b2ba078de4135c23ce636b57/pulsar-broker/src/test/java/com/yahoo/pulsar/client/impl/BrokerClientIntegrationTest.java#L469).

### Modifications

I have used Java 8's `getAndUpdate` method and added the `getAndUpdateState` method to `HandlerBase` so that the state may be updated atomically and checked to see if it was in the closing or closed states before updating.

### Result

A race condition in `ProducerImpl.closeAsync` which caused a NPE should be resolved.
