### PR TITLE
Shaded AsyncHttpClient in pulsar client

### DIFF
--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -139,6 +139,10 @@
               </filters>
               <relocations>
                 <relocation>
+                    <pattern>org.asynchttpclient</pattern>
+                    <shadedPattern>com.yahoo.pulsar.shade.org.asynchttpclient</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>com.yahoo.pulsar.shade.org.apache.commons</shadedPattern>
                 </relocation>

--- a/pulsar-client/src/main/resources/ahc.properties
+++ b/pulsar-client/src/main/resources/ahc.properties
@@ -1,0 +1,47 @@
+# This file is used by the shaded asynchttpclient packaged in pulsar-client-${VERSION}-shaded.jar.
+# For more details please refer https://github.com/yahoo/pulsar/issues/389
+
+com.yahoo.pulsar.shade.org.asynchttpclient.threadPoolName=AsyncHttpClient
+com.yahoo.pulsar.shade.org.asynchttpclient.maxConnections=-1
+com.yahoo.pulsar.shade.org.asynchttpclient.maxConnectionsPerHost=-1
+com.yahoo.pulsar.shade.org.asynchttpclient.connectTimeout=5000
+com.yahoo.pulsar.shade.org.asynchttpclient.pooledConnectionIdleTimeout=60000
+com.yahoo.pulsar.shade.org.asynchttpclient.connectionPoolCleanerPeriod=1000
+com.yahoo.pulsar.shade.org.asynchttpclient.readTimeout=60000
+com.yahoo.pulsar.shade.org.asynchttpclient.requestTimeout=60000
+com.yahoo.pulsar.shade.org.asynchttpclient.connectionTtl=-1
+com.yahoo.pulsar.shade.org.asynchttpclient.followRedirect=false
+com.yahoo.pulsar.shade.org.asynchttpclient.maxRedirects=5
+com.yahoo.pulsar.shade.org.asynchttpclient.compressionEnforced=false
+com.yahoo.pulsar.shade.org.asynchttpclient.userAgent=AHC/2.0
+com.yahoo.pulsar.shade.org.asynchttpclient.enabledProtocols=TLSv1.2, TLSv1.1, TLSv1
+com.yahoo.pulsar.shade.org.asynchttpclient.enabledCipherSuites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
+com.yahoo.pulsar.shade.org.asynchttpclient.useProxySelector=false
+com.yahoo.pulsar.shade.org.asynchttpclient.useProxyProperties=false
+com.yahoo.pulsar.shade.org.asynchttpclient.validateResponseHeaders=true
+com.yahoo.pulsar.shade.org.asynchttpclient.strict302Handling=false
+com.yahoo.pulsar.shade.org.asynchttpclient.keepAlive=true
+com.yahoo.pulsar.shade.org.asynchttpclient.maxRequestRetry=5
+com.yahoo.pulsar.shade.org.asynchttpclient.disableUrlEncodingForBoundRequests=false
+com.yahoo.pulsar.shade.org.asynchttpclient.removeQueryParamOnRedirect=true
+com.yahoo.pulsar.shade.org.asynchttpclient.useOpenSsl=false
+com.yahoo.pulsar.shade.org.asynchttpclient.acceptAnyCertificate=false
+com.yahoo.pulsar.shade.org.asynchttpclient.sslSessionCacheSize=0
+com.yahoo.pulsar.shade.org.asynchttpclient.sslSessionTimeout=0
+com.yahoo.pulsar.shade.org.asynchttpclient.tcpNoDelay=true
+com.yahoo.pulsar.shade.org.asynchttpclient.soReuseAddress=false
+com.yahoo.pulsar.shade.org.asynchttpclient.soLinger=-1
+com.yahoo.pulsar.shade.org.asynchttpclient.soSndBuf=-1
+com.yahoo.pulsar.shade.org.asynchttpclient.soRcvBuf=-1
+com.yahoo.pulsar.shade.org.asynchttpclient.httpClientCodecMaxInitialLineLength=4096
+com.yahoo.pulsar.shade.org.asynchttpclient.httpClientCodecMaxHeaderSize=8192
+com.yahoo.pulsar.shade.org.asynchttpclient.httpClientCodecMaxChunkSize=8192
+com.yahoo.pulsar.shade.org.asynchttpclient.disableZeroCopy=false
+com.yahoo.pulsar.shade.org.asynchttpclient.handshakeTimeout=10000
+com.yahoo.pulsar.shade.org.asynchttpclient.chunkedFileChunkSize=8192
+com.yahoo.pulsar.shade.org.asynchttpclient.webSocketMaxBufferSize=128000000
+com.yahoo.pulsar.shade.org.asynchttpclient.webSocketMaxFrameSize=10240
+com.yahoo.pulsar.shade.org.asynchttpclient.keepEncodingHeader=false
+com.yahoo.pulsar.shade.org.asynchttpclient.shutdownQuietPeriod=2000
+com.yahoo.pulsar.shade.org.asynchttpclient.shutdownTimeout=15000
+com.yahoo.pulsar.shade.org.asynchttpclient.useNativeTransport=false


### PR DESCRIPTION
### Motivation
Want to shade the asynchttpclient in pulsar-client-java since one of our customers want to use their own version of asynchttpclient. (Issue #389)

### Modifications

Added asynchttpclient to maven shade plugin and created a custom properties file which is a replica on the default properties with class name shaded.

### Result

We are able to provide pulsar-client-shaded.jar with asynchttpclient shaded.