### PR TITLE
close webService on test to close pulsarClient and executors

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
@@ -126,7 +126,9 @@ public class WebSocketService implements Closeable {
             pulsarClient.close();
         }
 
-        authenticationService.close();
+        if (authenticationService != null) {
+            authenticationService.close();
+        }
 
         if (globalZkCache != null) {
             globalZkCache.close();

--- a/pulsar-websocket/src/test/java/com/yahoo/pulsar/proxy/authentication/AuthenticationServiceTest.java
+++ b/pulsar-websocket/src/test/java/com/yahoo/pulsar/proxy/authentication/AuthenticationServiceTest.java
@@ -46,6 +46,7 @@ public class AuthenticationServiceTest {
         AuthenticationService service = new AuthenticationService(config);
         String result = service.authenticate(null, "auth");
         assertEquals(result, s_authentication_success);
+        service.close();
     }
 
     @Test
@@ -61,6 +62,7 @@ public class AuthenticationServiceTest {
         when(request.getHeader(anyString())).thenReturn("data");
         String result = service.authenticateHttpRequest(request);
         assertEquals(result, s_authentication_success);
+        service.close();
     }
 
     public static class MockAuthenticationProvider implements AuthenticationProvider {

--- a/pulsar-websocket/src/test/java/com/yahoo/pulsar/websocket/LookupProtocolTest.java
+++ b/pulsar-websocket/src/test/java/com/yahoo/pulsar/websocket/LookupProtocolTest.java
@@ -35,6 +35,7 @@ public class LookupProtocolTest {
         lookupField.setAccessible(true);
         Assert.assertEquals(lookupField.get(testClient).getClass().getName(), "com.yahoo.pulsar.client.impl.HttpLookupService");
         Assert.assertFalse(testClient.getConfiguration().isUseTls());
+        service.close();
     }
 
     @Test
@@ -50,6 +51,7 @@ public class LookupProtocolTest {
         lookupField.setAccessible(true);
         Assert.assertEquals(lookupField.get(testClient).getClass().getName(), "com.yahoo.pulsar.client.impl.HttpLookupService");
         Assert.assertTrue(testClient.getConfiguration().isUseTls());
+        service.close();
     }
 
     @Test
@@ -65,6 +67,7 @@ public class LookupProtocolTest {
         lookupField.setAccessible(true);
         Assert.assertEquals(lookupField.get(testClient).getClass().getName(), "com.yahoo.pulsar.client.impl.BinaryProtoLookupService");
         Assert.assertFalse(testClient.getConfiguration().isUseTls());
+        service.close();
     }
 
     @Test
@@ -81,5 +84,6 @@ public class LookupProtocolTest {
         lookupField.setAccessible(true);
         Assert.assertEquals(lookupField.get(testClient).getClass().getName(), "com.yahoo.pulsar.client.impl.BinaryProtoLookupService");
         Assert.assertTrue(testClient.getConfiguration().isUseTls());
+        service.close();
     }
 }


### PR DESCRIPTION
### Motivation

Websocket-proxy tests don't close webSocketService which can create possible leak of resource.

### Modifications

Close `WebSocketService` at end of test.

### Result

It can prevent possible leak on test and prevent travis build failure as it stuck sometime.
