### PR TITLE
Fix LoadManager shutdown timing issue

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -575,8 +575,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     @Override
     public void stop() throws PulsarServerException {
         availableActiveBrokers.close();
-        brokerDataCache.clear();
         brokerDataCache.close();
+        brokerDataCache.clear();
         scheduler.shutdown();
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1434,8 +1434,8 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public void stop() throws PulsarServerException {
-        loadReportCacheZk.clear();
         loadReportCacheZk.close();
+        loadReportCacheZk.clear();
         availableActiveBrokers.close();
         scheduler.shutdown();
     }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -143,7 +143,7 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
         }
     }
 
-    public void close() {
+    public synchronized void close() {
         IS_SHUTDOWN_UPDATER.set(this, TRUE);
     }
 }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -143,7 +143,7 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
         }
     }
 
-    public synchronized void close() {
+    public void close() {
         IS_SHUTDOWN_UPDATER.set(this, TRUE);
     }
 }


### PR DESCRIPTION
### Motivation

When changing the load balancer strategy dynamically via pulsar-admin, it is possible for a ZooKeeper watch to fire inside the LoadManager::stop() after the ZK load report cache was cleared but before it was closed.

### Modifications

Switch the order of close() and clear(). 

### Result

It should be possible to change load balancer strategies dynamically.