### PR TITLE
add complete list of configuration into websocket.conf template file

### DIFF
--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -19,7 +19,10 @@
 # Global Zookeeper quorum connection string
 globalZookeeperServers=
 
-// Pulsar cluster url to connect to broker (optional if globalZookeeperServers present)
+# Zookeeper session timeout in milliseconds
+zooKeeperSessionTimeoutMillis=30000
+
+# Pulsar cluster url to connect to broker (optional if globalZookeeperServers present)
 serviceUrl=
 serviceUrlTls=
 brokerServiceUrl=
@@ -27,6 +30,8 @@ brokerServiceUrlTls=
 
 # Port to use to server HTTP request
 webServicePort=8080
+# Port to use to server HTTPS request
+webServicePortTls=8443
 
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0
@@ -49,6 +54,26 @@ authorizationEnabled=false
 # operations and publish/consume from all topics
 superUserRoles=
 
+# Autentication provider name list (comma-separated), which is a list of class names
+authenticationProviders=
+
 # Authentication settings of the proxy itself. Used to connect to brokers
 brokerClientAuthenticationPlugin=
 brokerClientAuthenticationParameters=
+
+### --- TLS --- ###
+
+# Enable TLS
+tlsEnabled=false
+
+# Accept untrusted TLS certificate from client
+tlsAllowInsecureConnection=false
+
+# Path for the TLS certificate file
+tlsCertificateFilePath=
+
+# Path for the TLS private key file
+tlsKeyFilePath=
+
+# Path for the trusted TLS certificate file
+tlsTrustCertsFilePath=


### PR DESCRIPTION
### Motivation

For user review to check possible available configurations in `websocket.conf` template: It should include all configuration and few of them are missing. 

### Modifications

Added missing configuration and doc to websocket.conf template file.

