### PR TITLE
Fix dispatcher returns unblocked consumer by performing round-robin iteration on consumer-list

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -94,6 +94,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
             log.warn("[{}] Dispatcher is already closed. Closing consumer ", name, consumer);
             consumer.disconnect();
+            return;
         }
         if (consumerList.isEmpty()) {
             if (havePendingRead || havePendingReplayRead) {
@@ -456,8 +457,8 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
 
             // if resultingAvailableConsumerIndex moved ahead of currentConsumerRoundRobinIndex: then we should
             // check skipped consumer which had same priority as currentConsumerRoundRobinIndex consumer
-            boolean isLastConsumerBlocked = (currentConsumerRoundRobinIndex == (consumerList.size() - 1)
-                    && !isConsumerAvailable(consumerList.get(currentConsumerRoundRobinIndex)));
+            boolean isLastConsumerBlocked = (resultingAvailableConsumerIndex == (consumerList.size() - 1)
+                    && !isConsumerAvailable(consumerList.get(resultingAvailableConsumerIndex)));
             boolean shouldScanCurrentLevel = priorityLevel < 0
                     /* means moved to next lower-priority-level */ || isLastConsumerBlocked;
             if (shouldScanCurrentLevel && scanFromBeginningIfCurrentConsumerNotAvailable) {
@@ -483,6 +484,9 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
         } while (true);
 
         // not found unblocked consumer
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Couldn't find available consumer ", name);
+        }
         return null;
     }
     

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -269,15 +269,15 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
-        Consumer consumer1 = createConsumer(0, 2, 1);
-        Consumer consumer2 = createConsumer(0, 2, 2);
-        Consumer consumer3 = createConsumer(0, 2, 3);
-        Consumer consumer4 = createConsumer(1, 2, 4);
-        Consumer consumer5 = createConsumer(1, 1, 5);
-        Consumer consumer6 = createConsumer(1, 2, 6);
-        Consumer consumer7 = createConsumer(2, 1, 7);
-        Consumer consumer8 = createConsumer(2, 1, 8);
-        Consumer consumer9 = createConsumer(2, 1, 9);
+        Consumer consumer1 = createConsumer(0, 2, false, 1);
+        Consumer consumer2 = createConsumer(0, 2, false, 2);
+        Consumer consumer3 = createConsumer(0, 2, false, 3);
+        Consumer consumer4 = createConsumer(1, 2, false, 4);
+        Consumer consumer5 = createConsumer(1, 1, false, 5);
+        Consumer consumer6 = createConsumer(1, 2, false, 6);
+        Consumer consumer7 = createConsumer(2, 1, false, 7);
+        Consumer consumer8 = createConsumer(2, 1, false, 8);
+        Consumer consumer9 = createConsumer(2, 1, false, 9);
         dispatcher.addConsumer(consumer1);
         dispatcher.addConsumer(consumer2);
         dispatcher.addConsumer(consumer3);
@@ -301,7 +301,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         Assert.assertEquals(getNextConsumer(dispatcher), consumer7);
         Assert.assertEquals(getNextConsumer(dispatcher), consumer8);
         // in between add upper priority consumer with more permits
-        Consumer consumer10 = createConsumer(0, 2, 10);
+        Consumer consumer10 = createConsumer(0, 2, false, 10);
         dispatcher.addConsumer(consumer10);
         Assert.assertEquals(getNextConsumer(dispatcher), consumer10);
         Assert.assertEquals(getNextConsumer(dispatcher), consumer10);
@@ -309,21 +309,134 @@ public class PersistentDispatcherFailoverConsumerTest {
 
     }
 
-    private Consumer getNextConsumer(PersistentDispatcherMultipleConsumers dispatcher) throws Exception {
-        Consumer consumer = dispatcher.getNextConsumer();
-        Field field = Consumer.class.getDeclaredField("MESSAGE_PERMITS_UPDATER");
-        field.setAccessible(true);
-        AtomicIntegerFieldUpdater<Consumer> messagePermits = (AtomicIntegerFieldUpdater) field.get(consumer);
-        messagePermits.decrementAndGet(consumer);
-        return consumer;
+    @Test
+    public void testFewBlockedConsumerSamePriority() throws Exception{
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        Consumer consumer1 = createConsumer(0, 2, false, 1);
+        Consumer consumer2 = createConsumer(0, 2, false, 2);
+        Consumer consumer3 = createConsumer(0, 2, false, 3);
+        Consumer consumer4 = createConsumer(0, 2, false, 4);
+        Consumer consumer5 = createConsumer(0, 1, true, 5);
+        Consumer consumer6 = createConsumer(0, 2, true, 6);
+        dispatcher.addConsumer(consumer1);
+        dispatcher.addConsumer(consumer2);
+        dispatcher.addConsumer(consumer3);
+        dispatcher.addConsumer(consumer4);
+        dispatcher.addConsumer(consumer5);
+        dispatcher.addConsumer(consumer6);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer1);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer2);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer3);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer1);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer2);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer3);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), null);
     }
 
-    private Consumer createConsumer(int priority, int permit, int id) throws BrokerServiceException {
+    @Test
+    public void testFewBlockedConsumerDifferentPriority() throws Exception {
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        Consumer consumer1 = createConsumer(0, 2, false, 1);
+        Consumer consumer2 = createConsumer(0, 2, false, 2);
+        Consumer consumer3 = createConsumer(0, 2, false, 3);
+        Consumer consumer4 = createConsumer(0, 2, false, 4);
+        Consumer consumer5 = createConsumer(0, 1, true, 5);
+        Consumer consumer6 = createConsumer(0, 2, true, 6);
+        Consumer consumer7 = createConsumer(1, 2, false, 7);
+        Consumer consumer8 = createConsumer(1, 10, true, 8);
+        Consumer consumer9 = createConsumer(1, 2, false, 9);
+        Consumer consumer10 = createConsumer(2, 2, false, 10);
+        Consumer consumer11 = createConsumer(2, 10, true, 11);
+        Consumer consumer12 = createConsumer(2, 2, false, 12);
+        dispatcher.addConsumer(consumer1);
+        dispatcher.addConsumer(consumer2);
+        dispatcher.addConsumer(consumer3);
+        dispatcher.addConsumer(consumer4);
+        dispatcher.addConsumer(consumer5);
+        dispatcher.addConsumer(consumer6);
+        dispatcher.addConsumer(consumer7);
+        dispatcher.addConsumer(consumer8);
+        dispatcher.addConsumer(consumer9);
+        dispatcher.addConsumer(consumer10);
+        dispatcher.addConsumer(consumer11);
+        dispatcher.addConsumer(consumer12);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer1);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer2);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer3);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer1);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer2);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer3);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer7);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer9);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer7);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer9);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer10);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer12);
+        // add consumer with lower priority again
+        Consumer consumer13 = createConsumer(0, 2, false, 13);
+        Consumer consumer14 = createConsumer(0, 2, true, 14);
+        dispatcher.addConsumer(consumer13);
+        dispatcher.addConsumer(consumer14);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer13);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer13);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer10);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer12);
+        Assert.assertEquals(getNextConsumer(dispatcher), null);
+    }
+
+    @Test
+    public void testFewBlockedConsumerDifferentPriority2() throws Exception {
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+        PersistentDispatcherMultipleConsumers dispatcher = new PersistentDispatcherMultipleConsumers(topic, cursorMock);
+        Consumer consumer1 = createConsumer(0, 2, true, 1);
+        Consumer consumer2 = createConsumer(0, 2, true, 2);
+        Consumer consumer3 = createConsumer(0, 2, true, 3);
+        Consumer consumer4 = createConsumer(1, 2, false, 4);
+        Consumer consumer5 = createConsumer(1, 1, false, 5);
+        Consumer consumer6 = createConsumer(2, 1, false, 6);
+        Consumer consumer7 = createConsumer(2, 2, true, 7);
+        dispatcher.addConsumer(consumer1);
+        dispatcher.addConsumer(consumer2);
+        dispatcher.addConsumer(consumer3);
+        dispatcher.addConsumer(consumer4);
+        dispatcher.addConsumer(consumer5);
+        dispatcher.addConsumer(consumer6);
+        dispatcher.addConsumer(consumer7);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer5);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer4);
+        Assert.assertEquals(getNextConsumer(dispatcher), consumer6);
+        Assert.assertEquals(getNextConsumer(dispatcher), null);
+    }
+
+    private Consumer getNextConsumer(PersistentDispatcherMultipleConsumers dispatcher) throws Exception {
+        Consumer consumer = dispatcher.getNextConsumer();
+        if (consumer != null) {
+            Field field = Consumer.class.getDeclaredField("MESSAGE_PERMITS_UPDATER");
+            field.setAccessible(true);
+            AtomicIntegerFieldUpdater<Consumer> messagePermits = (AtomicIntegerFieldUpdater) field.get(consumer);
+            messagePermits.decrementAndGet(consumer);
+            return consumer;
+        }
+        return null;
+    }
+
+    private Consumer createConsumer(int priority, int permit, boolean blocked, int id) throws Exception {
         Consumer consumer = new Consumer(null, SubType.Shared, id, priority, ""+id, 5000, serverCnx, "appId");
         try {
             consumer.flowPermits(permit);
         } catch (Exception e) {
         }
+        // set consumer blocked flag
+        Field blockField = Consumer.class.getDeclaredField("blockedConsumerOnUnackedMsgs");
+        blockField.setAccessible(true);
+        blockField.set(consumer, blocked);
         return consumer;
     }
 


### PR DESCRIPTION
### Motivation

While finding `nextAvailableConsumer`:  `Dispatcher` traverse consumerList sequentially using index `resultingAvailableConsumerIndex` which increments by 1 on each iteration. So, `Dispatcher` should use `resultingAvailableConsumerIndex` to check current consumer's state rather checking `currentConsumerRoundRobinIndex`. 
Right now, `Dispatcher` checks wrong index (`currentConsumerRoundRobinIndex`) for current-iteration so, `Dispatcher` fails to complete `round-robin` if consumer is blocked on `currentConsumerRoundRobinIndex`.

**Issue:**
If we have list of consumers: [c1(unblocked), c2(unblocked), c3(blocked), c4 (blocked)] and if `currentConsumerRoundRobinIndex=2 (c3)` then 
- in first iteration it finds c3 is blocked and checks it’s not [last consumer](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L459) in the list so moves to next
- Second iteration it finds c4 is blocked and due to bug at [line-459](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L459) it checks currentConsumerRoundRobinIndex=c3 as last consumer instead currentIndex = c4 so, it finds c4 is not last consumer and it skips the scanning of skipped consumers (c1, c2) and couldn't find available consumer.
 Same scenario has been added as [testcase](https://github.com/rdhabalia/pulsar/blob/7bf4197b1e69b27e782d9bcd4258afc743160113/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java#L313) 


### Modifications

`Dispatcher` always uses `resultingAvailableConsumerIndex` as current index for the iteration.

### Result

`Dispatcher` successfully completes `round-robin` if consumer is blocked on `currentConsumerRoundRobinIndex`.
