### PR TITLE
Dispatcher blocks dispatching once unackMsgs reached max limit

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -103,10 +103,10 @@ tlsAllowInsecureConnection=false
 maxUnackedMessagesPerConsumer=50000
 
 # Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
-# all consumers once, this limit reaches until consumer starts acknowledging messages back and unack count reaches
-# to maxUnackedMessagesPerDispatcher/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher
-# can dispatch messages without any restriction
-maxUnackedMessagesPerDispatcher=200000
+# all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and
+# unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit
+# check and dispatcher can dispatch messages without any restriction
+maxUnackedMessagesPerSubscription=200000
 
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -102,6 +102,12 @@ tlsAllowInsecureConnection=false
 # Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction 
 maxUnackedMessagesPerConsumer=50000
 
+# Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
+# all consumers once, this limit reaches until consumer starts acknowledging messages back and unack count reaches
+# to maxUnackedMessagesPerDispatcher/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher
+# can dispatch messages without any restriction
+maxUnackedMessagesPerDispatcher=200000
+
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -76,10 +76,10 @@ statusFilePath=/usr/local/apache/htdocs
 maxUnackedMessagesPerConsumer=50000
 
 # Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
-# all consumers once, this limit reaches until consumer starts acknowledging messages back and unack count reaches
-# to maxUnackedMessagesPerDispatcher/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher
-# can dispatch messages without any restriction
-maxUnackedMessagesPerDispatcher=200000
+# all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and
+# unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit
+# check and dispatcher can dispatch messages without any restriction
+maxUnackedMessagesPerSubscription=200000
 
 ### --- Authentication --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -75,6 +75,12 @@ statusFilePath=/usr/local/apache/htdocs
 # Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
 maxUnackedMessagesPerConsumer=50000
 
+# Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
+# all consumers once, this limit reaches until consumer starts acknowledging messages back and unack count reaches
+# to maxUnackedMessagesPerDispatcher/2. Using a value of 0, is disabling unackedMessage-limit check and dispatcher
+# can dispatch messages without any restriction
+maxUnackedMessagesPerDispatcher=200000
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Entry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/Entry.java
@@ -46,10 +46,21 @@ public interface Entry {
      * @return the position at which the entry was stored
      */
     Position getPosition();
+    
+    /**
+     * @return ledgerId of the position
+     */
+    long getLedgerId();
+
+    /**
+     * @return entryId of the position
+     */
+    long getEntryId();
 
     /**
      * Release the resources (data) allocated for this entry and recycle if all the resources are deallocated (ref-count
      * of data reached to 0)
      */
     boolean release();
+
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -126,6 +126,16 @@ final class EntryImpl extends AbstractReferenceCounted implements Entry, Compara
     }
 
     @Override
+    public long getLedgerId() {
+        return ledgerId;
+    }
+
+    @Override
+    public long getEntryId() {
+        return entryId;
+    }
+    
+    @Override
     public int compareTo(EntryImpl other) {
         return ComparisonChain.start().compare(ledgerId, other.ledgerId).compare(entryId, other.entryId).result();
     }

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -90,10 +90,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // check and consumer can receive messages without any restriction
     private int maxUnackedMessagesPerConsumer = 50000;
     // Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
-    // all consumers once, this limit reaches until consumer starts acknowledging messages back and unack count reaches
-    // to maxUnackedMessagesPerDispatcher/2 Using a value of 0, is disabling unackedMessage-limit check and dispatcher
-    // can dispatch messages without any restriction
-    private int maxUnackedMessagesPerDispatcher = 4 * 50000;
+    // all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and
+    // unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit
+    // check and dispatcher can dispatch messages without any restriction
+    private int maxUnackedMessagesPerSubscription = 4 * 50000;
     // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
     @FieldContext(dynamic = true)
     private int maxConcurrentLookupRequest = 10000;
@@ -438,12 +438,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         this.maxUnackedMessagesPerConsumer = maxUnackedMessagesPerConsumer;
     }
 
-    public int getMaxUnackedMessagesPerDispatcher() {
-        return maxUnackedMessagesPerDispatcher;
+    public int getMaxUnackedMessagesPerSubscription() {
+        return maxUnackedMessagesPerSubscription;
     }
 
-    public void setMaxUnackedMessagesPerDispatcher(int maxUnackedMessagesPerDispatcher) {
-        this.maxUnackedMessagesPerDispatcher = maxUnackedMessagesPerDispatcher;
+    public void setMaxUnackedMessagesPerSubscription(int maxUnackedMessagesPerSubscription) {
+        this.maxUnackedMessagesPerSubscription = maxUnackedMessagesPerSubscription;
     }
 
     public int getMaxConcurrentLookupRequest() {

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -84,10 +84,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Path for the file used to determine the rotation status for the broker
     // when responding to service discovery health checks
     private String statusFilePath;
-    // Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
-    // messages to consumer once, this limit reaches until consumer starts acknowledging messages back
-    // Using a value of 0, is disabling unackedMessage-limit check and consumer can receive messages without any restriction
+    // Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker
+    // will stop sending messages to consumer once, this limit reaches until consumer starts acknowledging messages back
+    // and unack count reaches to maxUnackedMessagesPerConsumer/2 Using a value of 0, is disabling unackedMessage-limit
+    // check and consumer can receive messages without any restriction
     private int maxUnackedMessagesPerConsumer = 50000;
+    // Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
+    // all consumers once, this limit reaches until consumer starts acknowledging messages back and unack count reaches
+    // to maxUnackedMessagesPerDispatcher/2 Using a value of 0, is disabling unackedMessage-limit check and dispatcher
+    // can dispatch messages without any restriction
+    private int maxUnackedMessagesPerDispatcher = 4 * 50000;
     // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
     @FieldContext(dynamic = true)
     private int maxConcurrentLookupRequest = 10000;
@@ -430,6 +436,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setMaxUnackedMessagesPerConsumer(int maxUnackedMessagesPerConsumer) {
         this.maxUnackedMessagesPerConsumer = maxUnackedMessagesPerConsumer;
+    }
+
+    public int getMaxUnackedMessagesPerDispatcher() {
+        return maxUnackedMessagesPerDispatcher;
+    }
+
+    public void setMaxUnackedMessagesPerDispatcher(int maxUnackedMessagesPerDispatcher) {
+        this.maxUnackedMessagesPerDispatcher = maxUnackedMessagesPerDispatcher;
     }
 
     public int getMaxConcurrentLookupRequest() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Dispatcher.java
@@ -65,4 +65,6 @@ public interface Dispatcher {
 
     void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions);
 
+    void addUnAckedMessages(int unAckMessages);
+
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Subscription.java
@@ -71,4 +71,6 @@ public interface Subscription {
     SubType getType();
     
     String getTypeString();
+
+    void addUnAckedMessages(int unAckMessages);
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -93,7 +93,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
         this.messagesToReplay = Sets.newTreeSet();
         this.readBatchSize = MaxReadBatchSize;
         this.maxUnackedMessages = topic.getBrokerService().pulsar().getConfiguration()
-                .getMaxUnackedMessagesPerDispatcher();
+                .getMaxUnackedMessagesPerSubscription();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -142,7 +142,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
                     log.debug("[{}] Consumer are left, reading more entries", name);
                 }
                 consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, none) -> {
-                    messagesToReplay.add(PositionImpl.get(ledgerId, entryId));
+                    messagesToReplay.add(new PositionImpl(ledgerId, entryId));
                 });
                 totalAvailablePermits -= consumer.getAvailablePermits();
                 readMoreEntries();
@@ -555,7 +555,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
     @Override
     public synchronized void redeliverUnacknowledgedMessages(Consumer consumer) {
         consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, none) -> {
-            messagesToReplay.add(PositionImpl.get(ledgerId, entryId));
+            messagesToReplay.add(new PositionImpl(ledgerId, entryId));
         });
         if (log.isDebugEnabled()) {
             log.debug("[{}] Redelivering unacknowledged messages for consumer ", consumer);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -141,8 +141,8 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Consumer are left, reading more entries", name);
                 }
-                consumer.getPendingAcks().forEach((pendingMessages, totalMsg) -> {
-                    messagesToReplay.add(pendingMessages);
+                consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, none) -> {
+                    messagesToReplay.add(PositionImpl.get(ledgerId, entryId));
                 });
                 totalAvailablePermits -= consumer.getAvailablePermits();
                 readMoreEntries();
@@ -554,8 +554,8 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
 
     @Override
     public synchronized void redeliverUnacknowledgedMessages(Consumer consumer) {
-        consumer.getPendingAcks().forEach((pendingMessages, totalMsg) -> {
-            messagesToReplay.add(pendingMessages);
+        consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, none) -> {
+            messagesToReplay.add(PositionImpl.get(ledgerId, entryId));
         });
         if (log.isDebugEnabled()) {
             log.debug("[{}] Redelivering unacknowledged messages for consumer ", consumer);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -586,6 +586,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
         } else if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE
                 && unAckedMessages < maxUnackedMessages / 2) {
             if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
+                log.info("[{}] Dispatcher is unblocked", name);
                 topic.getBrokerService().executor().submit(() -> readMoreEntries());
             }
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -381,4 +381,9 @@ public final class PersistentDispatcherSingleActiveConsumer implements Dispatche
         return ACTIVE_CONSUMER_UPDATER.get(this);
     }
 
+    @Override
+    public void addUnAckedMessages(int unAckMessages) {
+        // No-op
+    }
+
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -609,6 +609,11 @@ public class PersistentSubscription implements Subscription {
     }
 
     @Override
+    public void addUnAckedMessages(int unAckMessages) {
+        dispatcher.addUnAckedMessages(unAckMessages);
+    }
+    
+    @Override
     public void markTopicWithBatchMessagePublished() {
         topic.markBatchMessagePublished();
     }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -597,7 +597,7 @@ public class PersistentSubscription implements Subscription {
             if (dispatcher instanceof PersistentDispatcherMultipleConsumers) {
                 subStats.unackedMessages = ((PersistentDispatcherMultipleConsumers) dispatcher)
                         .getTotalUnackedMessages();
-                subStats.blockedDispatcherOnUnackedMsgs = ((PersistentDispatcherMultipleConsumers) dispatcher)
+                subStats.blockedSubscriptionOnUnackedMsgs = ((PersistentDispatcherMultipleConsumers) dispatcher)
                         .isBlockedDispatcherOnUnackedMsgs();
             }
         }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -592,9 +592,17 @@ public class PersistentSubscription implements Subscription {
             });
         }
 
+        subStats.type = getType();
+        if (SubType.Shared.equals(subStats.type)) {
+            if (dispatcher instanceof PersistentDispatcherMultipleConsumers) {
+                subStats.unackedMessages = ((PersistentDispatcherMultipleConsumers) dispatcher)
+                        .getTotalUnackedMessages();
+                subStats.blockedDispatcherOnUnackedMsgs = ((PersistentDispatcherMultipleConsumers) dispatcher)
+                        .isBlockedDispatcherOnUnackedMsgs();
+            }
+        }
         subStats.msgBacklog = getNumberOfEntriesInBacklog();
         subStats.msgRateExpired = expiryMonitor.getMessageExpiryRate();
-        subStats.type = getType();
         return subStats;
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -916,7 +916,6 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             double subMsgRateOut = 0;
             double subMsgThroughputOut = 0;
             double subMsgRateRedeliver = 0;
-            long subUnackedMessages = 0;
 
             // Start subscription name & consumers
             try {
@@ -935,7 +934,6 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                     subMsgRateOut += consumerStats.msgRateOut;
                     subMsgThroughputOut += consumerStats.msgThroughputOut;
                     subMsgRateRedeliver += consumerStats.msgRateRedeliver;
-                    subUnackedMessages += consumerStats.unackedMessages;
 
                     // Populate consumer specific stats here
                     destStatsStream.startObject();
@@ -969,7 +967,12 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                 destStatsStream.writePair("msgRateRedeliver", subMsgRateRedeliver);
                 destStatsStream.writePair("type", subscription.getTypeString());
                 if (SubType.Shared.equals(subscription.getType())) {
-                    destStatsStream.writePair("unackedMessages", subUnackedMessages);
+                    if(subscription.getDispatcher() instanceof PersistentDispatcherMultipleConsumers) {
+                        PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers)subscription.getDispatcher();
+                        destStatsStream.writePair("blockedDispatcherOnUnackedMsgs",  dispatcher.isBlockedDispatcherOnUnackedMsgs());
+                        destStatsStream.writePair("unackedMessages", dispatcher.getTotalUnackedMessages());
+                    }
+                    
                 }
 
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -969,7 +969,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                 if (SubType.Shared.equals(subscription.getType())) {
                     if(subscription.getDispatcher() instanceof PersistentDispatcherMultipleConsumers) {
                         PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers)subscription.getDispatcher();
-                        destStatsStream.writePair("blockedDispatcherOnUnackedMsgs",  dispatcher.isBlockedDispatcherOnUnackedMsgs());
+                        destStatsStream.writePair("blockedSubscriptionOnUnackedMsgs",  dispatcher.isBlockedDispatcherOnUnackedMsgs());
                         destStatsStream.writePair("unackedMessages", dispatcher.getTotalUnackedMessages());
                     }
                     

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -70,7 +70,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
     public void testConsumerBlockingWithUnAckedMessagesAtDispatcher() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerSubscription();
         try {
             stopBroker();
             startBroker();
@@ -80,7 +80,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
             final String subscriberName = "subscriber-1";
 
-            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            pulsar.getConfiguration().setMaxUnackedMessagesPerSubscription(unackMsgAllowed);
             ConsumerConfiguration conf = new ConsumerConfiguration();
             conf.setReceiverQueueSize(receiverQueueSize);
             conf.setSubscriptionType(SubscriptionType.Shared);
@@ -170,7 +170,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
     public void testConsumerBlockingWithUnAckedMessagesAndRedelivery() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerSubscription();
         try {
             stopBroker();
             startBroker();
@@ -180,7 +180,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
             final String subscriberName = "subscriber-1";
 
-            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            pulsar.getConfiguration().setMaxUnackedMessagesPerSubscription(unackMsgAllowed);
             ConsumerConfiguration conf = new ConsumerConfiguration();
             conf.setReceiverQueueSize(receiverQueueSize);
             conf.setSubscriptionType(SubscriptionType.Shared);
@@ -301,7 +301,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
     public void testCloseConsumerBlockedDispatcher() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerSubscription();
         try {
             stopBroker();
             startBroker();
@@ -311,7 +311,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
             final String subscriberName = "subscriber-1";
 
-            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            pulsar.getConfiguration().setMaxUnackedMessagesPerSubscription(unackMsgAllowed);
             ConsumerConfiguration conf = new ConsumerConfiguration();
             conf.setReceiverQueueSize(receiverQueueSize);
             conf.setSubscriptionType(SubscriptionType.Shared);
@@ -381,7 +381,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
     public void testRedeliveryOnBlockedDistpatcher() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerSubscription();
         try {
             stopBroker();
             startBroker();
@@ -391,7 +391,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
             final String subscriberName = "subscriber-1";
 
-            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            pulsar.getConfiguration().setMaxUnackedMessagesPerSubscription(unackMsgAllowed);
             ConsumerConfiguration conf = new ConsumerConfiguration();
             conf.setSubscriptionType(SubscriptionType.Shared);
             conf.setReceiverQueueSize(receiverQueueSize);
@@ -511,7 +511,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
     @Test
     public void testBlockDispatcherStats() throws Exception {
 
-        int orginalDispatcherLimit = conf.getMaxUnackedMessagesPerDispatcher();
+        int orginalDispatcherLimit = conf.getMaxUnackedMessagesPerSubscription();
         try {
             final String topicName = "persistent://prop/use/ns-abc/blockDispatch";
             final String subName = "blockDispatch";
@@ -521,7 +521,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             PersistentSubscriptionStats subStats;
 
             // configure maxUnackMessagePerDispatcher then restart broker to get this change
-            conf.setMaxUnackedMessagesPerDispatcher(10);
+            conf.setMaxUnackedMessagesPerSubscription(10);
             stopBroker();
             startBroker();
 
@@ -557,7 +557,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
 
             assertTrue(subStats.msgBacklog > 0);
             assertTrue(subStats.unackedMessages > 0);
-            assertTrue(subStats.blockedDispatcherOnUnackedMsgs);
+            assertTrue(subStats.blockedSubscriptionOnUnackedMsgs);
             assertEquals(subStats.consumers.get(0).unackedMessages, subStats.unackedMessages);
 
             // consumer stats
@@ -568,7 +568,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             consumer.close();
 
         } finally {
-            conf.setMaxUnackedMessagesPerDispatcher(orginalDispatcherLimit);
+            conf.setMaxUnackedMessagesPerSubscription(orginalDispatcherLimit);
         }
 
     }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -1,0 +1,505 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.client.api;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.yahoo.pulsar.client.impl.ConsumerImpl;
+import com.yahoo.pulsar.client.impl.MessageIdImpl;
+
+import jersey.repackaged.com.google.common.collect.Sets;
+
+public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
+    private static final Logger log = LoggerFactory.getLogger(DispatcherBlockConsumerTest.class);
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    /**
+     * Verifies broker blocks dispatching after unack-msgs reaches to max-limit and start dispatching back once client
+     * ack messages.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerBlockingWithUnAckedMessagesAtDispatcher() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        try {
+            stopBroker();
+            startBroker();
+            final int unackMsgAllowed = 100;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 200;
+            final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
+            final String subscriberName = "subscriber-1";
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe(topicName, subscriberName, conf);
+            Consumer consumer2 = pulsarClient.subscribe(topicName, subscriberName, conf);
+            Consumer consumer3 = pulsarClient.subscribe(topicName, subscriberName, conf);
+            Consumer[] consumers = { consumer1, consumer2, consumer3 };
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (2) try to consume messages: but will be able to consume number of messages = unackMsgAllowed
+            Message msg = null;
+            Map<Message, Consumer> messages = Maps.newHashMap();
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < totalProducedMsgs; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages.put(msg, consumers[i]);
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+            assertEquals(messages.size(), unackMsgAllowed, receiverQueueSize * 2);
+
+            // start acknowledging messages
+            messages.forEach((m, c) -> {
+                try {
+                    c.acknowledge(m);
+                } catch (PulsarClientException e) {
+                    fail("ack failed", e);
+                }
+            });
+            // wait to start dispatching-async
+            Thread.sleep(2000);
+            // try to consume remaining messages
+            int remainingMessages = totalProducedMsgs - messages.size();
+            for (int i = 0; i < consumers.length; i++) {
+                for (int j = 0; j < remainingMessages; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages.put(msg, consumers[i]);
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // total received-messages should match to produced messages
+            assertEquals(totalProducedMsgs, messages.size());
+            producer.close();
+            Arrays.asList(consumers).forEach(c -> {
+                try {
+                    c.close();
+                } catch (PulsarClientException e) {
+                }
+            });
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+
+    /**
+     * 
+     * Verifies: broker blocks dispatching once unack-msg reaches to max-limit. However, on redelivery it redelivers
+     * those already delivered-unacked messages again
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testConsumerBlockingWithUnAckedMessagesAndRedelivery() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        try {
+            stopBroker();
+            startBroker();
+            final int unackMsgAllowed = 100;
+            final int totalProducedMsgs = 200;
+            final int receiverQueueSize = 10;
+            final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
+            final String subscriberName = "subscriber-1";
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            ConsumerImpl consumer1 = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriberName, conf);
+            ConsumerImpl consumer2 = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriberName, conf);
+            ConsumerImpl consumer3 = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriberName, conf);
+            ConsumerImpl[] consumers = { consumer1, consumer2, consumer3 };
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (2) try to consume messages: but will be able to consume number of messages = unackMsgAllowed
+            Message msg = null;
+            Multimap<ConsumerImpl, MessageId> messages = ArrayListMultimap.create();
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < totalProducedMsgs; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages.put(consumers[i], msg.getMessageId());
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            int totalConsumedMsgs = messages.size();
+            // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+            assertNotEquals(messages.size(), totalProducedMsgs);
+
+            // trigger redelivery
+            messages.asMap().forEach((c, msgs) -> {
+                c.redeliverUnacknowledgedMessages(
+                        msgs.stream().map(m -> (MessageIdImpl) m).collect(Collectors.toSet()));
+            });
+
+            // wait for redelivery to be completed
+            Thread.sleep(1000);
+
+            // now, broker must have redelivered all unacked messages
+            messages.clear();
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < totalProducedMsgs; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages.put(consumers[i], msg.getMessageId());
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // check all unacked messages have been redelivered
+            Set<MessageId> result = Sets.newHashSet(messages.values());
+            assertEquals(totalConsumedMsgs, result.size(), 2 * receiverQueueSize);
+
+            // start acknowledging messages
+            messages.asMap().forEach((c, msgs) -> {
+                msgs.forEach(m -> {
+                    try {
+                        c.acknowledge(m);
+                    } catch (PulsarClientException e) {
+                        fail("ack failed", e);
+                    }
+                });
+            });
+
+            // now: dispatcher must be unblocked: wait to start dispatching-async
+            Thread.sleep(1000);
+            // try to consume remaining messages
+            for (int i = 0; i < consumers.length; i++) {
+                for (int j = 0; j < totalProducedMsgs; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages.put(consumers[i], msg.getMessageId());
+                        consumers[i].acknowledge(msg);
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            result = Sets.newHashSet(messages.values());
+            // total received-messages should match to produced messages
+            assertEquals(totalProducedMsgs, result.size());
+            producer.close();
+            Arrays.asList(consumers).forEach(c -> {
+                try {
+                    c.close();
+                } catch (PulsarClientException e) {
+                }
+            });
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+
+    /**
+     * It verifies that consumer1 attached to dispatcher will be blocked after reaching limit. But consumer2 connects
+     * and consumer1 will be closed: makes broker to dispatch all those consumer1's unack messages back to consumer2.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCloseConsumerBlockedDispatcher() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        try {
+            stopBroker();
+            startBroker();
+            final int unackMsgAllowed = 100;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 200;
+            final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
+            final String subscriberName = "subscriber-1";
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe(topicName, subscriberName, conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (2) try to consume messages: but will be able to consume number of messages = unackMsgAllowed
+            Message msg = null;
+            Map<Message, Consumer> messages = Maps.newHashMap();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer1.receive(500, TimeUnit.MILLISECONDS);
+                if (msg != null) {
+                    messages.put(msg, consumer1);
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+
+            // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+            assertEquals(messages.size(), unackMsgAllowed, receiverQueueSize * 2);
+
+            // create consumer2
+            Consumer consumer2 = pulsarClient.subscribe(topicName, subscriberName, conf);
+            // close consumer1: all messages of consumer1 must be replayed and received by consumer2
+            consumer1.close();
+            Map<Message, Consumer> messages2 = Maps.newHashMap();
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                msg = consumer2.receive(500, TimeUnit.MILLISECONDS);
+                if (msg != null) {
+                    messages2.put(msg, consumer2);
+                    consumer2.acknowledge(msg);
+                    log.info("Received message: " + new String(msg.getData()));
+                } else {
+                    break;
+                }
+            }
+
+            assertEquals(messages2.size(), totalProducedMsgs);
+            log.info("-- Exiting {} test --", methodName);
+            producer.close();
+            consumer2.close();
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+
+    /**
+     * Verifies: old-client which does redelivery of all messages makes broker to redeliver all unacked messages for
+     * redelivery.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testRedeliveryOnBlockedDistpatcher() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        int unAckedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerDispatcher();
+        try {
+            stopBroker();
+            startBroker();
+            final int unackMsgAllowed = 100;
+            final int receiverQueueSize = 10;
+            final int totalProducedMsgs = 200;
+            final String topicName = "persistent://my-property/use/my-ns/unacked-topic";
+            final String subscriberName = "subscriber-1";
+
+            pulsar.getConfiguration().setMaxUnackedMessagesPerDispatcher(unackMsgAllowed);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            conf.setReceiverQueueSize(receiverQueueSize);
+            ConsumerImpl consumer1 = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriberName, conf);
+            ConsumerImpl consumer2 = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriberName, conf);
+            ConsumerImpl consumer3 = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriberName, conf);
+            ConsumerImpl[] consumers = { consumer1, consumer2, consumer3 };
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
+
+            // (1) Produced Messages
+            for (int i = 0; i < totalProducedMsgs; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (2) try to consume messages: but will be able to consume number of messages = unackMsgAllowed
+            Message msg = null;
+            Set<MessageId> messages = Sets.newHashSet();
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < totalProducedMsgs; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages.add(msg.getMessageId());
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            int totalConsumedMsgs = messages.size();
+            // client must receive number of messages = unAckedMessagesBufferSize rather all produced messages
+            assertEquals(totalConsumedMsgs, unackMsgAllowed, 2 * receiverQueueSize);
+
+            // trigger redelivery
+            Arrays.asList(consumers).forEach(c -> {
+                c.redeliverUnacknowledgedMessages();
+            });
+
+            // wait for redelivery to be completed
+            Thread.sleep(1000);
+
+            // now, broker must have redelivered all unacked messages
+            Map<ConsumerImpl, Set<MessageId>> messages1 = Maps.newHashMap();
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < totalProducedMsgs; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages1.putIfAbsent(consumers[i], Sets.newHashSet());
+                        messages1.get(consumers[i]).add(msg.getMessageId());
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            Set<MessageId> result = Sets.newHashSet();
+            messages1.values().forEach(s -> result.addAll(s));
+
+            // check all unacked messages have been redelivered
+
+            assertEquals(totalConsumedMsgs, result.size(), 3 * receiverQueueSize);
+
+            // start acknowledging messages
+            messages1.forEach((c, msgs) -> {
+                msgs.forEach(m -> {
+                    try {
+                        c.acknowledge(m);
+                    } catch (PulsarClientException e) {
+                        fail("ack failed", e);
+                    }
+                });
+            });
+
+            // now: dispatcher must be unblocked: wait to start dispatching-async
+            Thread.sleep(2000);
+            // try to consume remaining messages
+            int remainingMessages = totalProducedMsgs - messages1.size();
+            for (int i = 0; i < consumers.length; i++) {
+                for (int j = 0; j < remainingMessages; j++) {
+                    msg = consumers[i].receive(500, TimeUnit.MILLISECONDS);
+                    if (msg != null) {
+                        messages1.putIfAbsent(consumers[i], Sets.newHashSet());
+                        messages1.get(consumers[i]).add(msg.getMessageId());
+                        consumers[i].acknowledge(msg);
+                        log.info("Received message: " + new String(msg.getData()));
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            result.clear();
+            messages1.values().forEach(s -> result.addAll(s));
+            // total received-messages should match to produced messages
+            assertEquals(totalProducedMsgs, result.size());
+            producer.close();
+            Arrays.asList(consumers).forEach(c -> {
+                try {
+                    c.close();
+                } catch (PulsarClientException e) {
+                }
+            });
+            log.info("-- Exiting {} test --", methodName);
+        } catch (Exception e) {
+            fail();
+        } finally {
+            pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
+        }
+    }
+}

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/PersistentSubscriptionStats.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/PersistentSubscriptionStats.java
@@ -37,6 +37,9 @@ public class PersistentSubscriptionStats {
     /** Number of messages in the subscription backlog */
     public long msgBacklog;
 
+    /** Flag to verify if dispatcher is blocked due to reaching threshold of unacked messages */
+    public boolean blockedDispatcherOnUnackedMsgs;
+    
     /** Number of unacknowledged messages for the subscription */
     public long unackedMessages;
 

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/PersistentSubscriptionStats.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/PersistentSubscriptionStats.java
@@ -37,8 +37,8 @@ public class PersistentSubscriptionStats {
     /** Number of messages in the subscription backlog */
     public long msgBacklog;
 
-    /** Flag to verify if dispatcher is blocked due to reaching threshold of unacked messages */
-    public boolean blockedDispatcherOnUnackedMsgs;
+    /** Flag to verify if subscription is blocked due to reaching threshold of unacked messages */
+    public boolean blockedSubscriptionOnUnackedMsgs;
     
     /** Number of unacknowledged messages for the subscription */
     public long unackedMessages;


### PR DESCRIPTION
### Motivation

as discussed at #398 : if client misbehaves where it doesn't ack messages and keep redelivering unack messages then it causes broker to keep large number of `PositionImpl` instances in memory  until broker dispatches those messages. It may cause frequent old-gc and zk-session lost. Therefore, broker requires a safe-guard to control number of dispatched messages which helps to reduce number of `PositionImpl` objects and gc occurrences. With this patch, It shows less gc and stable broker by running same test mentioned into #398.

### Modifications

Broker blocks dispatching of messages on subscription if given subscriber reaches defined unacked message limit. Broker unblocks dispatching once it receives required number of acked messages and it starts dispatching new messages on that subscriber again.

### Result

Subscriber will not receive any new messages once it reaches to unack message limit. Broker can redeliver unacked messages to blocked-subscriber so, subscriber can ack them back and get unblocked to receieve new messages.
