### PR TITLE
Fixed Null Pointer Exception in handleLookup

### DIFF
--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
@@ -416,11 +416,15 @@ public class Commands {
     public static ByteBuf newLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
             LookupType response, long requestId) {
         CommandLookupTopicResponse.Builder connectionBuilder = CommandLookupTopicResponse.newBuilder();
-        connectionBuilder.setBrokerServiceUrl(brokerServiceUrl);
+        if (brokerServiceUrl != null) {
+            connectionBuilder.setBrokerServiceUrl(brokerServiceUrl);
+        }
         if (brokerServiceUrlTls != null) {
             connectionBuilder.setBrokerServiceUrlTls(brokerServiceUrlTls);    
         }
-        connectionBuilder.setResponse(response);
+        if (response != null) {
+            connectionBuilder.setResponse(response);
+        }
         connectionBuilder.setRequestId(requestId);
         connectionBuilder.setAuthoritative(authoritative);
 


### PR DESCRIPTION
### Motivation
Solve NPE in handleLookup

### Modifications

Added a null check before setting the responseType and serviceUrl

### Result

No more NPE

### Exception

Caused by: java.lang.NullPointerException: null
        at com.yahoo.pulsar.common.api.proto.PulsarApi$CommandLookupTopicResponse$Builder.setBrokerServiceUrl(PulsarApi.java:7062) ~[pulsar-common-1.17.1.jar:na]
        at com.yahoo.pulsar.common.api.Commands.newLookupResponse(Commands.java:419) ~[pulsar-common-1.17.1.jar:na]
        at com.yahoo.pulsar.broker.lookup.DestinationLookup.lambda$lookupDestinationAsync$4(DestinationLookup.java:172) ~[pulsar-broker-1.17.1.jar:na]
        at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[na:1.8.0_112]