### PR TITLE
Fixed pulsar-spark pom version

### DIFF
--- a/pulsar-spark/pom.xml
+++ b/pulsar-spark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.yahoo.pulsar</groupId>
     <artifactId>pulsar</artifactId>
-    <version>1.17-SNAPSHOT</version>
+    <version>1.18-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
After merging #296 the pom version was still pointing to 1.17-SNAPHSOT version.