### PR TITLE
Use multiple ZK sessions for BK and ManagedLedger

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -98,8 +98,8 @@ tlsTrustCertsFilePath=
 tlsAllowInsecureConnection=false
 
 # Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
-# messages to consumer once, this limit reaches until consumer starts acknowledging messages back. 
-# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction 
+# messages to consumer once, this limit reaches until consumer starts acknowledging messages back.
+# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
 maxUnackedMessagesPerConsumer=50000
 
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
@@ -213,6 +213,9 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # crashes.
 managedLedgerMaxUnackedRangesToPersist=1000
 
+# Number of independent ZK sessions to open. More sessions will speed
+# up ZK operations by using different threads and connections
+managedLedgerZooKeeperSessions=1
 
 
 ### --- Load balancer --- ###

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
@@ -137,8 +137,8 @@ public class ManagedLedgerOfflineBacklog {
     private void readLedgerMeta(final ManagedLedgerFactoryImpl factory, final DestinationName dn,
             final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers) throws Exception {
         String managedLedgerName = dn.getPersistenceNamingEncoding();
-        MetaStore store = factory.getMetaStore();
-        BookKeeper bk = factory.getBookKeeper();
+        MetaStore store = factory.getMetaStore(managedLedgerName);
+        BookKeeper bk = factory.getBookKeeper(managedLedgerName);
         final CountDownLatch mlMetaCounter = new CountDownLatch(1);
 
         store.getManagedLedgerInfo(managedLedgerName,
@@ -213,8 +213,8 @@ public class ManagedLedgerOfflineBacklog {
             return;
         }
         String managedLedgerName = dn.getPersistenceNamingEncoding();
-        MetaStore store = factory.getMetaStore();
-        BookKeeper bk = factory.getBookKeeper();
+        MetaStore store = factory.getMetaStore(managedLedgerName);
+        BookKeeper bk = factory.getBookKeeper(managedLedgerName);
         final CountDownLatch allCursorsCounter = new CountDownLatch(1);
         final long errorInReadingCursor = (long) -1;
         ConcurrentOpenHashMap<String, Long> ledgerRetryMap = new ConcurrentOpenHashMap<>();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1135,7 +1135,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
     @Test
     public void ledgersList() throws Exception {
-        MetaStore store = factory.getMetaStore();
+        MetaStore store = factory.getMetaStore("mlName");
 
         assertEquals(Sets.newHashSet(store.getManagedLedgers()), Sets.newHashSet());
         ManagedLedger ledger1 = factory.open("ledger1");
@@ -1471,7 +1471,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         // Add the deleted ledger back in the meta-data to simulate an empty ledger that was deleted but not removed
         // from the list of ledgers
         final CountDownLatch counter = new CountDownLatch(1);
-        final MetaStore store = factory.getMetaStore();
+        final MetaStore store = factory.getMetaStore("my_test_ledger");
         store.getManagedLedgerInfo("my_test_ledger", new MetaStoreCallback<ManagedLedgerInfo>() {
             @Override
             public void operationComplete(ManagedLedgerInfo result, Stat version) {

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -194,6 +194,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // crashes.
     private int managedLedgerMaxUnackedRangesToPersist = 1000;
 
+    // Number of independent ZK sessions to open. More sessions will speed
+    // up ZK operations by using different threads and connections
+    @FieldContext(minValue = 1)
+    private int managedLedgerZooKeeperSessions = 1;
+
     /*** --- Load balancer --- ****/
     // Enable load balancer
     private boolean loadBalancerEnabled = false;
@@ -720,6 +725,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setManagedLedgerMaxUnackedRangesToPersist(int managedLedgerMaxUnackedRangesToPersist) {
         this.managedLedgerMaxUnackedRangesToPersist = managedLedgerMaxUnackedRangesToPersist;
+    }
+
+    public int getManagedLedgerZooKeeperSessions() {
+        return managedLedgerZooKeeperSessions;
+    }
+
+    public void setManagedLedgerZooKeeperSessions(int managedLedgerZooKeeperSessions) {
+        this.managedLedgerZooKeeperSessions = managedLedgerZooKeeperSessions;
     }
 
     public boolean isLoadBalancerEnabled() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/BookKeeperClientFactory.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/BookKeeperClientFactory.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.zookeeper.ZooKeeper;
 
+import io.netty.channel.EventLoopGroup;
+
 /**
  * Provider of a new BookKeeper client instance
  */
 public interface BookKeeperClientFactory {
-    BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient) throws IOException;
+    BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient, EventLoopGroup eventLoopGroup) throws IOException;
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -29,10 +29,12 @@ import com.yahoo.pulsar.zookeeper.ZkBookieRackAffinityMapping;
 import com.yahoo.pulsar.zookeeper.ZkIsolatedBookieEnsemblePlacementPolicy;
 import com.yahoo.pulsar.zookeeper.ZooKeeperCache;
 
+import io.netty.channel.EventLoopGroup;
+
 public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
 
     @Override
-    public BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient) throws IOException {
+    public BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient, EventLoopGroup eventLoopGroup) throws IOException {
         ClientConfiguration bkConf = new ClientConfiguration();
 
         if (conf.getBookkeeperClientAuthenticationPlugin() != null
@@ -46,7 +48,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setAddEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setReadEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setSpeculativeReadTimeout(conf.getBookkeeperClientSpeculativeReadTimeoutInMillis());
-        bkConf.setNumChannelsPerBookie(16);
+        bkConf.setNumChannelsPerBookie(1);
         bkConf.setUseV2WireProtocol(true);
         bkConf.setLedgerManagerFactoryClassName(HierarchicalLedgerManagerFactory.class.getName());
         if (conf.isBookkeeperClientHealthCheckEnabled()) {
@@ -76,7 +78,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         }
 
         try {
-            return new BookKeeper(bkConf, zkClient);
+            return new BookKeeper(bkConf, zkClient, eventLoopGroup);
         } catch (InterruptedException | KeeperException e) {
             throw new IOException(e);
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
@@ -30,12 +30,7 @@ import java.util.function.Supplier;
 
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
-import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooDefs;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.zookeeper.ZooKeeper;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
@@ -73,6 +68,9 @@ import com.yahoo.pulsar.zookeeper.ZooKeeperCache;
 import com.yahoo.pulsar.zookeeper.ZooKeeperClientFactory;
 import com.yahoo.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
@@ -109,6 +107,8 @@ public class PulsarService implements AutoCloseable {
     private final String brokerServiceUrl;
     private final String brokerServiceUrlTls;
 
+    private final EventLoopGroup ioEventLoopGroup;
+
     private final MessagingServiceShutdownHook shutdownService;
 
     private MetricsGenerator metricsGenerator;
@@ -131,6 +131,7 @@ public class PulsarService implements AutoCloseable {
         this.brokerServiceUrl = brokerUrl(config);
         this.brokerServiceUrlTls = brokerUrlTls(config);
         this.config = config;
+        this.ioEventLoopGroup = newEventLoopGroup("pulsar-io", 2 * Runtime.getRuntime().availableProcessors());
         this.shutdownService = new MessagingServiceShutdownHook(this);
         loadManagerExecutor = Executors.newSingleThreadScheduledExecutor();
     }
@@ -235,7 +236,7 @@ public class PulsarService implements AutoCloseable {
             // Initialize and start service to access configuration repository.
             this.startZkCacheService();
 
-            managedLedgerClientFactory = new ManagedLedgerClientFactory(config, getZkClient(),
+            managedLedgerClientFactory = new ManagedLedgerClientFactory(this, getZooKeeperClientFactory(),
                     getBookKeeperClientFactory());
 
             this.brokerService = new BrokerService(this);
@@ -635,4 +636,23 @@ public class PulsarService implements AutoCloseable {
         return loadManager;
     }
 
+    public EventLoopGroup getIOEventLoopGroup() {
+        return ioEventLoopGroup;
+    }
+
+    public EventLoopGroup newEventLoopGroup(String name, int numberOfThreads) {
+        DefaultThreadFactory workersThreadFactory = new DefaultThreadFactory(name);
+        EventLoopGroup eventLoopGroup;
+        if (SystemUtils.IS_OS_LINUX) {
+            try {
+                eventLoopGroup = new EpollEventLoopGroup(numberOfThreads, workersThreadFactory);
+            } catch (UnsatisfiedLinkError e) {
+                eventLoopGroup = new NioEventLoopGroup(numberOfThreads, workersThreadFactory);
+            }
+        } else {
+            eventLoopGroup = new NioEventLoopGroup(numberOfThreads, workersThreadFactory);
+        }
+
+        return eventLoopGroup;
+    }
 }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -49,6 +49,8 @@ import com.yahoo.pulsar.client.api.PulsarClient;
 import com.yahoo.pulsar.zookeeper.ZooKeeperClientFactory;
 import com.yahoo.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 
+import io.netty.channel.EventLoopGroup;
+
 /**
  * Base class for all tests that need a Pulsar instance without a ZK and BK cluster
  */
@@ -212,7 +214,7 @@ public abstract class MockedPulsarServiceBaseTest {
     private BookKeeperClientFactory mockBookKeeperClientFactory = new BookKeeperClientFactory() {
 
         @Override
-        public BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient) throws IOException {
+        public BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient, EventLoopGroup eventLoopGroup) throws IOException {
             // Always return the same instance (so that we don't loose the mock BK content on broker restart
             return mockBookKeeper;
         }


### PR DESCRIPTION
### Motivation

Using multiple ZK sessions in ManagedLedger can speed up the concurrent graceful shutdown and reloading of many topics at the same time.

Default is being kept to 1 single ZK session.

### Modifications

Create multiple ZK sessions and multiple BK instances. Topics are hashed to a specific ZK/BK instance.
