### PR TITLE
Add documentation for changing load manager

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -12,6 +12,7 @@
   - [Geo-Replication](GeoReplication.md)
   - [WebSocket API](WebSocket.md)
   - [Apache Storm adaptor](PulsarStorm.md)
+  - [Modular Load Manager](ModularLoadManager.md)
 * Internal Docs
   - [Binary protocol specification](BinaryProtocol.md)
 * Other Languages

--- a/docs/ModularLoadManager.md
+++ b/docs/ModularLoadManager.md
@@ -1,0 +1,23 @@
+# Modular Load Manager
+
+The modular load manager, implemented in `ModularLoadManagerImpl`, is a flexible alternative to the previously
+implemented load manager `SimpleLoadManagerImpl` which attempts to simplify how load is manager while also providing
+abstractions so that complex load management strategies may be implemented.
+
+## Usage
+
+To use the modular load manager, change
+
+`loadManagerClassName=com.yahoo.broker.loadbalance.impl.SimpleLoadManagerImpl`
+
+in `broker.conf` to
+
+`loadManagerClassName=com.yahoo.broker.loadbalance.impl.ModularLoadManagerImpl`
+
+Alternatively, the load manager may also be changed dynamically via the `pulsar-admin` tool as follows:
+
+`pulsar-admin update-dynamic-config --config loadManagerClassName --value 
+com.yahoo.broker.loadbalance.impl.ModularLoadManagerImpl`
+
+The admin tool may also be used to change back to `com.yahoo.broker.loadbalance.impl.SimpleLoadManagerImpl`
+Note that the ZooKeeper node `/admin/configuration` must exist BEFORE brokers are started for this to work correctly.

--- a/docs/ModularLoadManager.md
+++ b/docs/ModularLoadManager.md
@@ -20,4 +20,3 @@ Alternatively, the load manager may also be changed dynamically via the `pulsar-
 com.yahoo.broker.loadbalance.impl.ModularLoadManagerImpl`
 
 The admin tool may also be used to change back to `com.yahoo.broker.loadbalance.impl.SimpleLoadManagerImpl`
-Note that the ZooKeeper node `/admin/configuration` must exist BEFORE brokers are started for this to work correctly.


### PR DESCRIPTION
### Motivation

Documentation for how to switch to `ModularLoadManagerImpl` needs to exist after #303 is merged.

### Modifications

The markdown document `docs/ModularLoadManagerImpl` describes how to switch between load managers.

### Result

Documentation for switching load managers will be present. The document will later be expanded to explain the architecture of `ModularLoadManagerImpl`.