### PR TITLE
Configure to use less memory for short-lived CLI tools

### DIFF
--- a/bin/pulsar-admin
+++ b/bin/pulsar-admin
@@ -21,9 +21,9 @@ PULSAR_HOME=`cd $BINDIR/..;pwd`
 DEFAULT_CLIENT_CONF=$PULSAR_HOME/conf/client.conf
 DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j.properties
 
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+if [ -f "$PULSAR_HOME/conf/pulsar_tools_env.sh" ]
 then
-    . "$PULSAR_HOME/conf/pulsar_env.sh"
+    . "$PULSAR_HOME/conf/pulsar_tools_env.sh"
 fi
 
 # Check for the java to use

--- a/bin/pulsar-client
+++ b/bin/pulsar-client
@@ -21,9 +21,9 @@ PULSAR_HOME=`cd $BINDIR/..;pwd`
 DEFAULT_CLIENT_CONF=$PULSAR_HOME/conf/client.conf
 DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j.properties
 
-if [ -f "$PULSAR_HOME/conf/pulsar_env.sh" ]
+if [ -f "$PULSAR_HOME/conf/pulsar_tools_env.sh" ]
 then
-    . "$PULSAR_HOME/conf/pulsar_env.sh"
+    . "$PULSAR_HOME/conf/pulsar_tools_env.sh"
 fi
 
 # Check for the java to use

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Yahoo Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+# Set JAVA_HOME here to override the environment setting
+# JAVA_HOME=
+
+# default settings for starting pulsar broker
+
+# Log4j configuration file
+# PULSAR_LOG_CONF=
+
+# Logs location
+# PULSAR_LOG_DIR=
+
+# Configuration file of settings used in broker server
+# PULSAR_BROKER_CONF=
+
+# Configuration file of settings used in bookie server
+# PULSAR_BOOKKEEPER_CONF=
+
+# Configuration file of settings used in zookeeper server
+# PULSAR_ZK_CONF=
+
+# Configuration file of settings used in global zookeeper server
+# PULSAR_GLOBAL_ZK_CONF=
+
+# Extra options to be passed to the jvm
+PULSAR_MEM=" -Xmx256m -XX:MaxDirectMemorySize=256m"
+
+# Garbage collection options
+PULSAR_GC=" -client "
+
+# Extra options to be passed to the jvm
+PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled"
+
+# Add extra paths to the bookkeeper classpath
+# PULSAR_EXTRA_CLASSPATH=
+
+#Folder where the Bookie server PID file should be stored
+#PULSAR_PID_DIR=
+
+#Wait time before forcefully kill the pulser server instance, if the stop is not successful
+#PULSAR_STOP_TIMEOUT=


### PR DESCRIPTION
### Motivation

Existing tools like `pulsar-admin` and `pulsar-client` should use less memory to have shorter startup times.