### PR TITLE
Fix for flaky test in testLeakFailedLedgerOfManageCursor

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2435,6 +2435,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             }
         });
 
+        // Wait until operation is completed and the failed ledger should have been deleted
+        latch2.await();
+
         try {
             bkc.openLedgerNoRecovery(ledgerId, mlConfig.getDigestType(), mlConfig.getPassword());
             fail("ledger should have deleted due to update-cursor failure");


### PR DESCRIPTION
### Motivation

Test is not waiting for latch, so sometimes it fails the validation since the ledger was not yet deleted.