### PR TITLE
Get messageId in string format

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/MessageId.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/MessageId.java
@@ -44,4 +44,11 @@ public interface MessageId {
     public static MessageId fromByteArray(byte[] data) throws IOException {
         return MessageIdImpl.fromByteArray(data);
     }
+    
+    /**
+     * Get messageId in string format
+     * 
+     * @return MessageId in string format
+     */
+    public String getMsgIdAsString(String entitySeparator);
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/MessageId.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/MessageId.java
@@ -44,11 +44,4 @@ public interface MessageId {
     public static MessageId fromByteArray(byte[] data) throws IOException {
         return MessageIdImpl.fromByteArray(data);
     }
-    
-    /**
-     * Get messageId in string format
-     * 
-     * @return MessageId in string format
-     */
-    public String getMsgIdAsString(String entitySeparator);
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BatchMessageIdImpl.java
@@ -62,8 +62,13 @@ public class BatchMessageIdImpl extends MessageIdImpl implements Comparable<Mess
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(MessageIdImpl.class).add("ledgerId", ledgerId).add("entryId", entryId)
-                .add("partitionIndex", partitionIndex).add("batchIndex", batchIndex).toString();
+        String entitySeparator = ":";
+        StringBuilder str = new StringBuilder();
+        str.append("BatchMessageIdImpl = ");
+        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
+        str.append(entitySeparator).append(batchIndex);
+        return str.toString();
+
     }
 
     // Serialization
@@ -71,16 +76,5 @@ public class BatchMessageIdImpl extends MessageIdImpl implements Comparable<Mess
     @Override
     public byte[] toByteArray() {
         return toByteArray(batchIndex);
-    }
-    
-    @Override
-    public String getMsgIdAsString(String entitySeparator) {
-        if (entitySeparator == null) {
-            entitySeparator = ":";
-        }
-        StringBuilder str = new StringBuilder();
-        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
-        str.append(entitySeparator).append(batchIndex);
-        return str.toString();
     }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BatchMessageIdImpl.java
@@ -62,13 +62,7 @@ public class BatchMessageIdImpl extends MessageIdImpl implements Comparable<Mess
 
     @Override
     public String toString() {
-        String entitySeparator = ":";
-        StringBuilder str = new StringBuilder();
-        str.append("BatchMessageIdImpl = ");
-        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
-        str.append(entitySeparator).append(batchIndex);
-        return str.toString();
-
+        return String.format("%d:%d:%d:%d", ledgerId, entryId, partitionIndex, batchIndex);
     }
 
     // Serialization

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BatchMessageIdImpl.java
@@ -72,4 +72,15 @@ public class BatchMessageIdImpl extends MessageIdImpl implements Comparable<Mess
     public byte[] toByteArray() {
         return toByteArray(batchIndex);
     }
+    
+    @Override
+    public String getMsgIdAsString(String entitySeparator) {
+        if (entitySeparator == null) {
+            entitySeparator = ":";
+        }
+        StringBuilder str = new StringBuilder();
+        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
+        str.append(entitySeparator).append(batchIndex);
+        return str.toString();
+    }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
@@ -77,8 +77,11 @@ public class MessageIdImpl implements MessageId, Comparable<MessageIdImpl> {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(MessageIdImpl.class).add("ledgerId", ledgerId).add("entryId", entryId)
-                .add("partitionIndex", partitionIndex).toString();
+        String entitySeparator = ":";
+        StringBuilder str = new StringBuilder();
+        str.append("MessageIdImpl = ");
+        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
+        return str.toString();
     }
 
     // / Serialization
@@ -143,15 +146,5 @@ public class MessageIdImpl implements MessageId, Comparable<MessageIdImpl> {
     public byte[] toByteArray() {
         // there is no message batch so we pass -1
         return toByteArray(-1);
-    }
-
-    @Override
-    public String getMsgIdAsString(String entitySeparator) {
-        if (entitySeparator == null) {
-            entitySeparator = ":";
-        }
-        StringBuilder str = new StringBuilder();
-        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
-        return str.toString();
     }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
@@ -144,4 +144,14 @@ public class MessageIdImpl implements MessageId, Comparable<MessageIdImpl> {
         // there is no message batch so we pass -1
         return toByteArray(-1);
     }
+
+    @Override
+    public String getMsgIdAsString(String entitySeparator) {
+        if (entitySeparator == null) {
+            entitySeparator = ":";
+        }
+        StringBuilder str = new StringBuilder();
+        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
+        return str.toString();
+    }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
@@ -77,11 +77,7 @@ public class MessageIdImpl implements MessageId, Comparable<MessageIdImpl> {
 
     @Override
     public String toString() {
-        String entitySeparator = ":";
-        StringBuilder str = new StringBuilder();
-        str.append("MessageIdImpl = ");
-        str.append(ledgerId).append(entitySeparator).append(entryId).append(entitySeparator).append(partitionIndex);
-        return str.toString();
+        return String.format("%d:%d:%d", ledgerId, entryId, partitionIndex);
     }
 
     // / Serialization

--- a/pulsar-client/src/test/java/com/yahoo/pulsar/client/api/MessageIdTest.java
+++ b/pulsar-client/src/test/java/com/yahoo/pulsar/client/api/MessageIdTest.java
@@ -32,15 +32,15 @@ public class MessageIdTest {
     @Test
     public void messageIdTest() {
         MessageId mId = new MessageIdImpl(1, 2, 3);
-        assertEquals(mId.toString(), "MessageIdImpl = 1:2:3");
+        assertEquals(mId.toString(), "1:2:3");
         
         mId = new BatchMessageIdImpl(0, 2, 3, 4);
-        assertEquals(mId.toString(), "BatchMessageIdImpl = 0:2:3:4");
+        assertEquals(mId.toString(), "0:2:3:4");
         
         mId = new BatchMessageIdImpl(-1, 2, -3, 4);
-        assertEquals(mId.toString(), "BatchMessageIdImpl = -1:2:-3:4");
+        assertEquals(mId.toString(), "-1:2:-3:4");
         
         mId = new MessageIdImpl(0, -23, 3);
-        assertEquals(mId.toString(), "MessageIdImpl = 0:-23:3");
+        assertEquals(mId.toString(), "0:-23:3");
     }
 }

--- a/pulsar-client/src/test/java/com/yahoo/pulsar/client/api/MessageIdTest.java
+++ b/pulsar-client/src/test/java/com/yahoo/pulsar/client/api/MessageIdTest.java
@@ -32,15 +32,15 @@ public class MessageIdTest {
     @Test
     public void messageIdTest() {
         MessageId mId = new MessageIdImpl(1, 2, 3);
-        assertEquals(mId.getMsgIdAsString(null), "1:2:3");
+        assertEquals(mId.toString(), "MessageIdImpl = 1:2:3");
         
         mId = new BatchMessageIdImpl(0, 2, 3, 4);
-        assertEquals(mId.getMsgIdAsString(null), "0:2:3:4");
+        assertEquals(mId.toString(), "BatchMessageIdImpl = 0:2:3:4");
         
         mId = new BatchMessageIdImpl(-1, 2, -3, 4);
-        assertEquals(mId.getMsgIdAsString("-"), "-1-2--3-4");
+        assertEquals(mId.toString(), "BatchMessageIdImpl = -1:2:-3:4");
         
         mId = new MessageIdImpl(0, -23, 3);
-        assertEquals(mId.getMsgIdAsString(""), "0-233");
+        assertEquals(mId.toString(), "MessageIdImpl = 0:-23:3");
     }
 }

--- a/pulsar-client/src/test/java/com/yahoo/pulsar/client/api/MessageIdTest.java
+++ b/pulsar-client/src/test/java/com/yahoo/pulsar/client/api/MessageIdTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.pulsar.client.api;
+
+import org.testng.annotations.Test;
+
+import com.google.common.base.Objects;
+import com.yahoo.pulsar.client.impl.BatchMessageIdImpl;
+import com.yahoo.pulsar.client.impl.ConsumerId;
+import com.yahoo.pulsar.client.impl.MessageIdImpl;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.Assert;
+
+public class MessageIdTest {
+    
+    @Test
+    public void messageIdTest() {
+        MessageId mId = new MessageIdImpl(1, 2, 3);
+        assertEquals(mId.getMsgIdAsString(null), "1:2:3");
+        
+        mId = new BatchMessageIdImpl(0, 2, 3, 4);
+        assertEquals(mId.getMsgIdAsString(null), "0:2:3:4");
+        
+        mId = new BatchMessageIdImpl(-1, 2, -3, 4);
+        assertEquals(mId.getMsgIdAsString("-"), "-1-2--3-4");
+        
+        mId = new MessageIdImpl(0, -23, 3);
+        assertEquals(mId.getMsgIdAsString(""), "0-233");
+    }
+}


### PR DESCRIPTION
### Motivation

Currently, we log the message id as 
```
MessageIdWrapper
{ledgerId=160431102, entryId=406}
```

We want to log it in a concise fashion:
`{160431102:406}`

### Modifications

a. Added a function getMsgAsString() in
- MessageId
- MessageIdImpl
- BatchMessageIdImpl

### Result

No functionality change.