### PR TITLE
Partitioned consumer test failure

### DIFF
--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -542,8 +542,12 @@ TEST(BasicEndToEndTest, testSinglePartitionRoutingPolicy)
     Producer producer;
     ProducerConfiguration producerConfiguration;
     producerConfiguration.setPartitionsRoutingMode(ProducerConfiguration::UseSinglePartition);
-
     Result result = client.createProducer(topicName, producerConfiguration, producer);
+
+    Consumer consumer;
+    result = client.subscribe(topicName, "subscription-A", consumer);
+    ASSERT_EQ(ResultOk, result);
+
     ASSERT_EQ(ResultOk, result);
     for (int i = 0; i < 10; i++ ) {
         boost::posix_time::ptime t(boost::posix_time::microsec_clock::universal_time());
@@ -553,9 +557,7 @@ TEST(BasicEndToEndTest, testSinglePartitionRoutingPolicy)
         Message msg = MessageBuilder().setContent(ss.str()).build();
         ASSERT_EQ(ResultOk, producer.send(msg));
     }
-    Consumer consumer;
-    result = client.subscribe(topicName, "subscription-A", consumer);
-    ASSERT_EQ(ResultOk, result);
+
     for (int i = 0; i < 10; i++) {
         Message m;
         consumer.receive(m);

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -128,7 +128,8 @@ TEST(BatchMessageTest, testProducerTimeout) {
         /* End the timer */
         end = time(NULL);
         LOG_INFO("end = "<<end);
-        ASSERT_EQ(timeout/1000.0, (double)(end - start));
+        // Greater than or equal to since there may be delay in sending messaging
+        ASSERT_GE((double)(end - start), timeout/1000.0);
     }
 
     Message receivedMsg;


### PR DESCRIPTION
### Motivation

Reduce the number of intermittent test failures before we start work on #238 

### Modifications
- Fixed a few test cases

### Result

- lesser number of intermittent build failures in CPP client
