### PR TITLE
Add api to get list of partitioned topics

### DIFF
--- a/docs/AdminTools.md
+++ b/docs/AdminTools.md
@@ -59,6 +59,7 @@
 			- [delete partitioned topic](#delete-partitioned-topic)
 			- [Delete topic](#delete-topic)
 			- [List of topics](#list-of-topics)
+			- [List of partitioned topics](#list-of-partitioned-topics)
 			- [Grant permission](#grant-permission)
 			- [Get permission](#get-permission)
 			- [Revoke permission](#revoke-permission)
@@ -1488,7 +1489,7 @@ admin.persistentTopics().delete(persistentTopic)
 
 #### List of topics
 
-It provides a list of persistent topics exist under a given namespace.  
+It provides a list of persistent topics existing under a given namespace.  
 
 ###### CLI
 
@@ -1511,6 +1512,34 @@ GET /admin/persistent/{property}/{cluster}/{namespace}
 ```java
 admin.persistentTopics().getList(namespace)
 ```
+
+#### List of partitioned topics
+
+It provides a list of partitioned topics existing under a given namespace.
+
+###### CLI
+
+```
+$ pulsar-admin persistent list-partitioned-topics test-property/cl1/ns1
+```
+
+```
+persistent://test-property/cl1/ns1/partitioned-tp1
+persistent://test-property/cl1/ns1/partitioned-tp2
+```
+
+###### REST
+
+```
+GET /admin/persistent/{property}/{cluster}/{namespace}/partitioned
+```
+
+###### Java
+
+```java
+admin.persistentTopics().getPartitionedTopicList(namespace)
+```
+
 
 #### Grant permission
 
@@ -1981,7 +2010,7 @@ POST /admin/persistent/{property}/{cluster}/{namespace}/{destination}/subscripti
 admin.persistentTopics().expireMessages(persistentTopic, subName, expireTimeInSeconds)
 ```
 
-#### Expire all messages 
+#### Expire all messages
 
 It expires messages which are older than given expiry time (in seconds) for all subscriptions of a given topic.
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/PersistentTopics.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -152,6 +153,46 @@ public class PersistentTopics extends AdminResource {
 
         destinations.sort(null);
         return destinations;
+    }
+
+    @GET
+    @Path("/{property}/{cluster}/{namespace}/partitioned")
+    @ApiOperation(value = "Get the list of partitioned topics under a namespace.", response = String.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace doesn't exist") })
+    public List<String> getPartitionedTopicList(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace) {
+        validateAdminAccessOnProperty(property);
+
+        // Validate that namespace exists, throws 404 if it doesn't exist
+        try {
+            policiesCache().get(path("policies", property, cluster, namespace));
+        } catch (KeeperException.NoNodeException e) {
+            log.warn("[{}] Failed to get partitioned topic list {}/{}/{}: Namespace does not exist", clientAppId(), property,
+                    cluster, namespace);
+            throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
+        } catch (Exception e) {
+            log.error("[{}] Failed to get partitioned topic list for namespace {}/{}/{}", clientAppId(), property, cluster, namespace, e);
+            throw new RestException(e);
+        }
+
+        List<String> partitionedTopics = Lists.newArrayList();
+
+        try {
+            String partitionedTopicPath = path(PARTITIONED_TOPIC_PATH_ZNODE, property, cluster, namespace, domain());
+            List<String> destinations = globalZk().getChildren(partitionedTopicPath, false);
+            partitionedTopics = destinations.stream().map(s -> String.format("persistent://%s/%s/%s/%s", property, cluster, namespace, decode(s))).collect(
+                    Collectors.toList());
+        } catch (KeeperException.NoNodeException e) {
+            // NoNode means there are no partitioned topics in this domain for this namespace
+        } catch (Exception e) {
+            log.error("[{}] Failed to get partitioned topic list for namespace {}/{}/{}", clientAppId(), property, cluster,
+                    namespace, e);
+            throw new RestException(e);
+        }
+
+        partitionedTopics.sort(null);
+        return partitionedTopics;
     }
 
     @GET

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
@@ -700,8 +700,11 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test(dataProvider = "topicName")
     public void partitionedTopics(String topicName) throws Exception {
+        assertEquals(admin.persistentTopics().getPartitionedTopicList("prop-xyz/use/ns1"), Lists.newArrayList());
         final String partitionedTopicName = "persistent://prop-xyz/use/ns1/" + topicName;
         admin.persistentTopics().createPartitionedTopic(partitionedTopicName, 4);
+        assertEquals(admin.persistentTopics().getPartitionedTopicList("prop-xyz/use/ns1"), Lists.newArrayList(partitionedTopicName));
+
 
         assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 4);
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminTest.java
@@ -589,7 +589,10 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         List<String> list = persistentTopics.getList(property, cluster, namespace);
         assertTrue(list.isEmpty());
         // create destination
+        assertEquals(persistentTopics.getPartitionedTopicList(property, cluster, namespace), Lists.newArrayList());
         persistentTopics.createPartitionedTopic(property, cluster, namespace, destination, 5, false);
+        assertEquals(persistentTopics.getPartitionedTopicList(property, cluster, namespace), Lists.newArrayList(
+                String.format("persistent://%s/%s/%s/%s", property, cluster, namespace, destination)));
 
         CountDownLatch notificationLatch = new CountDownLatch(2);
         configurationCache.policiesCache().registerListener((path, data, stat) -> {

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
@@ -60,6 +60,29 @@ public interface PersistentTopics {
     List<String> getList(String namespace) throws PulsarAdminException;
 
     /**
+     * Get the list of partitioned topics under a namespace.
+     * <p>
+     * Response example:
+     *
+     * <pre>
+     * <code>["persistent://my-property/use/my-namespace/topic-1",
+     *  "persistent://my-property/use/my-namespace/topic-2"]</code>
+     * </pre>
+     *
+     * @param namespace
+     *            Namespace name
+     * @return a list of partitioned topics
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<String> getPartitionedTopicList(String namespace) throws PulsarAdminException;
+
+    /**
      * Get permissions on a destination.
      * <p>
      * Retrieve the effective permissions for a destination. These permissions are defined by the permissions set at the

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
@@ -77,6 +77,18 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
     }
 
     @Override
+    public List<String> getPartitionedTopicList(String namespace) throws PulsarAdminException {
+        try {
+            NamespaceName ns = new NamespaceName(namespace);
+            return request(persistentTopics.path(ns.getProperty()).path(ns.getCluster()).path(ns.getLocalName()).path("partitioned")).get(
+                    new GenericType<List<String>>() {
+                    });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
     public Map<String, Set<AuthAction>> getPermissions(String destination) throws PulsarAdminException {
         try {
             DestinationName ds = DestinationName.get(destination);

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
@@ -40,6 +40,7 @@ public class CmdPersistentTopics extends CmdBase {
         persistentTopics = admin.persistentTopics();
 
         jcommander.addCommand("list", new ListCmd());
+        jcommander.addCommand("list-partitioned-topics", new PartitionedTopicListCmd());
         jcommander.addCommand("permissions", new Permissions());
         jcommander.addCommand("grant-permission", new GrantPermissions());
         jcommander.addCommand("revoke-permission", new RevokePermissions());
@@ -70,6 +71,18 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
             print(persistentTopics.getList(namespace));
+        }
+    }
+
+    @Parameters(commandDescription = "Get the list of partitioned topics under a namespace.")
+    private class PartitionedTopicListCmd extends CliCommand {
+        @Parameter(description = "property/cluster/namespace\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            print(persistentTopics.getPartitionedTopicList(namespace));
         }
     }
 

--- a/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/com/yahoo/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -377,6 +377,9 @@ public class PulsarAdminToolTest {
         topics.run(split("create-partitioned-topic persistent://myprop/clust/ns1/ds1 --partitions 32"));
         verify(mockTopics).createPartitionedTopic("persistent://myprop/clust/ns1/ds1", 32);
 
+        topics.run(split("list-partitioned-topics myprop/clust/ns1"));
+        verify(mockTopics).getPartitionedTopicList("myprop/clust/ns1");
+
         topics.run(split("get-partitioned-topic-metadata persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPartitionedTopicMetadata("persistent://myprop/clust/ns1/ds1");
 


### PR DESCRIPTION
### Motivation

To manage partitioned topics, we need to get the list of only partitioned topics.

### Modifications

- Added REST API
- Added Java API
- Added command line API
- Added document's statement

### Result

Users can get a list of partitioned topics.