### PR TITLE
Fixed comment typo in broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -81,8 +81,8 @@ clientLibraryVersionCheckAllowUnversioned=true
 statusFilePath=
 
 # If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to
-* use only brokers running the latest software version (to minimize impact to bundles)
-preferLaterVersions=false;
+# use only brokers running the latest software version (to minimize impact to bundles)
+preferLaterVersions=false
 
 ### --- Authentication --- ###
 
@@ -102,8 +102,8 @@ tlsTrustCertsFilePath=
 tlsAllowInsecureConnection=false
 
 # Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
-# messages to consumer once, this limit reaches until consumer starts acknowledging messages back. 
-# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction 
+# messages to consumer once, this limit reaches until consumer starts acknowledging messages back.
+# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
 maxUnackedMessagesPerConsumer=50000
 
 # Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to


### PR DESCRIPTION
### Motivation

Fixed the `*` as line comment in `broker.conf`
