### PR TITLE
Legacy code expects the AuthData to be initialized to Auth::Disabled

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -39,6 +39,12 @@
                 return ptr;
             }
         };
+        class Auth {
+            public:
+            static AuthDataPtr Disabled() {
+                return AuthDataPtr();
+            }
+        }
     }
 #endif
 #pragma GCC visibility push(default)

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -42,6 +42,7 @@ struct ClientConfiguration::Impl {
     std::string tlsTrustCertsFilePath;
     bool tlsAllowInsecureConnection;
     Impl() : authenticationPtr(AuthFactory::Disabled()),
+             authDataPtr(Auth::Disabled()),
              ioThreads(1),
              operationTimeoutSeconds(30),
              messageListenerThreads(1),


### PR DESCRIPTION
### Motivation

Legacy code expects the AuthData to be initialized to Auth::Disabled. Don't want the legacy code to fail.

### Modifications

Added pogo Auth class and initialized authDataPtr with Auth::Disabled

### Result

Legacy code doesn't need to change.
