### PR TITLE
Remove Exceptionally Completed Topic Futures

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -379,7 +379,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             if (topicFuture != null) {
                 if (topicFuture.isCompletedExceptionally()) {
                     // Exceptional topics should be recreated.
-                    topics.remove(topic);
+                    topics.remove(topic, topicFuture);
                 } else {
                     return topicFuture;
                 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -377,7 +377,12 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         try {
             CompletableFuture<Topic> topicFuture = topics.get(topic);
             if (topicFuture != null) {
-                return topicFuture;
+                if (topicFuture.isCompletedExceptionally()) {
+                    // Exceptional topics should be recreated.
+                    topics.remove(topic);
+                } else {
+                    return topicFuture;
+                }
             }
             return topics.computeIfAbsent(topic, this::createPersistentTopic);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
### Motivation

It has been observed that [BrokerService](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java#L380) can have topics in a state in where exceptionally completed topic futures never recover. In particular, if a namespace is being unloaded while topics for that namespace are being created and then the namespace is again assigned to the same broker, these topics seem to never recover due to [an exceptional completion](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java#L474). 

### Modifications

When `getTopic` is invoked, if the future has already completed exceptionally, it is removed from the topic map.

### Result

Topics no longer fail to recover when unloading a namespace while being created.
