### PR TITLE
C++ Client - moving all MessageData related code to MessageImpl

### DIFF
--- a/pulsar-client-cpp/lib/MessageImpl.cc
+++ b/pulsar-client-cpp/lib/MessageImpl.cc
@@ -71,4 +71,8 @@ namespace pulsar {
         keyValue->set_value(value);
         metadata.mutable_properties()->AddAllocated(keyValue);
     }
+
+    void MessageImpl::setPartitionKey(const std::string& partitionKey) {
+        metadata.set_partition_key(partitionKey);
+    }
 }

--- a/pulsar-client-cpp/lib/MessageImpl.h
+++ b/pulsar-client-cpp/lib/MessageImpl.h
@@ -54,6 +54,7 @@ private:
     void setReplicationClusters(const std::vector<std::string>& clusters);
     void setProperty(const std::string& name, const std::string& value);
     void disableReplication(bool flag);
+    void setPartitionKey(const std::string& partitionKey);
     Message::StringMap properties_;
 };
 


### PR DESCRIPTION
### Motivation
Maintain backward compatibility with Yahoo code.
Pushing all metadata related functions to MessageImpl so that only libpulsar depends on protobuf-lite and not the wapper.

### Modifications

Added setPartitionKey to MessageImpl

### Result

No change in functionality - function will be used by the wrapper.
