### PR TITLE
Fix Bugs Introduced by New Load Manager

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
@@ -51,7 +51,7 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
     // max_usage < overload_threshold ? 1 / (overload_threshold - max_usage): Inf
     // This weight attempts to discourage the placement of bundles on brokers whose system resource usage is high.
     private static double getScore(final BrokerData brokerData, final ServiceConfiguration conf) {
-        final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100;
+        final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
         double totalMessageRate = 0;
         for (BundleData bundleData : brokerData.getPreallocatedBundleData().values()) {
             final TimeAverageMessageData longTermData = bundleData.getLongTermData();

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.yahoo.pulsar.broker.BrokerData;
 import com.yahoo.pulsar.broker.BundleData;
+import com.yahoo.pulsar.broker.LocalBrokerData;
 import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.broker.TimeAverageBrokerData;
 import com.yahoo.pulsar.broker.TimeAverageMessageData;
@@ -61,14 +62,10 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
         if (maxUsage > overloadThreshold) {
             return Double.POSITIVE_INFINITY;
         }
-        // 1 / weight is the proportion of load this machine should receive in
-        // proportion to a machine with no system resource burden.
-        // This attempts to spread out the load in such a way that
-        // machines only become overloaded if there is too much
-        // load for the system to handle (e.g., all machines are
-        // at least nearly overloaded).
-        final double weight = maxUsage < overloadThreshold ? 1 / (overloadThreshold - maxUsage)
-                : Double.POSITIVE_INFINITY;
+        // 1 / weight is the proportion of load this machine should receive in proportion to a machine with no system
+        // resource burden. This attempts to spread out the load in such a way that machines only become overloaded if
+        // there is too much load for the system to handle (e.g., all machines are at least nearly overloaded).
+        final double weight = 1 / (overloadThreshold - maxUsage);
         final double totalMessageRateEstimate = totalMessageRate + timeAverageData.getLongTermMsgRateIn()
                 + timeAverageData.getLongTermMsgRateOut();
         return weight * totalMessageRateEstimate;
@@ -95,16 +92,26 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
         // Maintain of list of all the best scoring brokers and then randomly
         // select one of them at the end.
         for (String broker : candidates) {
-            final double score = getScore(loadData.getBrokerData().get(broker), conf);
-            log.info("{} got score {}", broker, score);
+            final BrokerData brokerData = loadData.getBrokerData().get(broker);
+            final double score = getScore(brokerData, conf);
+            if (score == Double.POSITIVE_INFINITY) {
+                final LocalBrokerData localData = brokerData.getLocalData();
+                log.warn(
+                        "Broker {} is overloaded: CPU: {}%, MEMORY: {}%, DIRECT MEMORY: {}%, BANDWIDTH IN: {}%, "
+                                + "BANDWIDTH OUT: {}%",
+                        broker, localData.getCpu().percentUsage(), localData.getMemory().percentUsage(),
+                        localData.getDirectMemory().percentUsage(), localData.getBandwidthIn().percentUsage(),
+                        localData.getBandwidthOut().percentUsage());
+
+            }
+            log.debug("{} got score {}", broker, score);
             if (score < minScore) {
                 // Clear best brokers since this score beats the other brokers.
                 bestBrokers.clear();
                 bestBrokers.add(broker);
                 minScore = score;
             } else if (score == minScore) {
-                // Add this broker to best brokers since it ties with the best
-                // score.
+                // Add this broker to best brokers since it ties with the best score.
                 bestBrokers.add(broker);
             }
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -427,8 +427,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
      */
     @Override
     public void disableBroker() throws PulsarServerException {
-        brokerDataCache.unregisterListener(this);
-        scheduler.shutdown();
+        stop();
         if (StringUtils.isNotEmpty(brokerZnodePath)) {
             try {
                 pulsar.getZkClient().delete(brokerZnodePath, -1);
@@ -552,7 +551,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
      */
     @Override
     public void stop() throws PulsarServerException {
-        // Do nothing.
+        brokerDataCache.unregisterListener(this);
+        scheduler.shutdown();
     }
 
     /**

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -553,9 +553,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
      */
     @Override
     public void stop() throws PulsarServerException {
-        availableActiveBrokers.shutdown();
+        availableActiveBrokers.close();
         brokerDataCache.clear();
-        brokerDataCache.shutdown();
+        brokerDataCache.close();
         scheduler.shutdown();
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -362,11 +362,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                         brokerDataMap.put(broker, new BrokerData(localData));
                     }
                 } catch (Exception e) {
-                    log.warn("Error reading broker data from cache for broker - [{}], [{}]", broker, e);
+                    log.warn("Error reading broker data from cache for broker - [{}], [{}]", broker, e.getMessage());
                 }
             }
         } catch (Exception e) {
-            log.warn("Error reading active brokers list from zookeeper while updating broker data [{}]", e);
+            log.warn("Error reading active brokers list from zookeeper while updating broker data [{}]", e.getMessage());
         }
     }
 
@@ -554,6 +554,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     @Override
     public void stop() throws PulsarServerException {
         availableActiveBrokers.shutdown();
+        brokerDataCache.clear();
         brokerDataCache.shutdown();
         scheduler.shutdown();
     }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -553,7 +553,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
      */
     @Override
     public void stop() throws PulsarServerException {
-        brokerDataCache.unregisterListener(this);
+        availableActiveBrokers.shutdown();
+        brokerDataCache.shutdown();
         scheduler.shutdown();
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -527,6 +527,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             try {
                 ZkUtils.createFullPathOptimistic(pulsar.getZkClient(), brokerZnodePath, localData.getJsonBytes(),
                         ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+            } catch (KeeperException.NodeExistsException e) {
+                // Node may already be created by another load manager: in this case update the data.
+                zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);
             } catch (Exception e) {
                 // Catching exception here to print the right error message
                 log.error("Unable to create znode - [{}] for load balance on zookeeper ", brokerZnodePath, e);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -493,14 +493,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         }
         final BundleData data = loadData.getBundleData().computeIfAbsent(bundle, key -> getBundleDataOrDefault(bundle));
         brokerCandidateCache.clear();
-        try {
-            LoadManagerShared.applyPolicies(serviceUnit, policies, brokerCandidateCache, availableActiveBrokers.get());
-        } catch (Exception e) {
-            // This try-catch block is mostly here to catch an exception when calling availableActiveBrokers.get():
-            // We should really only see this if something has gone seriously wrong.
-            log.warn("Error while trying to apply policies: ", e);
-            brokerCandidateCache.addAll(loadData.getBrokerData().keySet());
-        }
+        LoadManagerShared.applyPolicies(serviceUnit, policies, brokerCandidateCache, loadData.getBrokerData().keySet());
         log.info("{} brokers being considered for assignment of {}", brokerCandidateCache.size(), bundle);
 
         // Use the filter pipeline to finalize broker candidates.

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -493,7 +493,14 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         }
         final BundleData data = loadData.getBundleData().computeIfAbsent(bundle, key -> getBundleDataOrDefault(bundle));
         brokerCandidateCache.clear();
-        LoadManagerShared.applyPolicies(serviceUnit, policies, brokerCandidateCache, loadData.getBrokerData().keySet());
+        try {
+            LoadManagerShared.applyPolicies(serviceUnit, policies, brokerCandidateCache, availableActiveBrokers.get());
+        } catch (Exception e) {
+            // This try-catch block is mostly here to catch an exception when calling availableActiveBrokers.get():
+            // We should really only see this if something has gone seriously wrong.
+            log.warn("Error while trying to apply policies: ", e);
+            brokerCandidateCache.addAll(loadData.getBrokerData().keySet());
+        }
         log.info("{} brokers being considered for assignment of {}", brokerCandidateCache.size(), bundle);
 
         // Use the filter pipeline to finalize broker candidates.

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -427,7 +427,6 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
      */
     @Override
     public void disableBroker() throws PulsarServerException {
-        stop();
         if (StringUtils.isNotEmpty(brokerZnodePath)) {
             try {
                 pulsar.getZkClient().delete(brokerZnodePath, -1);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -19,6 +19,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -286,6 +287,10 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
             try {
                 ZkUtils.createFullPathOptimistic(pulsar.getZkClient(), brokerZnodePath,
                         loadReportJson.getBytes(Charsets.UTF_8), Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+            } catch (KeeperException.NodeExistsException e) {
+                // Node may already be created by another load manager: in this case update the data.
+                pulsar.getZkClient().setData(brokerZnodePath, loadReportJson.getBytes(Charsets.UTF_8), -1);
+
             } catch (Exception e) {
                 // Catching excption here to print the right error message
                 log.error("Unable to create znode - [{}] for load balance on zookeeper ", brokerZnodePath, e);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -289,7 +289,9 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
                         loadReportJson.getBytes(Charsets.UTF_8), Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
             } catch (KeeperException.NodeExistsException e) {
                 // Node may already be created by another load manager: in this case update the data.
-                pulsar.getZkClient().setData(brokerZnodePath, loadReportJson.getBytes(Charsets.UTF_8), -1);
+                if (loadReport != null) {
+                    pulsar.getZkClient().setData(brokerZnodePath, loadReportJson.getBytes(Charsets.UTF_8), -1);
+                }
 
             } catch (Exception e) {
                 // Catching excption here to print the right error message

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -312,8 +312,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void disableBroker() throws Exception {
-        loadReportCacheZk.unregisterListener(this);
-        scheduler.shutdown();
+        stop();
         if (isNotEmpty(brokerZnodePath)) {
             pulsar.getZkClient().delete(brokerZnodePath, -1);
         }
@@ -1425,6 +1424,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void stop() throws PulsarServerException {
-        // do nothing
+        loadReportCacheZk.unregisterListener(this);
+        scheduler.shutdown();
     }
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -312,6 +312,8 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void disableBroker() throws Exception {
+        loadReportCacheZk.unregisterListener(this);
+        scheduler.shutdown();
         if (isNotEmpty(brokerZnodePath)) {
             pulsar.getZkClient().delete(brokerZnodePath, -1);
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1429,6 +1429,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void stop() throws PulsarServerException {
+        loadReportCacheZk.clear();
         loadReportCacheZk.close();
         availableActiveBrokers.close();
         scheduler.shutdown();

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -19,7 +19,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1430,7 +1429,8 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void stop() throws PulsarServerException {
-        loadReportCacheZk.unregisterListener(this);
+        loadReportCacheZk.shutdown();
+        availableActiveBrokers.shutdown();
         scheduler.shutdown();
     }
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -312,7 +312,6 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void disableBroker() throws Exception {
-        stop();
         if (isNotEmpty(brokerZnodePath)) {
             pulsar.getZkClient().delete(brokerZnodePath, -1);
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1429,8 +1429,8 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void stop() throws PulsarServerException {
-        loadReportCacheZk.shutdown();
-        availableActiveBrokers.shutdown();
+        loadReportCacheZk.close();
+        availableActiveBrokers.close();
         scheduler.shutdown();
     }
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/NamespaceService.java
@@ -17,6 +17,7 @@ package com.yahoo.pulsar.broker.namespace;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.yahoo.pulsar.broker.admin.AdminResource.jsonMapper;
 import static com.yahoo.pulsar.broker.cache.LocalZooKeeperCacheService.LOCAL_POLICIES_ROOT;
 import static com.yahoo.pulsar.broker.web.PulsarWebResource.joinPath;
 import static com.yahoo.pulsar.common.naming.NamespaceBundleFactory.getBundlesData;
@@ -36,7 +37,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.yahoo.pulsar.common.policies.data.loadbalancer.ServiceLookupData;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.zookeeper.AsyncCallback.StatCallback;
@@ -46,13 +46,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
+import com.yahoo.pulsar.broker.LocalBrokerData;
 import com.yahoo.pulsar.broker.PulsarServerException;
 import com.yahoo.pulsar.broker.PulsarService;
 import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.broker.admin.AdminResource;
 import com.yahoo.pulsar.broker.loadbalance.LoadManager;
-import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
-import com.yahoo.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import com.yahoo.pulsar.broker.lookup.LookupResult;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import com.yahoo.pulsar.client.admin.PulsarAdmin;
@@ -68,11 +67,12 @@ import com.yahoo.pulsar.common.policies.data.BrokerAssignment;
 import com.yahoo.pulsar.common.policies.data.BundlesData;
 import com.yahoo.pulsar.common.policies.data.LocalPolicies;
 import com.yahoo.pulsar.common.policies.data.NamespaceOwnershipStatus;
+import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
+import com.yahoo.pulsar.common.policies.data.loadbalancer.ServiceLookupData;
 import com.yahoo.pulsar.common.policies.impl.NamespaceIsolationPolicies;
 import com.yahoo.pulsar.common.util.Codec;
 import com.yahoo.pulsar.common.util.ObjectMapperFactory;
 import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
-import static com.yahoo.pulsar.broker.admin.AdminResource.jsonMapper;
 
 /**
  * The <code>NamespaceService</code> provides resource ownership lookup as well as resource ownership claiming services

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/ServiceUnitZkUtils.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/ServiceUnitZkUtils.java
@@ -114,17 +114,21 @@ public final class ServiceUnitZkUtils {
      */
     private static final void cleanupNamespaceNodes(ZooKeeper zkc, String root, String selfBrokerUrl) throws Exception {
         // we don't need a watch here since we are only cleaning up the stale ephemeral nodes from previous session
-        for (String node : zkc.getChildren(root, false)) {
-            String currentPath = root + "/" + node;
-            // retrieve the content and try to decode with ServiceLookupData
-            List<String> children = zkc.getChildren(currentPath, false);
-            if (children.size() == 0) {
-                // clean up a single namespace node
-                cleanupSingleNamespaceNode(zkc, currentPath, selfBrokerUrl);
-            } else {
-                // this is an intermediate node, which means this is v2 namespace path
-                cleanupNamespaceNodes(zkc, currentPath, selfBrokerUrl);
+        try {
+            for (String node : zkc.getChildren(root, false)) {
+                String currentPath = root + "/" + node;
+                // retrieve the content and try to decode with ServiceLookupData
+                List<String> children = zkc.getChildren(currentPath, false);
+                if (children.size() == 0) {
+                    // clean up a single namespace node
+                    cleanupSingleNamespaceNode(zkc, currentPath, selfBrokerUrl);
+                } else {
+                    // this is an intermediate node, which means this is v2 namespace path
+                    cleanupNamespaceNodes(zkc, currentPath, selfBrokerUrl);
+                }
             }
+        } catch (NoNodeException nne) {
+            LOG.info("No children for [{}]", nne.getPath());
         }
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -920,7 +920,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             try {
                 final LoadManager newLoadManager = LoadManager.create(pulsar);
                 log.info("Created load manager: {}", className);
-                pulsar.getLoadManager().get().disableBroker();
+                pulsar.getLoadManager().get().stop();
                 newLoadManager.start();
                 pulsar.getLoadManager().set(newLoadManager);
             } catch (Exception ex) {

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.bookkeeper.test.PortManager;
@@ -434,9 +435,10 @@ public class LoadBalancerTest {
         loadReportCacheField.setAccessible(true);
         ZooKeeperDataCache<LoadReport> loadReportCache = (ZooKeeperDataCache<LoadReport>) loadReportCacheField
                 .get(loadManager);
-        Field isShutdownField = ZooKeeperDataCache.class.getDeclaredField("isShutdown");
-        isShutdownField.setAccessible(true);
-        assert (((AtomicBoolean) (isShutdownField.get(loadReportCache))).get());
+        Field IS_SHUTDOWN_UPDATER = ZooKeeperDataCache.class.getDeclaredField("IS_SHUTDOWN_UPDATER");
+        IS_SHUTDOWN_UPDATER.setAccessible(true);
+        final int TRUE = 1;
+        assert (((AtomicIntegerFieldUpdater<ZooKeeperDataCache>) (IS_SHUTDOWN_UPDATER.get(loadReportCache))).get(loadReportCache) == TRUE);
     }
 
     private AtomicReference<Map<String, ResourceQuota>> getRealtimeResourceQuota(PulsarService pulsar)

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -715,8 +715,7 @@ public class LoadBalancerTest {
             Assert.assertNotEquals(newLeader, oldLeader);
         }
     }
-
-    @Test
+    
     private void createNamespacePolicies(PulsarService pulsar) throws Exception {
         // // prepare three policies for the namespace isolation
         NamespaceIsolationPolicies policies = new NamespaceIsolationPolicies();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.bookkeeper.test.PortManager;
@@ -423,7 +424,7 @@ public class LoadBalancerTest {
     }
 
     /**
-     * Ensure that the load manager is unregistered as a listener after invoking stop.
+     * Ensure that the load manager's zookeeper data cache is shutdown after invoking stop().
      */
     @Test
     public void testStop() throws Exception {
@@ -433,9 +434,9 @@ public class LoadBalancerTest {
         loadReportCacheField.setAccessible(true);
         ZooKeeperDataCache<LoadReport> loadReportCache = (ZooKeeperDataCache<LoadReport>) loadReportCacheField
                 .get(loadManager);
-        Field listenersField = ZooKeeperDataCache.class.getDeclaredField("listeners");
-        listenersField.setAccessible(true);
-        assert (((List) (listenersField.get(loadReportCache))).isEmpty());
+        Field isShutdownField = ZooKeeperDataCache.class.getDeclaredField("isShutdown");
+        isShutdownField.setAccessible(true);
+        assert (((AtomicBoolean) (isShutdownField.get(loadReportCache))).get());
     }
 
     private AtomicReference<Map<String, ResourceQuota>> getRealtimeResourceQuota(PulsarService pulsar)

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -715,7 +715,7 @@ public class LoadBalancerTest {
             Assert.assertNotEquals(newLeader, oldLeader);
         }
     }
-    
+
     private void createNamespacePolicies(PulsarService pulsar) throws Exception {
         // // prepare three policies for the namespace isolation
         NamespaceIsolationPolicies policies = new NamespaceIsolationPolicies();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -1,5 +1,9 @@
 package com.yahoo.pulsar.broker.loadbalance;
 
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
 import com.yahoo.pulsar.broker.BrokerData;
 import com.yahoo.pulsar.broker.BundleData;
 import com.yahoo.pulsar.broker.LocalBrokerData;
@@ -7,10 +11,6 @@ import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.broker.TimeAverageBrokerData;
 import com.yahoo.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate;
 import com.yahoo.pulsar.common.policies.data.loadbalancer.ResourceUsage;
-import org.testng.annotations.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class ModularLoadManagerStrategyTest {
     // Test that least long term message rate works correctly.

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -1,0 +1,51 @@
+package com.yahoo.pulsar.broker.loadbalance;
+
+import com.yahoo.pulsar.broker.BrokerData;
+import com.yahoo.pulsar.broker.BundleData;
+import com.yahoo.pulsar.broker.LocalBrokerData;
+import com.yahoo.pulsar.broker.ServiceConfiguration;
+import com.yahoo.pulsar.broker.TimeAverageBrokerData;
+import com.yahoo.pulsar.broker.loadbalance.impl.LeastLongTermMessageRate;
+import com.yahoo.pulsar.common.policies.data.loadbalancer.ResourceUsage;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ModularLoadManagerStrategyTest {
+    // Test that least long term message rate works correctly.
+    @Test
+    public void testLeastLongTermMessageRate() {
+        BundleData bundleData = new BundleData();
+        BrokerData brokerData1 = initBrokerData();
+        BrokerData brokerData2 = initBrokerData();
+        BrokerData brokerData3 = initBrokerData();
+        brokerData1.getTimeAverageData().setLongTermMsgRateIn(100);
+        brokerData2.getTimeAverageData().setLongTermMsgRateIn(200);
+        brokerData3.getTimeAverageData().setLongTermMsgRateIn(300);
+        LoadData loadData = new LoadData();
+        Map<String, BrokerData> brokerDataMap = loadData.getBrokerData();
+        brokerDataMap.put("1", brokerData1);
+        brokerDataMap.put("2", brokerData2);
+        brokerDataMap.put("3", brokerData3);
+        ServiceConfiguration conf = new ServiceConfiguration();
+        ModularLoadManagerStrategy strategy = new LeastLongTermMessageRate(conf);
+        assert (strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf).equals("1"));
+        brokerData1.getTimeAverageData().setLongTermMsgRateIn(400);
+        assert (strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf).equals("2"));
+        brokerData2.getLocalData().setCpu(new ResourceUsage(90, 100));
+        assert (strategy.selectBroker(brokerDataMap.keySet(), bundleData, loadData, conf).equals("3"));
+    }
+
+    private BrokerData initBrokerData() {
+        LocalBrokerData localBrokerData = new LocalBrokerData();
+        localBrokerData.setCpu(new ResourceUsage());
+        localBrokerData.setMemory(new ResourceUsage());
+        localBrokerData.setBandwidthIn(new ResourceUsage());
+        localBrokerData.setBandwidthOut(new ResourceUsage());
+        BrokerData brokerData = new BrokerData(localBrokerData);
+        TimeAverageBrokerData timeAverageBrokerData = new TimeAverageBrokerData();
+        brokerData.setTimeAverageData(timeAverageBrokerData);
+        return brokerData;
+    }
+}

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -15,34 +15,29 @@
  */
 package com.yahoo.pulsar.broker.namespace;
 
-import static com.yahoo.pulsar.broker.cache.LocalZooKeeperCacheService.LOCAL_POLICIES_ROOT;
-import static com.yahoo.pulsar.broker.web.PulsarWebResource.joinPath;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.google.common.collect.Lists;
+import com.google.common.hash.Hashing;
+import com.yahoo.pulsar.broker.LocalBrokerData;
+import com.yahoo.pulsar.broker.loadbalance.LoadManager;
+import com.yahoo.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
+import com.yahoo.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
+import com.yahoo.pulsar.broker.lookup.LookupResult;
+import com.yahoo.pulsar.broker.service.BrokerTestBase;
+import com.yahoo.pulsar.broker.service.Topic;
+import com.yahoo.pulsar.broker.service.persistent.PersistentTopic;
+import com.yahoo.pulsar.client.api.Consumer;
+import com.yahoo.pulsar.client.api.ConsumerConfiguration;
+import com.yahoo.pulsar.common.naming.*;
+import com.yahoo.pulsar.common.policies.data.Policies;
+import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
+import com.yahoo.pulsar.common.util.ObjectMapperFactory;
+import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
 import org.mockito.invocation.InvocationOnMock;
@@ -54,35 +49,19 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
-import com.google.common.collect.Lists;
-import com.google.common.hash.Hashing;
-import com.yahoo.pulsar.broker.LocalBrokerData;
-import com.yahoo.pulsar.broker.PulsarServerException;
-import com.yahoo.pulsar.broker.PulsarService;
-import com.yahoo.pulsar.broker.loadbalance.LoadManager;
-import com.yahoo.pulsar.broker.loadbalance.ModularLoadManager;
-import com.yahoo.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
-import com.yahoo.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
-import com.yahoo.pulsar.broker.lookup.LookupResult;
-import com.yahoo.pulsar.broker.service.BrokerTestBase;
-import com.yahoo.pulsar.broker.service.Topic;
-import com.yahoo.pulsar.broker.service.persistent.PersistentTopic;
-import com.yahoo.pulsar.client.api.Consumer;
-import com.yahoo.pulsar.client.api.ConsumerConfiguration;
-import com.yahoo.pulsar.common.naming.DestinationName;
-import com.yahoo.pulsar.common.naming.NamespaceBundle;
-import com.yahoo.pulsar.common.naming.NamespaceBundleFactory;
-import com.yahoo.pulsar.common.naming.NamespaceBundles;
-import com.yahoo.pulsar.common.naming.NamespaceName;
-import com.yahoo.pulsar.common.naming.ServiceUnitId;
-import com.yahoo.pulsar.common.policies.data.Policies;
-import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
-import com.yahoo.pulsar.common.policies.data.loadbalancer.ServiceLookupData;
-import com.yahoo.pulsar.common.util.ObjectMapperFactory;
-import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static com.yahoo.pulsar.broker.cache.LocalZooKeeperCacheService.LOCAL_POLICIES_ROOT;
+import static com.yahoo.pulsar.broker.web.PulsarWebResource.joinPath;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 public class NamespaceServiceTest extends BrokerTestBase {
 
@@ -332,6 +311,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         Assert.assertEquals(result1.getLookupData().getBrokerUrl(), candidateBroker1);
         Assert.assertEquals(result2.getLookupData().getBrokerUrl(), candidateBroker2);
         System.out.println(result2);
+
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperChildrenCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperChildrenCache.java
@@ -96,7 +96,7 @@ public class ZooKeeperChildrenCache implements Watcher, CacheUpdater<Set<String>
         }
     }
 
-    public void shutdown() {
+    public void close() {
         isShutdown.set(true);
     }
 }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperChildrenCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperChildrenCache.java
@@ -17,6 +17,7 @@ package com.yahoo.pulsar.zookeeper;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -36,10 +37,12 @@ public class ZooKeeperChildrenCache implements Watcher, CacheUpdater<Set<String>
     private final ZooKeeperCache cache;
     private final String path;
     private final List<ZooKeeperCacheListener<Set<String>>> listeners = Lists.newCopyOnWriteArrayList();
+    private final AtomicBoolean isShutdown;
 
     public ZooKeeperChildrenCache(ZooKeeperCache cache, String path) {
         this.cache = cache;
         this.path = path;
+        isShutdown = new AtomicBoolean(false);
     }
 
     public Set<String> get() throws KeeperException, InterruptedException {
@@ -88,6 +91,12 @@ public class ZooKeeperChildrenCache implements Watcher, CacheUpdater<Set<String>
     @Override
     public void process(WatchedEvent event) {
         LOG.debug("[{}] Received ZooKeeper watch event: {}", cache.zkSession.get(), event);
-        cache.process(event, this);
+        if (!isShutdown.get()) {
+            cache.process(event, this);
+        }
+    }
+
+    public void shutdown() {
+        isShutdown.set(true);
     }
 }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -138,7 +138,7 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
     @Override
     public void process(WatchedEvent event) {
         LOG.info("[{}] Received ZooKeeper watch event: {}", cache.zkSession.get(), event);
-        if (IS_SHUTDOWN_UPDATER.get(this) == TRUE) {
+        if (IS_SHUTDOWN_UPDATER.get(this) == FALSE) {
             cache.process(event, this);
         }
     }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -143,7 +143,7 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
         }
     }
 
-    public void shutdown() {
+    public void close() {
         IS_SHUTDOWN_UPDATER.set(this, TRUE);
     }
 }


### PR DESCRIPTION
### Motivation

The new load management API introduced a few bugs that have been observed, namely that

* After dynamically changing the Load Manager, watches from the old load manager will continue to try to parse jsons in the wrong format (`LoadReport` -> `LocalBrokerData` and vice-versa).
* `NamespaceService` will fail to construct `LookupResult` since JSON cannot instantiate the abstract class `ServiceLookupData`.
* `LeastLongTermMessageRate` always reported that brokers were overloaded due to an integer division bug

### Modifications
Both load managers will now shutdown their schedulers and unregister themselves as watchers. Some log statements were added for the new load manager.

### Result
Some bugs introduced by the new load manager will be fixed.
