### PR TITLE
Print hostname and error when we get connection failures

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConnectionPool.java
@@ -132,6 +132,7 @@ public class ConnectionPool implements Closeable {
         // Trigger async connect to broker
         bootstrap.connect(address).addListener((ChannelFuture future) -> {
             if (!future.isSuccess()) {
+                log.warn("Failed to open connection to {} : {}", address, future.cause().getClass().getSimpleName());
                 cnxFuture.completeExceptionally(new PulsarClientException(future.cause()));
                 cleanupConnection(address, connectionKey, cnxFuture);
                 return;


### PR DESCRIPTION
### Motivation

When we have a connection failure in the client library we are not printing the hostname we were trying to connect to.

This typically happens when the topic lookup returns an address that is unreachable from the client machine. Then in the client logs it's not easy to understand why the connection failed.

### Modifications

Add warn log message
