### PR TITLE
Avoid extra retain of entry data to prevent memory leak

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -88,7 +88,6 @@ final class EntryImpl extends AbstractReferenceCounted implements Entry, Compara
         entry.entryId = other.entryId;
         entry.data = RecyclableDuplicateByteBuf.create(other.data);
         entry.setRefCnt(1);
-        entry.data.retain();
         return entry;
     }
 


### PR DESCRIPTION
### Motivation

While creating duplicate byte-buf (`RecyclableDuplicateByteBuf`) it internally retains on original byte-buf so, don't have to retain again to prevent memory-leak.

### Modifications

Avoid multiple retain on given entry data.

### Result

It prevents memory leak while creating entry from existing entry.
