### PR TITLE
BrokerService should not remove failed topic from map with the same thread which adds in map to prevent deadlock

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerService.java
@@ -471,6 +471,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             // namespace is being unloaded
             String msg = String.format("Namespace is being unloaded, cannot add topic %s", topic);
             log.warn(msg);
+            pulsar.getExecutor().submit(() -> topics.remove(topic, topicFuture));
             topicFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
             return;
         }
@@ -514,7 +515,9 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
         }).exceptionally((exception) -> {
             log.warn("[{}] Failed to get topic configuration: {}", topic, exception.getMessage(), exception);
-            topics.remove(topic, topicFuture);
+            // remove topic from topics-map in different thread to avoid possible deadlock if
+            // createPersistentTopic-thread only tries to handle this future-result
+            pulsar.getExecutor().submit(() -> topics.remove(topic, topicFuture));
             topicFuture.completeExceptionally(exception);
             return null;
         });


### PR DESCRIPTION
### Motivation

while loading topic if broker-service fails to load it tries to remove topic from the map in the same thread which tries to load topic and it can create a [deadlock](https://gist.github.com/rdhabalia/c444d8602b6a0321fb2a59c0a2688187) while loading topic.

### Modifications

Remove topic from concurrentMap `topics` to prevent possible deadlock.

### Result

It will prevent possible deadlock while loading a topic.
