### PR TITLE
Add max per-broker unacked message limit

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -121,7 +121,7 @@ maxUnackedMessagesPerBroker=0
 # Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
 # than this percentage limit and subscription will not receive any new messages until that subscription acks back
 # limit/2 messages   
-unAckMsgSubscriptionPercentageLimitOnBrokerBlocked=0.16
+maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
 
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -112,6 +112,17 @@ maxUnackedMessagesPerConsumer=50000
 # check and dispatcher can dispatch messages without any restriction
 maxUnackedMessagesPerSubscription=200000
 
+# Max number of unacknowledged messages allowed per broker. Once this limit reaches, broker will stop dispatching
+# messages to all shared subscription which has higher number of unack messages until subscriptions start
+# acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
+# unackedMessage-limit check and broker doesn't block dispatchers
+maxUnackedMessagesPerBroker=30000000
+
+# Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
+# than this percentage limit and subscription will not receive any new messages until that subscription acks back
+# limit/2 messages   
+unAckMsgSubscriptionPercentageLimitOnBrokerBlocked=0.16
+
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -116,7 +116,7 @@ maxUnackedMessagesPerSubscription=200000
 # messages to all shared subscription which has higher number of unack messages until subscriptions start
 # acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
 # unackedMessage-limit check and broker doesn't block dispatchers
-maxUnackedMessagesPerBroker=30000000
+maxUnackedMessagesPerBroker=0
 
 # Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
 # than this percentage limit and subscription will not receive any new messages until that subscription acks back

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -81,6 +81,17 @@ maxUnackedMessagesPerConsumer=50000
 # check and dispatcher can dispatch messages without any restriction
 maxUnackedMessagesPerSubscription=200000
 
+# Max number of unacknowledged messages allowed per broker. Once this limit reaches, broker will stop dispatching
+# messages to all shared subscription which has higher number of unack messages until subscriptions start
+# acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
+# unackedMessage-limit check and broker doesn't block dispatchers
+maxUnackedMessagesPerBroker=30000000
+
+# Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
+# than this percentage limit and subscription will not receive any new messages until that subscription acks back
+# limit/2 messages  
+unAckMsgSubscriptionPercentageLimitOnBrokerBlocked=0.16
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -90,7 +90,7 @@ maxUnackedMessagesPerBroker=0
 # Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
 # than this percentage limit and subscription will not receive any new messages until that subscription acks back
 # limit/2 messages  
-unAckMsgSubscriptionPercentageLimitOnBrokerBlocked=0.16
+maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
 
 ### --- Authentication --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -85,7 +85,7 @@ maxUnackedMessagesPerSubscription=200000
 # messages to all shared subscription which has higher number of unack messages until subscriptions start
 # acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
 # unackedMessage-limit check and broker doesn't block dispatchers
-maxUnackedMessagesPerBroker=30000000
+maxUnackedMessagesPerBroker=0
 
 # Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
 # than this percentage limit and subscription will not receive any new messages until that subscription acks back

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -94,6 +94,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit
     // check and dispatcher can dispatch messages without any restriction
     private int maxUnackedMessagesPerSubscription = 4 * 50000;
+    // Max number of unacknowledged messages allowed per broker. Once this limit reaches, broker will stop dispatching
+    // messages to all shared subscription which has higher number of unack messages until subscriptions start
+    // acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
+    // unackedMessage-limit check and broker doesn't block dispatchers
+    private int maxUnackedMessagesPerBroker = 30000000;
+    // Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
+    // than this percentage limit and subscription will not receive any new messages until that subscription acks back
+    // limit/2 messages 
+    private double unAckMsgSubscriptionPercentageLimitOnBrokerBlocked = 0.16;
     // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
     @FieldContext(dynamic = true)
     private int maxConcurrentLookupRequest = 10000;
@@ -450,6 +459,23 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setMaxUnackedMessagesPerSubscription(int maxUnackedMessagesPerSubscription) {
         this.maxUnackedMessagesPerSubscription = maxUnackedMessagesPerSubscription;
+    }
+
+    public int getMaxUnackedMessagesPerBroker() {
+        return maxUnackedMessagesPerBroker;
+    }
+
+    public void setMaxUnackedMessagesPerBroker(int maxUnackedMessagesPerBroker) {
+        this.maxUnackedMessagesPerBroker = maxUnackedMessagesPerBroker;
+    }
+
+    public double getUnAckMsgSubscriptionPercentageLimitOnBrokerBlocked() {
+        return unAckMsgSubscriptionPercentageLimitOnBrokerBlocked;
+    }
+
+    public void setUnAckMsgSubscriptionPercentageLimitOnBrokerBlocked(
+            double unAckMsgSubscriptionPercentageLimitOnBrokerBlocked) {
+        this.unAckMsgSubscriptionPercentageLimitOnBrokerBlocked = unAckMsgSubscriptionPercentageLimitOnBrokerBlocked;
     }
 
     public int getMaxConcurrentLookupRequest() {

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -98,11 +98,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // messages to all shared subscription which has higher number of unack messages until subscriptions start
     // acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
     // unackedMessage-limit check and broker doesn't block dispatchers
-    private int maxUnackedMessagesPerBroker = 30000000;
+    private int maxUnackedMessagesPerBroker = 0;
     // Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
     // than this percentage limit and subscription will not receive any new messages until that subscription acks back
     // limit/2 messages 
-    private double unAckMsgSubscriptionPercentageLimitOnBrokerBlocked = 0.16;
+    private double maxUnackedMessagesPerSubscriptionOnBrokerBlocked = 0.16;
     // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
     @FieldContext(dynamic = true)
     private int maxConcurrentLookupRequest = 10000;
@@ -469,13 +469,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
         this.maxUnackedMessagesPerBroker = maxUnackedMessagesPerBroker;
     }
 
-    public double getUnAckMsgSubscriptionPercentageLimitOnBrokerBlocked() {
-        return unAckMsgSubscriptionPercentageLimitOnBrokerBlocked;
+    public double getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked() {
+        return maxUnackedMessagesPerSubscriptionOnBrokerBlocked;
     }
 
-    public void setUnAckMsgSubscriptionPercentageLimitOnBrokerBlocked(
-            double unAckMsgSubscriptionPercentageLimitOnBrokerBlocked) {
-        this.unAckMsgSubscriptionPercentageLimitOnBrokerBlocked = unAckMsgSubscriptionPercentageLimitOnBrokerBlocked;
+    public void setMaxUnackedMessagesPerSubscriptionOnBrokerBlocked(
+            double maxUnackedMessagesPerSubscriptionOnBrokerBlocked) {
+        this.maxUnackedMessagesPerSubscriptionOnBrokerBlocked = maxUnackedMessagesPerSubscriptionOnBrokerBlocked;
     }
 
     public int getMaxConcurrentLookupRequest() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.ObjectSet;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Lists;
 import com.yahoo.pulsar.broker.service.BrokerServiceException;
 import com.yahoo.pulsar.broker.service.Consumer;
 import com.yahoo.pulsar.broker.service.Dispatcher;
@@ -170,7 +171,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
         readMoreEntries();
     }
 
-    private void readMoreEntries() {
+    public void readMoreEntries() {
         if (totalAvailablePermits > 0 && isAtleastOneConsumerAvailable()) {
             int messagesToRead = Math.min(totalAvailablePermits, readBatchSize);
 
@@ -586,30 +587,56 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
     @Override
     public void addUnAckedMessages(int numberOfMessages) {
         // don't block dispatching if maxUnackedMessages = 0
-        if(maxUnackedMessages <= 0) {
+        if (maxUnackedMessages <= 0) {
             return;
         }
         int unAckedMessages = TOTAL_UNACKED_MESSAGES_UPDATER.addAndGet(this, numberOfMessages);
         if (unAckedMessages >= maxUnackedMessages
                 && BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, FALSE, TRUE)) {
+            // block dispatcher if it reaches maxUnAckMsg limit
             log.info("[{}] Dispatcher is blocked due to unackMessages {} reached to max {}", name,
                     TOTAL_UNACKED_MESSAGES_UPDATER.get(this), maxUnackedMessages);
+        } else if (topic.getBrokerService().isBrokerDispatchingBlocked()
+                && BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE) {
+            // unblock dispatcher: if dispatcher is blocked due to broker-unackMsg limit and if it ack back enough
+            // messages
+            if (TOTAL_UNACKED_MESSAGES_UPDATER.get(this) < (topic.getBrokerService().maxUnackedMsgsPerDispatcher / 2)) {
+                if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
+                    // it removes dispatcher from blocked list and unblocks dispatcher by scheduling read
+                    topic.getBrokerService().unblockDispatchersOnUnAckMessages(Lists.newArrayList(this));
+                }
+            }
         } else if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE
                 && unAckedMessages < maxUnackedMessages / 2) {
+            // unblock dispatcher if it acks back enough messages
             if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
                 log.info("[{}] Dispatcher is unblocked", name);
                 topic.getBrokerService().executor().submit(() -> readMoreEntries());
             }
         }
+        // increment broker-level count
+        topic.getBrokerService().addUnAckedMessages(this, numberOfMessages);
     }
 
     public boolean isBlockedDispatcherOnUnackedMsgs() {
         return BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE;
+    }
+    
+    public void blockDispatcherOnUnackedMsgs() {
+        BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.set(this, TRUE);
+    }
+    
+    public void unBlockDispatcherOnUnackedMsgs() {
+        BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.set(this, FALSE);
     }
 
     public int getTotalUnackedMessages() {
         return TOTAL_UNACKED_MESSAGES_UPDATER.get(this);
     }
 
+    public String getName() {
+        return name;
+    }
+    
     private static final Logger log = LoggerFactory.getLogger(PersistentDispatcherMultipleConsumers.class);
 }


### PR DESCRIPTION
### Motivation

As discussed at #399 broker has max-unack message limit per subscription but if number of misbehaving subscriptions are high then broker still keeps higher number of unack-message positions in memory and it still can cause frequent gc at broker. Therefore, broker should have per-broker unack message as well to safeguard against subscriptions which generates high number of unack messages.

### Modifications

Now, broker has two additional configuration.
1. [Max unack message limit per broker](https://github.com/rdhabalia/pulsar/blob/2c7d5c8b020fcd5dad1cdf87ab778e398ec73484/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java#L101) `maxUnackedMessagesPerBroker` : Limit to block all dispatchers that generates high number (`unAckMsgSubscriptionPercentageLimitOnBrokerBlocked`) of unack messages.
2. [per-subscription limit when broker is blocked on unack-message limit](https://github.com/rdhabalia/pulsar/blob/2c7d5c8b020fcd5dad1cdf87ab778e398ec73484/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java#L105) `unAckMsgSubscriptionPercentageLimitOnBrokerBlocked`: when broker reaches per-broker limit, it blocks all dispatchers whose unack message number is higher than this limit. Broker unblocks dispatcher once it acks back `unAckMsgSubscriptionPercentageLimitOnBrokerBlocked`/2 messages or per-broker unack message count decreases to `maxUnackedMessagesPerBroker/2`

### Result

It helps broker to safe-guard if broker loads many subscriptions which are not acking and making broker to store high number of unack message positions in memory which can cause frequent gc at broker.
