### PR TITLE
Made log category name configurable in CPP Client

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -21,6 +21,13 @@ set(Boost_NO_BOOST_CMAKE ON)
 
 set (CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
 set(PROTOBUF_LIBRARIES $ENV{PROTOBUF_LIBRARIES})
+set(LOG_CATEGORY_NAME $ENV{LOG_CATEGORY_NAME})
+
+if (NOT LOG_CATEGORY_NAME)
+    set(LOG_CATEGORY_NAME "\"pulsar.\"")
+endif(NOT LOG_CATEGORY_NAME)
+
+add_definitions(-DLOG_CATEGORY_NAME=${LOG_CATEGORY_NAME})
 
 find_package(Boost REQUIRED COMPONENTS program_options filesystem regex thread system)
 find_package(OpenSSL REQUIRED)

--- a/pulsar-client-cpp/lib/LogUtils.h
+++ b/pulsar-client-cpp/lib/LogUtils.h
@@ -27,7 +27,7 @@
         static boost::thread_specific_ptr<log4cxx::LoggerPtr> threadSpecificLogPtr; \
         log4cxx::LoggerPtr* ptr = threadSpecificLogPtr.get(); \
         if (!ptr) { \
-            threadSpecificLogPtr.reset(new log4cxx::LoggerPtr(log4cxx::Logger::getLogger("pulsar." __FILE__)));\
+            threadSpecificLogPtr.reset(new log4cxx::LoggerPtr(log4cxx::Logger::getLogger(LOG_CATEGORY_NAME __FILE__)));\
             ptr = threadSpecificLogPtr.get(); \
         } \
         return *ptr;                                      \


### PR DESCRIPTION
CPP Legacy client users use log category name as "cms" in log4cpp.conf - hence making the name configurable so that I can pass a different value in the wrapper.