### PR TITLE
Add syntax statement for proto file

### DIFF
--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+syntax = "proto2";
+
 option java_package = "org.apache.bookkeeper.mledger.proto";
 option optimize_for = SPEED;
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+syntax = "proto2";
+
 package pulsar.proto;
 option java_package = "com.yahoo.pulsar.common.api.proto";
 option optimize_for = LITE_RUNTIME;


### PR DESCRIPTION
### Motivation

In my environment, protoc warns to declare syntax  as below.

```bash
$ protoc --go_out=src/pulsar/proto PulsarApi.proto 
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: PulsarApi.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```

My protoc version is here.

```bash
$ protoc --version
libprotoc 3.3.0
```

According the Protocol Buffers document, syntax statement is at top of proto file.

```
proto = syntax { import | package | option | topLevelDef | emptyStatement }
topLevelDef = message | enum | extend | service
```

* https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#proto_file

### Modifications

Add syntax statement into proto file.

```
syntax = "proto2";
```

### Result

protoc doesn't warn.