### PR TITLE
Include default values uncommented in conf/bookkepeer.conf

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -47,7 +47,7 @@ fi
 BINDIR=`dirname "$0"`
 BK_HOME=`cd $BINDIR/..;pwd`
 
-DEFAULT_CONF=$BK_HOME/conf/bk_server.conf
+DEFAULT_CONF=$BK_HOME/conf/bookkeper.conf
 DEFAULT_LOG_CONF=$BK_HOME/conf/log4j.properties
 
 source $BK_HOME/conf/bkenv.sh
@@ -66,14 +66,14 @@ else
 fi
 
 # exclude tests jar
-RELEASE_JAR=`ls $BK_HOME/bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1` 
+RELEASE_JAR=`ls $BK_HOME/bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? == 0 ]; then
     BOOKIE_JAR=$RELEASE_JAR
 fi
 
 # exclude tests jar
 BUILT_JAR=`ls $BK_HOME/target/bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1`
-if [ $? != 0 ] && [ ! -e "$BOOKIE_JAR" ]; then 
+if [ $? != 0 ] && [ ! -e "$BOOKIE_JAR" ]; then
     echo "\nCouldn't find bookkeeper jar.";
     echo "Make sure you've run 'mvn package'\n";
     exit 1;
@@ -112,7 +112,7 @@ add_maven_deps_to_classpath() {
     if [ "$MAVEN_HOME" != "" ]; then
 	MVN=${MAVEN_HOME}/bin/mvn
     fi
-    
+
     # Need to generate classpath from maven pom. This is costly so generate it
     # and cache it. Save the file into our target dir so a mvn clean will get
     # clean it up and force us create a new one.
@@ -195,4 +195,3 @@ elif [ $COMMAND == "help" ]; then
 else
     exec $JAVA $OPTS $COMMAND $@
 fi
-

--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -34,7 +34,7 @@ bookiePort=3181
 # establish their identities as 127.0.0.1:3181, and only one will be able
 # to join the cluster. For VPSs configured like this, you should explicitly
 # set the listening interface.
-#allowLoopback=false
+allowLoopback=false
 
 # Directory Bookkeeper outputs its write ahead log
 journalDirectory=data/bookkeeper/journal
@@ -59,27 +59,27 @@ ledgerManagerType=hierarchical
 # Root zookeeper path to store ledger metadata
 # This parameter is used by zookeeper-based ledger manager as a root znode to
 # store all ledgers.
-# zkLedgersRootPath=/ledgers
+zkLedgersRootPath=/ledgers
 
 # Ledger storage implementation class
 ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage
 
 # Enable/Disable entry logger preallocation
-# entryLogFilePreallocationEnabled=true
+entryLogFilePreallocationEnabled=true
 
 # Max file size of entry logger, in bytes
 # A new entry log file will be created when the old one reaches the file size limitation
-# logSizeLimit=2147483648
+logSizeLimit=2147483648
 
 # Threshold of minor compaction
 # For those entry log files whose remaining size percentage reaches below
 # this threshold will be compacted in a minor compaction.
 # If it is set to less than zero, the minor compaction is disabled.
-# minorCompactionThreshold=0.2
+minorCompactionThreshold=0.2
 
 # Interval to run minor compaction, in seconds
 # If it is set to less than zero, the minor compaction is disabled.
-# minorCompactionInterval=3600
+minorCompactionInterval=3600
 
 # Threshold of major compaction
 # For those entry log files whose remaining size percentage reaches below
@@ -91,7 +91,7 @@ majorCompactionThreshold=0.5
 
 # Interval to run major compaction, in seconds
 # If it is set to less than zero, the major compaction is disabled.
-# majorCompactionInterval=86400
+majorCompactionInterval=86400
 
 # Set the maximum number of entries which can be compacted without flushing.
 # When compacting, the entries are written to the entrylog and the new offsets
@@ -101,42 +101,42 @@ majorCompactionThreshold=0.5
 # more memory will be used for offsets. Each offset consists of 3 longs.
 # This parameter should _not_ be modified unless you know what you're doing.
 # The default is 100,000.
-#compactionMaxOutstandingRequests=100000
+compactionMaxOutstandingRequests=100000
 
 # Set the rate at which compaction will readd entries. The unit is adds per second.
-#compactionRate=1000
+compactionRate=1000
 
 # Throttle compaction by bytes or by entries.
-#isThrottleByBytes=false
+isThrottleByBytes=false
 
 # Set the rate at which compaction will readd entries. The unit is adds per second.
-#compactionRateByEntries=1000
+compactionRateByEntries=1000
 
 # Set the rate at which compaction will readd entries. The unit is bytes added per second.
-#compactionRateByBytes=1000000
+compactionRateByBytes=1000000
 
 # Max file size of journal file, in mega bytes
 # A new journal file will be created when the old one reaches the file size limitation
 #
-# journalMaxSizeMB=2048
+journalMaxSizeMB=2048
 
 # Max number of old journal file to kept
 # Keep a number of old journal files would help data recovery in specia case
 #
-# journalMaxBackups=5
+journalMaxBackups=5
 
 # How much space should we pre-allocate at a time in the journal
-# journalPreAllocSizeMB=16
+journalPreAllocSizeMB=16
 
 # Size of the write buffers used for the journal
-# journalWriteBufferSizeKB=64
+journalWriteBufferSizeKB=64
 
 # Should we remove pages from page cache after force write
 journalRemoveFromPageCache=true
 
 # Should we group journal force writes, which optimize group commit
 # for higher throughput
-# journalAdaptiveGroupWrites=true
+journalAdaptiveGroupWrites=true
 
 # Maximum latency to impose on a journal write to achieve grouping
 journalMaxGroupWaitMSec=1
@@ -145,10 +145,10 @@ journalMaxGroupWaitMSec=1
 journalAlignmentSize=4096
 
 # Maximum writes to buffer to achieve grouping
-# journalBufferedWritesThreshold=524288
+journalBufferedWritesThreshold=524288
 
 # If we should flush the journal when journal queue is empty
-# journalFlushWhenQueueEmpty=false
+journalFlushWhenQueueEmpty=false
 
 # The number of threads that should handle journal callbacks
 numJournalCallbackThreads=8
@@ -165,7 +165,7 @@ gcWaitTime=900000
 # How long the interval to trigger next garbage collection of overreplicated
 # ledgers, in milliseconds [Default: 1 day]. This should not be run very frequently since we read
 # the metadata for all the ledgers on the bookie from zk
-# gcOverreplicatedLedgerWaitTime=86400000
+gcOverreplicatedLedgerWaitTime=86400000
 
 # How long the interval to flush ledger index pages to disk, in milliseconds
 # Flushing index files will introduce much random disk I/O.
@@ -180,7 +180,7 @@ flushInterval=60000
 
 # Interval to watch whether bookie is dead or not, in milliseconds
 #
-# bookieDeathWatchInterval=1000
+bookieDeathWatchInterval=1000
 
 ## zookeeper client settings
 
@@ -205,7 +205,7 @@ zkTimeout=30000
 # can provide better performance.
 # Default value is true.
 #
-# serverTcpNoDelay=true
+serverTcpNoDelay=true
 
 ## ledger cache settings
 
@@ -248,18 +248,18 @@ readOnlyModeEnabled=true
 #will turn to readonly mode if 'readOnlyModeEnabled=true' is set, else it will
 #shutdown.
 #Valid values should be in between 0 and 1 (exclusive).
-#diskUsageThreshold=0.95
+diskUsageThreshold=0.95
 
 #Disk check interval in milli seconds, interval to check the ledger dirs usage.
 #Default is 10000
-#diskCheckInterval=10000
+diskCheckInterval=10000
 
 # Interval at which the auditor will do a check of all ledgers in the cluster.
 # By default this runs once a week. The interval is set in seconds.
 # To disable the periodic check completely, set this to 0.
 # Note that periodic checking will put extra load on the cluster, so it should
 # not be run more frequently than once a day.
-#auditorPeriodicCheckInterval=604800
+auditorPeriodicCheckInterval=604800
 
 # The interval between auditor bookie checks.
 # The auditor bookie check, checks ledger metadata to see which bookies should
@@ -268,7 +268,7 @@ readOnlyModeEnabled=true
 # Setting this to 0 disabled the periodic check. Bookie checks will still
 # run when a bookie fails.
 # The interval is specified in seconds.
-#auditorPeriodicBookieCheckInterval=86400
+auditorPeriodicBookieCheckInterval=86400
 
 # number of threads that should handle write requests. if zero, the writes would
 # be handled by netty threads directly.
@@ -286,13 +286,13 @@ maxPendingReadRequestsPerThread=2500
 readBufferSizeBytes=4096
 
 # The number of bytes used as capacity for the write buffer. Default is 64KB.
-# writeBufferSizeBytes=65536
+writeBufferSizeBytes=65536
 
 # Whether the bookie should use its hostname to register with the
 # co-ordination service(eg: zookeeper service).
 # When false, bookie will use its ipaddress for the registration.
 # Defaults to false.
-#useHostNameAsBookieID=false
+useHostNameAsBookieID=false
 
 # Stats Provider Class
 statsProviderClass=org.apache.bokkeeper.stats.datasketches.DataSketchesMetricsProvider
@@ -321,12 +321,13 @@ dbStorage_readAheadCacheBatchSize=1000
 # Size of RocksDB block-cache. For best performance, this cache
 # should be big enough to hold a significant portion of the index
 # database which can reach ~2GB in some cases
-# dbStorage_rocksDB_blockCacheSize=268435456 # 256 MBytes
+# 256 MBytes
+dbStorage_rocksDB_blockCacheSize=268435456
 
-# dbStorage_rocksDB_writeBufferSizeMB=64
-# dbStorage_rocksDB_sstSizeInMB=64
-# dbStorage_rocksDB_blockSize=65536
-# dbStorage_rocksDB_bloomFilterBitsPerKey=10
-# dbStorage_rocksDB_numLevels=-1
-# dbStorage_rocksDB_numFilesInLevel0=4
-# dbStorage_rocksDB_maxSizeInLevel1MB=256
+dbStorage_rocksDB_writeBufferSizeMB=64
+dbStorage_rocksDB_sstSizeInMB=64
+dbStorage_rocksDB_blockSize=65536
+dbStorage_rocksDB_bloomFilterBitsPerKey=10
+dbStorage_rocksDB_numLevels=-1
+dbStorage_rocksDB_numFilesInLevel0=4
+dbStorage_rocksDB_maxSizeInLevel1MB=256


### PR DESCRIPTION
### Motivation

To write a tool that apply specific configuration specialization is useful
to get a list of all the variables that can be changed in the config
file.

In all the other config files we have the same thing, all the keys with the 
default values.
