### PR TITLE
Fixed WebSocket TLS connection bug

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
@@ -160,6 +160,9 @@ public class WebSocketService implements Closeable {
     private PulsarClient createClientInstance(ClusterData clusterData) throws IOException {
         ClientConfiguration clientConf = new ClientConfiguration();
         clientConf.setStatsInterval(0, TimeUnit.SECONDS);
+        clientConf.setUseTls(config.isTlsEnabled());
+        clientConf.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
+        clientConf.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
         if (config.isAuthenticationEnabled()) {
             clientConf.setAuthentication(config.getBrokerClientAuthenticationPlugin(),
                     config.getBrokerClientAuthenticationParameters());
@@ -194,8 +197,10 @@ public class WebSocketService implements Closeable {
         serviceConfig.setGlobalZookeeperServers(config.getGlobalZookeeperServers());
         serviceConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());
         serviceConfig.setTlsEnabled(config.isTlsEnabled());
+        serviceConfig.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
         serviceConfig.setTlsCertificateFilePath(config.getTlsCertificateFilePath());
         serviceConfig.setTlsKeyFilePath(config.getTlsKeyFilePath());
+        serviceConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
         return serviceConfig;
     }
 

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -65,6 +65,10 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String tlsCertificateFilePath;
     // Path for the TLS private key file
     private String tlsKeyFilePath;
+    // Path for the trusted TLS certificate file
+    private String tlsTrustCertsFilePath = "";
+    // Accept untrusted TLS certificate from client
+    private boolean tlsAllowInsecureConnection = false;
     
     private Properties properties = new Properties();
 
@@ -202,6 +206,22 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     public void setTlsKeyFilePath(String tlsKeyFilePath) {
         this.tlsKeyFilePath = tlsKeyFilePath;
+    }
+
+    public String getTlsTrustCertsFilePath() {
+        return tlsTrustCertsFilePath;
+    }
+
+    public void setTlsTrustCertsFilePath(String tlsTrustCertsFilePath) {
+        this.tlsTrustCertsFilePath = tlsTrustCertsFilePath;
+    }
+
+    public boolean isTlsAllowInsecureConnection() {
+        return tlsAllowInsecureConnection;
+    }
+
+    public void setTlsAllowInsecureConnection(boolean tlsAllowInsecureConnection) {
+        this.tlsAllowInsecureConnection = tlsAllowInsecureConnection;
     }
     
     public Properties getProperties() {


### PR DESCRIPTION
### Motivation

WebSocket connection is failed when using TLS connection between WebSocket proxy and broker because of the lack of some configurations.

### Modifications

Added statement for configurations.

### Result

WebSocket connection won't be failed.