### PR TITLE
fix import into AdminApiTest and introduce disable-namespaceBundle unit test

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -439,7 +439,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
      * @return CompletableFuture<Topic>
      * @throws RuntimeException
      */
-    private CompletableFuture<Topic> createPersistentTopic(final String topic) throws RuntimeException {
+    protected CompletableFuture<Topic> createPersistentTopic(final String topic) throws RuntimeException {
         checkTopicNsOwnership(topic);
 
         final CompletableFuture<Topic> topicFuture = new CompletableFuture<>();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
@@ -57,6 +57,7 @@ import com.yahoo.pulsar.broker.ServiceConfiguration;
 import com.yahoo.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import com.yahoo.pulsar.broker.namespace.NamespaceEphemeralData;
 import com.yahoo.pulsar.broker.namespace.NamespaceService;
+import com.yahoo.pulsar.broker.service.BrokerService;
 import com.yahoo.pulsar.client.admin.PulsarAdmin;
 import com.yahoo.pulsar.client.admin.PulsarAdminException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.ConflictException;

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
@@ -1698,34 +1698,4 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(uriStats.get().subscriptions.size(), 1);
     }
 
-    /**
-     * Verifies that deleteNamespace cleans up policies(global,local), bundle cache and bundle ownership
-     * 
-     * @throws Exception
-     */
-    @Test
-    public void testDeleteNamespace() throws Exception {
-
-        final String namespace = "prop-xyz/use/deleteNs";
-        admin.namespaces().createNamespace(namespace, 100);
-        assertEquals(admin.namespaces().getPolicies(namespace).bundles.numBundles, 100);
-
-        // (1) Force topic creation and namespace being loaded
-        final String topicName = "persistent://" + namespace + "/my-topic";
-        DestinationName destination = DestinationName.get(topicName);
-
-        Producer producer = pulsarClient.createProducer(topicName);
-        producer.close();
-        NamespaceBundle bundle1 = pulsar.getNamespaceService().getBundle(destination);
-        // (2) Delete topic
-        admin.persistentTopics().delete(topicName);
-        // (3) Delete ns
-        admin.namespaces().deleteNamespace(namespace);
-        // (4) check bundle
-        NamespaceBundle bundle2 = pulsar.getNamespaceService().getBundle(destination);
-        assertNotEquals(bundle1.getBundleRange(), bundle2.getBundleRange());
-        // returns full bundle if policies not present 
-        assertEquals("0x00000000_0xffffffff", bundle2.getBundleRange());
-
-    }
 }


### PR DESCRIPTION
### Motivation

Seems due to merge build is failing with following error
```
[ERROR] /home/travis/build/yahoo/pulsar/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java:[451,31] error: cannot find symbol
[ERROR]  class AdminApiTest
/home/travis/build/yahoo/pulsar/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java:[458,31] error: cannot find symbol
```

Also added unit-test for #336 