### PR TITLE
Fixed websocket proxy stats license headers

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/admin/WebSocketWebResource.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/admin/WebSocketWebResource.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yahoo.pulsar.websocket.admin;
 
 import javax.naming.AuthenticationException;

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/stats/ProxyStats.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/stats/ProxyStats.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yahoo.pulsar.websocket.stats;
 
 import static com.yahoo.pulsar.websocket.ProducerHandler.ENTRY_LATENCY_BUCKETS_USEC;

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/stats/ProxyTopicStat.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/stats/ProxyTopicStat.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yahoo.pulsar.websocket.stats;
 
 import java.util.Set;


### PR DESCRIPTION
### Motivation

Some files added in #341 didn't have the license headers.
