### PR TITLE
handle zkCache failure: invalidate cache and zk-getData failure

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
@@ -96,7 +96,7 @@ public class PulsarService implements AutoCloseable {
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(20,
             new DefaultThreadFactory("pulsar"));
     private final ScheduledExecutorService cacheExecutor = Executors.newScheduledThreadPool(10,
-            new DefaultThreadFactory("cache-callback"));
+            new DefaultThreadFactory("zk-cache-callback"));
     private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(8, "pulsar-ordered");
     private ScheduledExecutorService loadManagerExecutor = null;
     private ScheduledFuture<?> loadReportTask = null;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
@@ -95,6 +95,8 @@ public class PulsarService implements AutoCloseable {
     private LocalZooKeeperConnectionService localZooKeeperConnectionProvider;
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(20,
             new DefaultThreadFactory("pulsar"));
+    private final ScheduledExecutorService cacheExecutor = Executors.newScheduledThreadPool(10,
+            new DefaultThreadFactory("cache-callback"));
     private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(8, "pulsar-ordered");
     private ScheduledExecutorService loadManagerExecutor = null;
     private ScheduledFuture<?> loadReportTask = null;
@@ -382,10 +384,10 @@ public class PulsarService implements AutoCloseable {
 
         LOG.info("starting configuration cache service");
 
-        this.localZkCache = new LocalZooKeeperCache(getZkClient(), getOrderedExecutor(), this.executor);
+        this.localZkCache = new LocalZooKeeperCache(getZkClient(), getOrderedExecutor(), this.cacheExecutor);
         this.globalZkCache = new GlobalZooKeeperCache(getZooKeeperClientFactory(),
                 (int) config.getZooKeeperSessionTimeoutMillis(), config.getGlobalZookeeperServers(),
-                getOrderedExecutor(), this.executor);
+                getOrderedExecutor(), this.cacheExecutor);
         try {
             this.globalZkCache.start();
         } catch (IOException e) {
@@ -531,6 +533,10 @@ public class PulsarService implements AutoCloseable {
 
     public ScheduledExecutorService getExecutor() {
         return executor;
+    }
+
+    public ScheduledExecutorService getCacheExecutor() {
+        return cacheExecutor;
     }
 
     public ScheduledExecutorService getLoadManagerExecutor() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/ServerCnx.java
@@ -155,11 +155,11 @@ public class ServerCnx extends PulsarHandler {
     
     @Override
     protected void handleLookup(CommandLookupTopic lookup) {
-        if (log.isDebugEnabled()) {
-            log.debug("Received Lookup from {}", remoteAddress);
-        }
         final long requestId = lookup.getRequestId();
         final String topic = lookup.getTopic();
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Received Lookup from {} for {}", topic, remoteAddress, requestId);
+        }
         final Semaphore lookupSemaphore = service.getLookupRequestSemaphore();
         if (lookupSemaphore.tryAcquire()) {
             lookupDestinationAsync(getBrokerService().pulsar(), DestinationName.get(topic), lookup.getAuthoritative(),
@@ -187,11 +187,11 @@ public class ServerCnx extends PulsarHandler {
 
     @Override
     protected void handlePartitionMetadataRequest(CommandPartitionedTopicMetadata partitionMetadata) {
-        if (log.isDebugEnabled()) {
-            log.debug("Received PartitionMetadataLookup from {}", remoteAddress);
-        }
         final long requestId = partitionMetadata.getRequestId();
         final String topic = partitionMetadata.getTopic();
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Received PartitionMetadataLookup from {} for {}", topic, remoteAddress, requestId);
+        }
         final Semaphore lookupSemaphore = service.getLookupRequestSemaphore();
         if (lookupSemaphore.tryAcquire()) {
             getPartitionedTopicMetadata(getBrokerService().pulsar(), getRole(), DestinationName.get(topic))

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -29,6 +29,8 @@ import static org.testng.Assert.fail;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
 import org.apache.zookeeper.KeeperException;
@@ -60,6 +62,7 @@ public class OwnershipCacheTest {
     private NamespaceService nsService;
     private BrokerService brokerService;
     private OrderedSafeExecutor executor;
+    private ScheduledExecutorService scheduledExecutor;
 
     @BeforeMethod
     public void setup() throws Exception {
@@ -68,7 +71,8 @@ public class OwnershipCacheTest {
         pulsar = mock(PulsarService.class);
         config = mock(ServiceConfiguration.class);
         executor = new OrderedSafeExecutor(1, "test");
-        zkCache = new LocalZooKeeperCache(MockZooKeeper.newInstance(), executor, null);
+        scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+        zkCache = new LocalZooKeeperCache(MockZooKeeper.newInstance(), executor, scheduledExecutor);
         localCache = new LocalZooKeeperCacheService(zkCache, null);
         bundleFactory = new NamespaceBundleFactory(pulsar, Hashing.crc32());
         nsService = mock(NamespaceService.class);
@@ -88,6 +92,7 @@ public class OwnershipCacheTest {
     @AfterMethod
     public void teardown() throws Exception {
         executor.shutdown();
+        scheduledExecutor.shutdown();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -71,7 +71,7 @@ public class OwnershipCacheTest {
         pulsar = mock(PulsarService.class);
         config = mock(ServiceConfiguration.class);
         executor = new OrderedSafeExecutor(1, "test");
-        scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+        scheduledExecutor = Executors.newScheduledThreadPool(2);
         zkCache = new LocalZooKeeperCache(MockZooKeeper.newInstance(), executor, scheduledExecutor);
         localCache = new LocalZooKeeperCacheService(zkCache, null);
         bundleFactory = new NamespaceBundleFactory(pulsar, Hashing.crc32());

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/BrokerDiscoveryProvider.java
@@ -41,6 +41,8 @@ import com.yahoo.pulsar.discovery.service.web.ZookeeperCacheLoader;
 import com.yahoo.pulsar.zookeeper.GlobalZooKeeperCache;
 import com.yahoo.pulsar.zookeeper.ZooKeeperClientFactory;
 
+import io.netty.util.concurrent.DefaultThreadFactory;
+
 /**
  * Maintains available active broker list and returns next active broker in round-robin for discovery service.
  *
@@ -52,7 +54,8 @@ public class BrokerDiscoveryProvider implements Closeable {
     private final AtomicInteger counter = new AtomicInteger();
 
     private final OrderedSafeExecutor orderedExecutor = new OrderedSafeExecutor(4, "pulsar-discovery-ordered");
-    private final ScheduledExecutorService scheduledExecutorScheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduledExecutorScheduler = Executors.newScheduledThreadPool(4,
+            new DefaultThreadFactory("pulsar-discovery"));
 
     private static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
 

--- a/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/ZookeeperCacheLoader.java
+++ b/pulsar-discovery-service/src/main/java/com/yahoo/pulsar/discovery/service/web/ZookeeperCacheLoader.java
@@ -112,6 +112,7 @@ public class ZookeeperCacheLoader implements Closeable {
     @Override
     public void close() {
         orderedExecutor.shutdown();
+        executor.shutdown();
     }
 
     private void updateBrokerList(Set<String> brokerNodes) throws Exception {

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -60,11 +60,7 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
     public CompletableFuture<Optional<T>> getAsync(String path) {
         CompletableFuture<Optional<T>> future = new CompletableFuture<>();
         cache.getDataAsync(path, this, this).thenAccept(entry -> {
-            if (entry == null) {
-                future.complete(Optional.empty());
-            } else {
-                future.complete(entry.map(Entry::getKey));
-            }
+            future.complete(entry.map(Entry::getKey));
         }).exceptionally(ex -> {
             cache.asyncInvalidate(path);
             future.completeExceptionally(ex);

--- a/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
@@ -77,7 +77,7 @@ public class ZkBookieRackAffinityMappingTest {
         // Case1: ZKCache is given
         ZkBookieRackAffinityMapping mapping1 = new ZkBookieRackAffinityMapping();
         ClientConfiguration bkClientConf1 = new ClientConfiguration();
-        bkClientConf1.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, null, null) {
+        bkClientConf1.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         mapping1.setConf(bkClientConf1);
         List<String> racks1 = mapping1.resolve(Lists.newArrayList(BOOKIE1, BOOKIE2, BOOKIE3));
@@ -104,7 +104,7 @@ public class ZkBookieRackAffinityMappingTest {
     public void testNoBookieInfo() throws Exception {
         ZkBookieRackAffinityMapping mapping = new ZkBookieRackAffinityMapping();
         ClientConfiguration bkClientConf = new ClientConfiguration();
-        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, null, null) {
+        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         mapping.setConf(bkClientConf);
         List<String> racks = mapping.resolve(Lists.newArrayList(BOOKIE1, BOOKIE2, BOOKIE3));
@@ -158,7 +158,7 @@ public class ZkBookieRackAffinityMappingTest {
 
         ZkBookieRackAffinityMapping mapping = new ZkBookieRackAffinityMapping();
         ClientConfiguration bkClientConf = new ClientConfiguration();
-        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, null, null) {
+        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         mapping.setConf(bkClientConf);
         List<String> racks = mapping.resolve(Lists.newArrayList(BOOKIE1, BOOKIE2, BOOKIE3));

--- a/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
@@ -106,7 +106,7 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
 
         ZkIsolatedBookieEnsemblePlacementPolicy isolationPolicy = new ZkIsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
-        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, null, null) {
+        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
         isolationPolicy.initialize(bkClientConf);
@@ -176,7 +176,7 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
     public void testNoBookieInfo() throws Exception {
         ZkIsolatedBookieEnsemblePlacementPolicy isolationPolicy = new ZkIsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
-        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, null, null) {
+        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         bkClientConf.setProperty(ZkIsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
         isolationPolicy.initialize(bkClientConf);
@@ -296,7 +296,7 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
 
         ZkIsolatedBookieEnsemblePlacementPolicy isolationPolicy = new ZkIsolatedBookieEnsemblePlacementPolicy();
         ClientConfiguration bkClientConf = new ClientConfiguration();
-        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc, null, null) {
+        bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         isolationPolicy.initialize(bkClientConf);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);


### PR DESCRIPTION
### Motivation

Due to some reason if broker lose Global-Zk session then `ZooKeeperCache` should handle failure while getting data from lost zkSession.

### Modifications

- Handle null data from [ZooKeeperCache](https://github.com/yahoo/pulsar/blob/master/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java#L290) to prevent NPE.
- It should invalidate failed `future` from the cache so, next time when call comes then ZKCache can load fresh data from reconnected ZKSession.
- It should handle unexpected exception thrown while accessing disconnected zkSession.
- Introduce dedicated executor for zkCacheCallback to avoid [bottleneck](https://gist.github.com/rdhabalia/12a81e5189d2e60c2cd0ca1c84d4fb45#file-slow-caching-jstack2-L2027) on [pulsar's executor](https://github.com/yahoo/pulsar/blob/master/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java#L96)

### Result

It helps `ZooKeeperCache` to reload zk-node data if it fails earlier with zksession issue.
