### PR TITLE
Add options to admin tool

### DIFF
--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdBrokers.java
@@ -79,7 +79,7 @@ public class CmdBrokers extends CmdBase {
         }
     }
     
-    CmdBrokers(PulsarAdmin admin) {
+    public CmdBrokers(PulsarAdmin admin) {
         super("brokers", admin);
         jcommander.addCommand("list", new List());
         jcommander.addCommand("namespaces", new Namespaces());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdClusters.java
@@ -101,7 +101,7 @@ public class CmdClusters extends CmdBase {
         }
     }
 
-    CmdClusters(PulsarAdmin admin) {
+    public CmdClusters(PulsarAdmin admin) {
         super("clusters", admin);
         jcommander.addCommand("get", new Get());
         jcommander.addCommand("create", new Create());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -185,7 +185,7 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         return nsIsolationData;
     }
 
-    CmdNamespaceIsolationPolicy(PulsarAdmin admin) {
+    public CmdNamespaceIsolationPolicy(PulsarAdmin admin) {
         super("clusters", admin);
         jcommander.addCommand("set", new SetPolicy());
         jcommander.addCommand("get", new GetPolicy());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNamespaces.java
@@ -490,7 +490,7 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    CmdNamespaces(PulsarAdmin admin) {
+    public CmdNamespaces(PulsarAdmin admin) {
         super("namespaces", admin);
         jcommander.addCommand("list", new GetNamespacesPerProperty());
         jcommander.addCommand("list-cluster", new GetNamespacesPerCluster());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdProperties.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdProperties.java
@@ -99,7 +99,7 @@ public class CmdProperties extends CmdBase {
         }
     }
 
-    CmdProperties(PulsarAdmin admin) {
+    public CmdProperties(PulsarAdmin admin) {
         super("properties", admin);
         jcommander.addCommand("list", new List());
         jcommander.addCommand("get", new Get());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdResourceQuotas.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdResourceQuotas.java
@@ -120,7 +120,7 @@ public class CmdResourceQuotas extends CmdBase {
         }
     }
 
-    CmdResourceQuotas(PulsarAdmin admin) {
+    public CmdResourceQuotas(PulsarAdmin admin) {
         super("resource-quotas", admin);
         jcommander.addCommand("get", new GetResourceQuota());
         jcommander.addCommand("set", new SetResourceQuota());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/PulsarAdminTool.java
@@ -19,6 +19,8 @@ import java.io.FileInputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
@@ -29,9 +31,9 @@ import com.yahoo.pulsar.client.admin.PulsarAdmin;
 import com.yahoo.pulsar.client.api.ClientConfiguration;
 
 public class PulsarAdminTool {
+    private final Map<String, Class> commandMap;
     private final JCommander jcommander;
     private final ClientConfiguration config;
-    private URL url;
 
     @Parameter(names = { "--admin-url" }, description = "Admin Service URL to which to connect.")
     String serviceUrl = null;
@@ -47,100 +49,90 @@ public class PulsarAdminTool {
 
     PulsarAdminTool(Properties properties) throws Exception {
         // fallback to previous-version serviceUrl property to maintain backward-compatibility
-        String serviceUrl = StringUtils.isNotBlank(properties.getProperty("webServiceUrl"))
+        serviceUrl = StringUtils.isNotBlank(properties.getProperty("webServiceUrl"))
                 ? properties.getProperty("webServiceUrl") : properties.getProperty("serviceUrl");
-        String authPluginClassName = properties.getProperty("authPlugin");
-        String authParams = properties.getProperty("authParams");
+        authPluginClassName = properties.getProperty("authPlugin");
+        authParams = properties.getProperty("authParams");
         boolean useTls = Boolean.parseBoolean(properties.getProperty("useTls"));
         boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection"));
         String tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
 
-        url = null;
-        try {
-            url = new URL(serviceUrl);
-        } catch (MalformedURLException e) {
-            System.err.println("Invalid serviceUrl: '" + serviceUrl + "'");
-            System.exit(1);
-        }
-
         config = new ClientConfiguration();
-        config.setAuthentication(authPluginClassName, authParams);
         config.setUseTls(useTls);
         config.setTlsAllowInsecureConnection(tlsAllowInsecureConnection);
         config.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);
 
-        PulsarAdmin admin = new PulsarAdmin(url, config);
         jcommander = new JCommander();
         jcommander.setProgramName("pulsar-admin");
         jcommander.addObject(this);
-        jcommander.addCommand("clusters", new CmdClusters(admin));
-        jcommander.addCommand("ns-isolation-policy", new CmdNamespaceIsolationPolicy(admin));
-        jcommander.addCommand("brokers", new CmdBrokers(admin));
-        jcommander.addCommand("broker-stats", new CmdBrokerStats(admin));
-        jcommander.addCommand("properties", new CmdProperties(admin));
-        jcommander.addCommand("namespaces", new CmdNamespaces(admin));
-        jcommander.addCommand("persistent", new CmdPersistentTopics(admin));
-        jcommander.addCommand("resource-quotas", new CmdResourceQuotas(admin));
+
+        commandMap = new HashMap<>();
+        commandMap.put("clusters", CmdClusters.class);
+        commandMap.put("ns-isolation-policy", CmdNamespaceIsolationPolicy.class);
+        commandMap.put("brokers", CmdBrokers.class);
+        commandMap.put("broker-stats", CmdBrokerStats.class);
+        commandMap.put("properties", CmdProperties.class);
+        commandMap.put("namespaces", CmdNamespaces.class);
+        commandMap.put("persistent", CmdPersistentTopics.class);
+        commandMap.put("resource-quotas", CmdResourceQuotas.class);
     }
 
-    JCommander getJCommander() {
-        return jcommander;
+    private void setupCommands() {
+        try {
+            URL url = new URL(serviceUrl);
+            config.setAuthentication(authPluginClassName, authParams);
+            PulsarAdmin admin = new PulsarAdmin(url, config);
+            for (Map.Entry<String, Class> c : commandMap.entrySet()) {
+                jcommander.addCommand(c.getKey(), c.getValue().getConstructor(PulsarAdmin.class).newInstance(admin));
+            }
+        } catch (MalformedURLException e) {
+            System.err.println("Invalid serviceUrl: '" + serviceUrl + "'");
+            System.exit(1);
+        } catch (Exception e) {
+            System.err.println(e.getClass() + ": " + e.getMessage());
+            System.exit(1);
+        }
     }
 
     boolean run(String[] args) {
         if (args.length == 0) {
+            setupCommands();
             jcommander.usage();
             return false;
         }
 
         int cmdPos;
         for (cmdPos=0; cmdPos < args.length; cmdPos++) {
-            if (jcommander.getCommands().containsKey(args[cmdPos])){
+            if (commandMap.containsKey(args[cmdPos])){
                 break;
             }
         }
 
         try {
-            jcommander.parse(Arrays.copyOfRange(args, 0, Math.min(cmdPos+1, args.length)));
+            jcommander.parse(Arrays.copyOfRange(args, 0, Math.min(cmdPos, args.length)));
         } catch (Exception e) {
             System.err.println(e.getMessage());
             System.err.println();
+            setupCommands();
             jcommander.usage();
             return false;
         }
 
         if (help) {
+            setupCommands();
             jcommander.usage();
             return false;
         }
 
-        if (jcommander.getParsedCommand() == null) {
+        if (cmdPos == args.length) {
+            setupCommands();
             jcommander.usage();
             return false;
         } else {
-            String cmd = jcommander.getParsedCommand();
+            setupCommands();
+            String cmd = args[cmdPos];
             JCommander obj = jcommander.getCommands().get(cmd);
             CmdBase cmdObj = (CmdBase) obj.getObjects().get(0);
-            if (StringUtils.isNotBlank(serviceUrl) || (StringUtils.isNotBlank(authPluginClassName) && StringUtils
-                    .isNotBlank(authParams))) {
-                if (StringUtils.isNotBlank(serviceUrl)) {
-                    try {
-                        url = new URL(serviceUrl);
-                    } catch (MalformedURLException e) {
-                        System.err.println("Invalid serviceUrl: '" + serviceUrl + "'");
-                        System.exit(1);
-                    }
-                }
-                try {
-                    if (StringUtils.isNotBlank(authPluginClassName) && StringUtils.isNotBlank(authParams)) {
-                        config.setAuthentication(authPluginClassName, authParams);
-                    }
-                    cmdObj = cmdObj.getClass().getConstructor(PulsarAdmin.class).newInstance(new PulsarAdmin(url, config));
-                } catch (Exception e) {
-                    System.err.println(e.getClass() + ": " + e.getMessage());
-                    System.exit(1);
-                }
-            }
 
             return cmdObj.run(Arrays.copyOfRange(args, cmdPos+1, args.length));
         }


### PR DESCRIPTION
### Motivation

pulsar-admin command doesn't have any options (e.g. serviceUrl).
I think it's better to have them like pulsar-client command.

### Modifications

Add some options to pulsar-admin as follows.
- admin-url
- auth-plugin
- auth-params

### Result
Some options can be used on pulsar-admin.