### PR TITLE
Immediately close WebSocket session after errors

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/AbstractWebSocketHandler.java
@@ -92,7 +92,6 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
         super.onWebSocketError(cause);
         log.info("[{}] WebSocket error on topic {} : {}", getSession().getRemoteAddress(), topic, cause.getMessage());
         try {
-            getSession().close();
             close();
         } catch (IOException e) {
             log.error("Failed in closing producer for topic[{}] with error: [{}]: ", topic, e.getMessage());


### PR DESCRIPTION
### Motivation

increasing close_wait connection when websocket is timout(jetty default idletimeout 5min).
it seems to exhaust file descriptor.

half day in our environment(we had about 60 websocket consumer clients), reached about 10,000.
```
$ netstat -ant |grep CLOSE_WAIT| wc -l
9855
```

### Modifications

no call session.close() in onWebSocketError().
( no need to call it in onWebSocketError() )

### Result

not increasing close_wait connection when websocket is timout.