### PR TITLE
Topic termination

### DIFF
--- a/docs/BinaryProtocol.md
+++ b/docs/BinaryProtocol.md
@@ -443,6 +443,15 @@ On redelivery, messages an be sent to the same consumer or, in the case of a
 shared subscription, spread across all available consumers.
 
 
+##### Command ReachedEndOfTopic
+
+This is sent by a broker to a particular consumer, whenever the topic
+has been "terminated" and all the messages on the subscription were
+acknowledged.
+
+The client should use this command to notify the application that no more
+messages are coming from the consumer.
+
 ## Service discovery
 
 ### Topic lookup

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -98,6 +98,12 @@ public interface AsyncCallbacks {
         public void deleteFailed(ManagedLedgerException exception, Object ctx);
     }
 
+    public interface TerminateCallback {
+        public void terminateComplete(Position lastCommittedPosition, Object ctx);
+
+        public void terminateFailed(ManagedLedgerException exception, Object ctx);
+    }
+
     public interface FindEntryCallback {
         public void findEntryComplete(Position position, Object ctx);
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -22,6 +22,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
 
 import com.google.common.annotations.Beta;
 
@@ -250,6 +251,19 @@ public interface ManagedLedger {
      */
     public void checkBackloggedCursors();
 
+    public void asyncTerminate(TerminateCallback callback, Object ctx);
+
+    /**
+     * Terminate the managed ledger and return the last committed entry.
+     * <p>
+     * Once the managed ledger is terminated, it will not accept any more write
+     *
+     * @return
+     * @throws InterruptedException
+     * @throws ManagedLedgerException
+     */
+    public Position terminate() throws InterruptedException, ManagedLedgerException;
+
     /**
      * Close the ManagedLedger.
      * <p>
@@ -299,4 +313,9 @@ public interface ManagedLedger {
      * @return the slowest consumer
      */
     public ManagedCursor getSlowestConsumer();
+
+    /**
+     * Returns whether the managed ledger was terminated
+     */
+    public boolean isTerminated();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -50,11 +50,22 @@ public class ManagedLedgerException extends Exception {
         }
     }
 
+    public static class ManagedLedgerTerminatedException extends ManagedLedgerException {
+        public ManagedLedgerTerminatedException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class NoMoreEntriesToReadException extends ManagedLedgerException {
+        public NoMoreEntriesToReadException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class InvalidCursorPositionException extends ManagedLedgerException {
         public InvalidCursorPositionException(String msg) {
             super(msg);
         }
-
     }
 
     public static class ConcurrentFindCursorPositionException extends ManagedLedgerException {
@@ -68,7 +79,7 @@ public class ManagedLedgerException extends Exception {
             super(msg);
         }
     }
-    
+
     public static class TooManyRequestsException extends ManagedLedgerException {
         public TooManyRequestsException(String msg) {
             super(msg);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
@@ -25,6 +25,7 @@ public class ManagedLedgerInfo {
     public String modificationDate;
 
     public List<LedgerInfo> ledgers;
+    public PositionInfo terminatedPosition;
 
     public Map<String, CursorInfo> cursors;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -52,6 +52,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.NoMoreEntriesToReadException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
@@ -112,7 +113,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     private final RateLimiter markDeleteLimiter;
-    
+
     private final ZNodeProtobufFormat protobufFormat;
 
     class PendingMarkDeleteEntry {
@@ -545,6 +546,11 @@ public class ManagedCursorImpl implements ManagedCursor {
                             log.debug("[{}] [{}] notification was already cancelled", ledger.getName(), name);
                         }
                     }
+                } else if (ledger.isTerminated()) {
+                    // At this point we registered for notification and still there were no more available
+                    // entries.
+                    // If the managed ledger was indeed terminated, we need to notify the cursor
+                    callback.readEntriesFailed(new NoMoreEntriesToReadException("Topic was terminated"), ctx);
                 }
             }), 10, TimeUnit.MILLISECONDS);
         }
@@ -861,12 +867,12 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     /**
-     * Async replays given positions: 
-     * a. before reading it filters out already-acked messages 
+     * Async replays given positions:
+     * a. before reading it filters out already-acked messages
      * b. reads remaining entries async and gives it to given ReadEntriesCallback
      * c. returns all already-acked messages which are not replayed so, those messages can be removed by
      * caller(Dispatcher)'s replay-list and it won't try to replay it again
-     * 
+     *
      */
     @Override
     public Set<? extends Position> asyncReplayEntries(final Set<? extends Position> positions, ReadEntriesCallback callback, Object ctx) {
@@ -884,7 +890,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         } finally {
             lock.readLock().unlock();
         }
-        
+
         final int totalValidPositions = positions.size() - alreadyAcknowledgedPositions.size();
         final AtomicReference<ManagedLedgerException> exception = new AtomicReference<>();
         ReadEntryCallback cb = new ReadEntryCallback() {
@@ -923,7 +929,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         positions.stream()
                 .filter(position -> !alreadyAcknowledgedPositions.contains(position))
                 .forEach(p -> ledger.asyncReadEntry((PositionImpl) p, cb, ctx));
-        
+
         return alreadyAcknowledgedPositions;
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -350,6 +350,12 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 info.modificationDate = DATE_FORMAT.format(Instant.ofEpochMilli(stat.getModificationTimestamp()));
 
                 info.ledgers = new ArrayList<>(pbInfo.getLedgerInfoCount());
+                if (pbInfo.hasTerminatedPosition()) {
+                    info.terminatedPosition = new PositionInfo();
+                    info.terminatedPosition.ledgerId = pbInfo.getTerminatedPosition().getLedgerId();
+                    info.terminatedPosition.entryId = pbInfo.getTerminatedPosition().getEntryId();
+                }
+
                 for (int i = 0; i < pbInfo.getLedgerInfoCount(); i++) {
                     MLDataFormats.ManagedLedgerInfo.LedgerInfo pbLedgerInfo = pbInfo.getLedgerInfo(i);
                     LedgerInfo ledgerInfo = new LedgerInfo();
@@ -457,6 +463,6 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     }
 
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerFactoryImpl.class);
-    
+
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeper.java
@@ -68,7 +68,7 @@ public class MetaStoreImplZookeeper implements MetaStore {
             this.creationTimestamp = stat.getCtime();
             this.modificationTimestamp = stat.getMtime();
         }
-        
+
         ZKStat() {
             this.version = 0;
             this.creationTimestamp = System.currentTimeMillis();
@@ -127,6 +127,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
         }
         ManagedLedgerInfo.Builder mlInfo = ManagedLedgerInfo.newBuilder();
         mlInfo.addAllLedgerInfo(infoList);
+        if (info.hasTerminatedPosition()) {
+            mlInfo.setTerminatedPosition(info.getTerminatedPosition());
+        }
         return mlInfo.build();
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
@@ -20,6 +20,11 @@ public final class MLDataFormats {
         getLedgerInfoOrBuilderList();
     org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfoOrBuilder getLedgerInfoOrBuilder(
         int index);
+    
+    // optional .NestedPositionInfo terminatedPosition = 2;
+    boolean hasTerminatedPosition();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getTerminatedPosition();
+    org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getTerminatedPositionOrBuilder();
   }
   public static final class ManagedLedgerInfo extends
       com.google.protobuf.GeneratedMessage
@@ -566,6 +571,7 @@ public final class MLDataFormats {
       // @@protoc_insertion_point(class_scope:ManagedLedgerInfo.LedgerInfo)
     }
     
+    private int bitField0_;
     // repeated .ManagedLedgerInfo.LedgerInfo ledgerInfo = 1;
     public static final int LEDGERINFO_FIELD_NUMBER = 1;
     private java.util.List<org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgerInfo_;
@@ -587,8 +593,22 @@ public final class MLDataFormats {
       return ledgerInfo_.get(index);
     }
     
+    // optional .NestedPositionInfo terminatedPosition = 2;
+    public static final int TERMINATEDPOSITION_FIELD_NUMBER = 2;
+    private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo terminatedPosition_;
+    public boolean hasTerminatedPosition() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getTerminatedPosition() {
+      return terminatedPosition_;
+    }
+    public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getTerminatedPositionOrBuilder() {
+      return terminatedPosition_;
+    }
+    
     private void initFields() {
       ledgerInfo_ = java.util.Collections.emptyList();
+      terminatedPosition_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -597,6 +617,12 @@ public final class MLDataFormats {
       
       for (int i = 0; i < getLedgerInfoCount(); i++) {
         if (!getLedgerInfo(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasTerminatedPosition()) {
+        if (!getTerminatedPosition().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -611,6 +637,9 @@ public final class MLDataFormats {
       for (int i = 0; i < ledgerInfo_.size(); i++) {
         output.writeMessage(1, ledgerInfo_.get(i));
       }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeMessage(2, terminatedPosition_);
+      }
       getUnknownFields().writeTo(output);
     }
     
@@ -623,6 +652,10 @@ public final class MLDataFormats {
       for (int i = 0; i < ledgerInfo_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, ledgerInfo_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, terminatedPosition_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -741,6 +774,7 @@ public final class MLDataFormats {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getLedgerInfoFieldBuilder();
+          getTerminatedPositionFieldBuilder();
         }
       }
       private static Builder create() {
@@ -755,6 +789,12 @@ public final class MLDataFormats {
         } else {
           ledgerInfoBuilder_.clear();
         }
+        if (terminatedPositionBuilder_ == null) {
+          terminatedPosition_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+        } else {
+          terminatedPositionBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       
@@ -792,6 +832,7 @@ public final class MLDataFormats {
       public org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo buildPartial() {
         org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo result = new org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo(this);
         int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         if (ledgerInfoBuilder_ == null) {
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
             ledgerInfo_ = java.util.Collections.unmodifiableList(ledgerInfo_);
@@ -801,6 +842,15 @@ public final class MLDataFormats {
         } else {
           result.ledgerInfo_ = ledgerInfoBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        if (terminatedPositionBuilder_ == null) {
+          result.terminatedPosition_ = terminatedPosition_;
+        } else {
+          result.terminatedPosition_ = terminatedPositionBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -842,6 +892,9 @@ public final class MLDataFormats {
             }
           }
         }
+        if (other.hasTerminatedPosition()) {
+          mergeTerminatedPosition(other.getTerminatedPosition());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -849,6 +902,12 @@ public final class MLDataFormats {
       public final boolean isInitialized() {
         for (int i = 0; i < getLedgerInfoCount(); i++) {
           if (!getLedgerInfo(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasTerminatedPosition()) {
+          if (!getTerminatedPosition().isInitialized()) {
             
             return false;
           }
@@ -883,6 +942,15 @@ public final class MLDataFormats {
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo.newBuilder();
               input.readMessage(subBuilder, extensionRegistry);
               addLedgerInfo(subBuilder.buildPartial());
+              break;
+            }
+            case 18: {
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder();
+              if (hasTerminatedPosition()) {
+                subBuilder.mergeFrom(getTerminatedPosition());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setTerminatedPosition(subBuilder.buildPartial());
               break;
             }
           }
@@ -1075,6 +1143,96 @@ public final class MLDataFormats {
           ledgerInfo_ = null;
         }
         return ledgerInfoBuilder_;
+      }
+      
+      // optional .NestedPositionInfo terminatedPosition = 2;
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo terminatedPosition_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder> terminatedPositionBuilder_;
+      public boolean hasTerminatedPosition() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo getTerminatedPosition() {
+        if (terminatedPositionBuilder_ == null) {
+          return terminatedPosition_;
+        } else {
+          return terminatedPositionBuilder_.getMessage();
+        }
+      }
+      public Builder setTerminatedPosition(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo value) {
+        if (terminatedPositionBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          terminatedPosition_ = value;
+          onChanged();
+        } else {
+          terminatedPositionBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder setTerminatedPosition(
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder builderForValue) {
+        if (terminatedPositionBuilder_ == null) {
+          terminatedPosition_ = builderForValue.build();
+          onChanged();
+        } else {
+          terminatedPositionBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder mergeTerminatedPosition(org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo value) {
+        if (terminatedPositionBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+              terminatedPosition_ != org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance()) {
+            terminatedPosition_ =
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.newBuilder(terminatedPosition_).mergeFrom(value).buildPartial();
+          } else {
+            terminatedPosition_ = value;
+          }
+          onChanged();
+        } else {
+          terminatedPositionBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      public Builder clearTerminatedPosition() {
+        if (terminatedPositionBuilder_ == null) {
+          terminatedPosition_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.getDefaultInstance();
+          onChanged();
+        } else {
+          terminatedPositionBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder getTerminatedPositionBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getTerminatedPositionFieldBuilder().getBuilder();
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder getTerminatedPositionOrBuilder() {
+        if (terminatedPositionBuilder_ != null) {
+          return terminatedPositionBuilder_.getMessageOrBuilder();
+        } else {
+          return terminatedPosition_;
+        }
+      }
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder> 
+          getTerminatedPositionFieldBuilder() {
+        if (terminatedPositionBuilder_ == null) {
+          terminatedPositionBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfoOrBuilder>(
+                  terminatedPosition_,
+                  getParentForChildren(),
+                  isClean());
+          terminatedPosition_ = null;
+        }
+        return terminatedPositionBuilder_;
       }
       
       // @@protoc_insertion_point(builder_scope:ManagedLedgerInfo)
@@ -3578,23 +3736,24 @@ public final class MLDataFormats {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\"src/main/proto/MLDataFormats.proto\"\230\001\n" +
+      "\n\"src/main/proto/MLDataFormats.proto\"\311\001\n" +
       "\021ManagedLedgerInfo\0221\n\nledgerInfo\030\001 \003(\0132\035" +
-      ".ManagedLedgerInfo.LedgerInfo\032P\n\nLedgerI" +
-      "nfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entries\030\002 \001(\003\022\014" +
-      "\n\004size\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003\"c\n\014Posit" +
-      "ionInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002" +
-      "(\003\0220\n\031individualDeletedMessages\030\003 \003(\0132\r." +
-      "MessageRange\"7\n\022NestedPositionInfo\022\020\n\010le" +
-      "dgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\"f\n\014Message" +
-      "Range\022*\n\rlowerEndpoint\030\001 \002(\0132\023.NestedPos",
-      "itionInfo\022*\n\rupperEndpoint\030\002 \002(\0132\023.Neste" +
-      "dPositionInfo\"\225\001\n\021ManagedCursorInfo\022\027\n\017c" +
-      "ursorsLedgerId\030\001 \002(\003\022\032\n\022markDeleteLedger" +
-      "Id\030\002 \001(\003\022\031\n\021markDeleteEntryId\030\003 \001(\003\0220\n\031i" +
-      "ndividualDeletedMessages\030\004 \003(\0132\r.Message" +
-      "RangeB\'\n#org.apache.bookkeeper.mledger.p" +
-      "rotoH\001"
+      ".ManagedLedgerInfo.LedgerInfo\022/\n\022termina" +
+      "tedPosition\030\002 \001(\0132\023.NestedPositionInfo\032P" +
+      "\n\nLedgerInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entrie" +
+      "s\030\002 \001(\003\022\014\n\004size\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003" +
+      "\"c\n\014PositionInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007en" +
+      "tryId\030\002 \002(\003\0220\n\031individualDeletedMessages" +
+      "\030\003 \003(\0132\r.MessageRange\"7\n\022NestedPositionI" +
+      "nfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\"f",
+      "\n\014MessageRange\022*\n\rlowerEndpoint\030\001 \002(\0132\023." +
+      "NestedPositionInfo\022*\n\rupperEndpoint\030\002 \002(" +
+      "\0132\023.NestedPositionInfo\"\225\001\n\021ManagedCursor" +
+      "Info\022\027\n\017cursorsLedgerId\030\001 \002(\003\022\032\n\022markDel" +
+      "eteLedgerId\030\002 \001(\003\022\031\n\021markDeleteEntryId\030\003" +
+      " \001(\003\0220\n\031individualDeletedMessages\030\004 \003(\0132" +
+      "\r.MessageRangeB\'\n#org.apache.bookkeeper." +
+      "mledger.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -3606,7 +3765,7 @@ public final class MLDataFormats {
           internal_static_ManagedLedgerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ManagedLedgerInfo_descriptor,
-              new java.lang.String[] { "LedgerInfo", },
+              new java.lang.String[] { "LedgerInfo", "TerminatedPosition", },
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.Builder.class);
           internal_static_ManagedLedgerInfo_LedgerInfo_descriptor =

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -27,6 +27,12 @@ message ManagedLedgerInfo {
     }
     
     repeated LedgerInfo ledgerInfo = 1;
+
+    // If present, it signals the managed ledger has been
+    // terminated and this was the position of the last
+    // committed entry.
+    // No more entries can be written.
+    optional NestedPositionInfo terminatedPosition = 2;
 }
 
 message PositionInfo {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTerminationTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTerminationTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.NoMoreEntriesToReadException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.Test;
+
+public class ManagedLedgerTerminationTest extends MockedBookKeeperTestCase {
+
+    @Test(timeOut = 20000)
+    public void terminateSimple() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+
+        Position p0 = ledger.addEntry("entry-0".getBytes());
+
+        Position lastPosition = ledger.terminate();
+
+        assertEquals(lastPosition, p0);
+
+        try {
+            ledger.addEntry("entry-1".getBytes());
+        } catch (ManagedLedgerTerminatedException e) {
+            // Expected
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void terminateReopen() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+
+        Position p0 = ledger.addEntry("entry-0".getBytes());
+
+        Position lastPosition = ledger.terminate();
+
+        assertEquals(lastPosition, p0);
+
+        ledger.close();
+
+        ledger = factory.open("my_test_ledger");
+
+        try {
+            ledger.addEntry("entry-1".getBytes());
+            fail("Should have thrown exception");
+        } catch (ManagedLedgerTerminatedException e) {
+            // Expected
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void terminateWithCursor() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+        ManagedCursor c1 = ledger.openCursor("c1");
+
+        Position p0 = ledger.addEntry("entry-0".getBytes());
+        Position p1 = ledger.addEntry("entry-1".getBytes());
+
+        List<Entry> entries = c1.readEntries(1);
+        assertEquals(entries.size(), 1);
+        assertEquals(entries.get(0).getPosition(), p0);
+        entries.forEach(Entry::release);
+
+        Position lastPosition = ledger.terminate();
+        assertEquals(lastPosition, p1);
+
+        // Cursor can keep reading
+        entries = c1.readEntries(1);
+        assertEquals(entries.size(), 1);
+        assertEquals(entries.get(0).getPosition(), p1);
+        entries.forEach(Entry::release);
+    }
+
+    @Test(timeOut = 20000)
+    public void terminateWithCursorReadOrWait() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+        ManagedCursor c1 = ledger.openCursor("c1");
+
+        Position p0 = ledger.addEntry("entry-0".getBytes());
+        Position p1 = ledger.addEntry("entry-1".getBytes());
+        assertEquals(ledger.isTerminated(), false);
+
+        Position lastPosition = ledger.terminate();
+        assertEquals(ledger.isTerminated(), true);
+        assertEquals(lastPosition, p1);
+
+        List<Entry> entries = c1.readEntries(10);
+        assertEquals(entries.size(), 2);
+        assertEquals(entries.get(0).getPosition(), p0);
+        assertEquals(entries.get(1).getPosition(), p1);
+        entries.forEach(Entry::release);
+
+        // Normal read will just return no entries
+        assertEquals(c1.readEntries(10), Collections.emptyList());
+
+        // Read or wait will fail
+        try {
+            c1.readEntriesOrWait(10);
+            fail("Should have thrown exception");
+        } catch (NoMoreEntriesToReadException e) {
+            // Expected
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void terminateWithNonDurableCursor() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+
+        Position p0 = ledger.addEntry("entry-0".getBytes());
+        Position p1 = ledger.addEntry("entry-1".getBytes());
+        assertEquals(ledger.isTerminated(), false);
+
+        Position lastPosition = ledger.terminate();
+        assertEquals(ledger.isTerminated(), true);
+        assertEquals(lastPosition, p1);
+
+        ManagedCursor c1 = ledger.newNonDurableCursor(PositionImpl.earliest);
+
+        List<Entry> entries = c1.readEntries(10);
+        assertEquals(entries.size(), 2);
+        assertEquals(entries.get(0).getPosition(), p0);
+        assertEquals(entries.get(1).getPosition(), p1);
+        entries.forEach(Entry::release);
+
+        // Normal read will just return no entries
+        assertEquals(c1.readEntries(10), Collections.emptyList());
+
+        // Read or wait will fail
+        try {
+            c1.readEntriesOrWait(10);
+            fail("Should have thrown exception");
+        } catch (NoMoreEntriesToReadException e) {
+            // Expected
+        }
+    }
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/BrokerServiceException.java
@@ -50,6 +50,16 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TopicTerminatedException extends BrokerServiceException {
+        public TopicTerminatedException(String msg) {
+            super(msg);
+        }
+
+        public TopicTerminatedException(Throwable t) {
+            super(t);
+        }
+    }
+
     public static class ServerMetadataException extends BrokerServiceException {
         public ServerMetadataException(Throwable t) {
             super(t);
@@ -101,7 +111,7 @@ public class BrokerServiceException extends Exception {
             super(msg);
         }
     }
-    
+
     public static class UnsupportedVersionException extends BrokerServiceException {
         public UnsupportedVersionException(String msg) {
             super(msg);
@@ -125,6 +135,8 @@ public class BrokerServiceException extends Exception {
             return PulsarApi.ServerError.UnsupportedVersionError;
         } else if (t instanceof TooManyRequestsException) {
             return PulsarApi.ServerError.TooManyRequests;
+        } else if (t instanceof TopicTerminatedException) {
+            return PulsarApi.ServerError.TopicTerminatedError;
         } else if (t instanceof ServiceUnitNotReadyException || t instanceof TopicFencedException
                 || t instanceof SubscriptionFencedException) {
             return PulsarApi.ServerError.ServiceNotReady;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
@@ -41,7 +41,7 @@ public interface Topic {
 
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId);
-    
+
     CompletableFuture<PersistentSubscription> createSubscription(String subscriptionName);
 
     CompletableFuture<Void> unsubscribe(String subName);
@@ -67,4 +67,6 @@ public interface Topic {
     boolean isBacklogQuotaExceeded(String producerName);
 
     BacklogQuota getBacklogQuota();
+
+    CompletableFuture<MessageId> terminate();
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -34,12 +34,14 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerFencedException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
@@ -58,12 +60,13 @@ import com.yahoo.pulsar.broker.service.BrokerService;
 import com.yahoo.pulsar.broker.service.BrokerServiceException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.NamingException;
-import com.yahoo.pulsar.broker.service.BrokerServiceException.UnsupportedVersionException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.TopicBusyException;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.TopicFencedException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.TopicTerminatedException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.UnsupportedVersionException;
 import com.yahoo.pulsar.broker.service.Consumer;
 import com.yahoo.pulsar.broker.service.Producer;
 import com.yahoo.pulsar.broker.service.ServerCnx;
@@ -117,6 +120,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
     protected static final AtomicLongFieldUpdater<PersistentTopic> USAGE_COUNT_UPDATER =
             AtomicLongFieldUpdater.newUpdater(PersistentTopic.class, "usageCount");
+    @SuppressWarnings("unused")
     private volatile long usageCount = 0;
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -125,14 +129,14 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     public final String replicatorPrefix;
 
     private static final double MESSAGE_EXPIRY_THRESHOLD = 1.5;
-    
+
     private static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
 
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 
     // Timestamp of when this topic was last seen active
     private volatile long lastActive;
-    
+
     // Flag to signal that producer of this topic has published batch-message so, broker should not allow consumer which
     // doesn't support batch-message
     private volatile boolean hasBatchMessagePublished = false;
@@ -212,7 +216,16 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     public void addFailed(ManagedLedgerException exception, Object ctx) {
         PublishCallback callback = (PublishCallback) ctx;
         log.error("[{}] Failed to persist msg in store: {}", topic, exception.getMessage());
-        callback.completed(new PersistenceException(exception), -1, -1);
+
+        if (exception instanceof ManagedLedgerTerminatedException) {
+            // Signal the producer that this topic is no longer available
+            callback.completed(new TopicTerminatedException(exception), -1, -1);
+        } else {
+            // Use generic persistence exception
+            callback.completed(new PersistenceException(exception), -1, -1);
+        }
+
+
 
         if (exception instanceof ManagedLedgerFencedException) {
             // If the managed ledger has been fenced, we cannot continue using it. We need to close and reopen
@@ -229,6 +242,11 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             if (isFenced) {
                 log.warn("[{}] Attempting to add producer to a fenced topic", topic);
                 throw new TopicFencedException("Topic is temporarily unavailable");
+            }
+
+            if (ledger.isTerminated()) {
+                log.warn("[{}] Attempting to add producer to a terminated topic", topic);
+                throw new TopicTerminatedException("Topic was already terminated");
             }
 
             if (log.isDebugEnabled()) {
@@ -649,7 +667,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         });
         return result;
     }
-    
+
     @Override
     public CompletableFuture<Void> checkReplication() {
         DestinationName name = DestinationName.get(topic);
@@ -950,7 +968,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                     destStatsStream.writePair("msgRateOut", consumerStats.msgRateOut);
                     destStatsStream.writePair("msgThroughputOut", consumerStats.msgThroughputOut);
                     destStatsStream.writePair("msgRateRedeliver", consumerStats.msgRateRedeliver);
-                    
+
                     if (SubType.Shared.equals(subscription.getType())) {
                         destStatsStream.writePair("unackedMessages", consumerStats.unackedMessages);
                         destStatsStream.writePair("blockedConsumerOnUnackedMsgs",
@@ -978,7 +996,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                         destStatsStream.writePair("blockedSubscriptionOnUnackedMsgs",  dispatcher.isBlockedDispatcherOnUnackedMsgs());
                         destStatsStream.writePair("unackedMessages", dispatcher.getTotalUnackedMessages());
                     }
-                    
+
                 }
 
 
@@ -1239,6 +1257,31 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return false;
     }
 
+    @Override
+    public CompletableFuture<MessageId> terminate() {
+        CompletableFuture<MessageId> future = new CompletableFuture<>();
+        ledger.asyncTerminate(new TerminateCallback() {
+            @Override
+            public void terminateComplete(Position lastCommittedPosition, Object ctx) {
+                producers.forEach(Producer::disconnect);
+                subscriptions.forEach((name, sub) -> sub.topicTerminated());
+
+                PositionImpl lastPosition = (PositionImpl) lastCommittedPosition;
+                MessageId messageId = new MessageIdImpl(lastPosition.getLedgerId(), lastPosition.getEntryId(), -1);
+
+                log.info("[{}] Topic terminated at {}", getName(), messageId);
+                future.complete(messageId);
+            }
+
+            @Override
+            public void terminateFailed(ManagedLedgerException exception, Object ctx) {
+                future.completeExceptionally(exception);
+            }
+        }, null);
+
+        return future;
+    }
+
     public boolean isOldestMessageExpired(ManagedCursor cursor, long messageTTLInSeconds) {
         MessageImpl msg = null;
         Entry entry = null;
@@ -1307,6 +1350,6 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     public void markBatchMessagePublished() {
         this.hasBatchMessagePublished = true;
     }
-    
+
     private static final Logger log = LoggerFactory.getLogger(PersistentTopic.class);
 }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/TopicTerminationTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/TopicTerminationTest.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.yahoo.pulsar.client.admin.PulsarAdminException.NotAllowedException;
+import com.yahoo.pulsar.client.api.Consumer;
+import com.yahoo.pulsar.client.api.ConsumerConfiguration;
+import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.api.MessageId;
+import com.yahoo.pulsar.client.api.MessageListener;
+import com.yahoo.pulsar.client.api.Producer;
+import com.yahoo.pulsar.client.api.PulsarClientException;
+import com.yahoo.pulsar.client.api.Reader;
+import com.yahoo.pulsar.client.api.ReaderConfiguration;
+import com.yahoo.pulsar.client.api.ReaderListener;
+import com.yahoo.pulsar.client.util.FutureUtil;
+
+@Test
+public class TopicTerminationTest extends BrokerTestBase {
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    private final String topicName = "persistent://prop/use/ns-abc/topic0";
+
+    @Test
+    public void testSimpleTermination() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        /* MessageId msgId1 = */producer.send("test-msg-1".getBytes());
+        /* MessageId msgId2 = */producer.send("test-msg-2".getBytes());
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        try {
+            producer.send("test-msg-4".getBytes());
+            fail("Should have thrown exception");
+        } catch (PulsarClientException.TopicTerminatedException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testCreateProducerOnTerminatedTopic() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        /* MessageId msgId1 = */producer.send("test-msg-1".getBytes());
+        /* MessageId msgId2 = */producer.send("test-msg-2".getBytes());
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        try {
+            pulsarClient.createProducer(topicName);
+            fail("Should have thrown exception");
+        } catch (PulsarClientException.TopicTerminatedException e) {
+            // Expected
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void testTerminateWhilePublishing() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>();
+        Thread t = new Thread(() -> {
+            try {
+                barrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                ///
+            }
+
+            for (int i = 0; i < 1000; i++) {
+                futures.add(producer.sendAsync("test".getBytes()));
+            }
+        });
+        t.start();
+
+        barrier.await();
+
+        admin.persistentTopics().terminateTopicAsync(topicName).get();
+
+        t.join();
+
+        // Ensure all futures are done. Also, once a future is failed, everything
+        // else after that should have failed
+        boolean alreadyFailed = false;
+
+        try {
+            FutureUtil.waitForAll(futures).get();
+        } catch (Exception e) {
+            // Ignore for now, check is below
+        }
+
+        for (int i = 0; i < 1000; i++) {
+            assertTrue(futures.get(i).isDone());
+            if (alreadyFailed) {
+                assertTrue(futures.get(i).isCompletedExceptionally());
+            }
+
+            alreadyFailed = futures.get(i).isCompletedExceptionally();
+        }
+    }
+
+    @Test
+    public void testDoubleTerminate() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        /* MessageId msgId1 = */producer.send("test-msg-1".getBytes());
+        /* MessageId msgId2 = */producer.send("test-msg-2".getBytes());
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        // Terminate it again
+        lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+    }
+
+    @Test
+    public void testTerminatePartitionedTopic() throws Exception {
+        admin.persistentTopics().createPartitionedTopic(topicName, 4);
+
+        try {
+            admin.persistentTopics().terminateTopicAsync(topicName).get();
+            fail("Should have failed");
+        } catch (ExecutionException ee) {
+            assertEquals(ee.getCause().getClass(), NotAllowedException.class);
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void testSimpleTerminationConsumer() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+        com.yahoo.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+
+        MessageId msgId1 = producer.send("test-msg-1".getBytes());
+        MessageId msgId2 = producer.send("test-msg-2".getBytes());
+
+        Message msg1 = consumer.receive();
+        assertEquals(msg1.getMessageId(), msgId1);
+        consumer.acknowledge(msg1);
+
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        assertFalse(consumer.hasReachedEndOfTopic());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        Message msg2 = consumer.receive();
+        assertEquals(msg2.getMessageId(), msgId2);
+        consumer.acknowledge(msg2);
+
+        Message msg3 = consumer.receive();
+        assertEquals(msg3.getMessageId(), msgId3);
+        consumer.acknowledge(msg3);
+
+        Message msg4 = consumer.receive(100, TimeUnit.MILLISECONDS);
+        assertNull(msg4);
+
+        Thread.sleep(100);
+        assertTrue(consumer.hasReachedEndOfTopic());
+    }
+
+    @SuppressWarnings("serial")
+    @Test(timeOut = 20000)
+    public void testSimpleTerminationMessageListener() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setMessageListener(new MessageListener() {
+
+            @Override
+            public void received(Consumer consumer, Message msg) {
+                // do nothing
+            }
+
+            @Override
+            public void reachedEndOfTopic(Consumer consumer) {
+                latch.countDown();
+                assertTrue(consumer.hasReachedEndOfTopic());
+            }
+        });
+        com.yahoo.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-sub", conf);
+
+        /* MessageId msgId1 = */ producer.send("test-msg-1".getBytes());
+        /* MessageId msgId2 = */ producer.send("test-msg-2".getBytes());
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        consumer.acknowledgeCumulative(msgId3);
+
+        Thread.sleep(100);
+        assertFalse(consumer.hasReachedEndOfTopic());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        assertTrue(consumer.hasReachedEndOfTopic());
+    }
+
+    @Test(timeOut = 20000)
+    public void testSimpleTerminationReader() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        MessageId msgId1 = producer.send("test-msg-1".getBytes());
+        MessageId msgId2 = producer.send("test-msg-2".getBytes());
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        Reader reader = pulsarClient.createReader(topicName, MessageId.earliest, new ReaderConfiguration());
+
+        Message msg1 = reader.readNext();
+        assertEquals(msg1.getMessageId(), msgId1);
+
+        Message msg2 = reader.readNext();
+        assertEquals(msg2.getMessageId(), msgId2);
+
+        Message msg3 = reader.readNext();
+        assertEquals(msg3.getMessageId(), msgId3);
+
+        Message msg4 = reader.readNext(100, TimeUnit.MILLISECONDS);
+        assertNull(msg4);
+
+        Thread.sleep(100);
+        assertTrue(reader.hasReachedEndOfTopic());
+    }
+
+    @SuppressWarnings("serial")
+    @Test(timeOut = 20000)
+    public void testSimpleTerminationReaderListener() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ReaderConfiguration conf = new ReaderConfiguration();
+        conf.setReaderListener(new ReaderListener() {
+
+            @Override
+            public void received(Reader r, Message msg) {
+                // do nothing
+            }
+
+            @Override
+            public void reachedEndOfTopic(Reader reader) {
+                latch.countDown();
+                assertTrue(reader.hasReachedEndOfTopic());
+            }
+        });
+        Reader reader = pulsarClient.createReader(topicName, MessageId.latest, conf);
+
+        /* MessageId msgId1 = */ producer.send("test-msg-1".getBytes());
+        /* MessageId msgId2 = */ producer.send("test-msg-2".getBytes());
+        MessageId msgId3 = producer.send("test-msg-3".getBytes());
+
+        Thread.sleep(100);
+        assertFalse(reader.hasReachedEndOfTopic());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId3);
+
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        assertTrue(reader.hasReachedEndOfTopic());
+    }
+
+    @Test(timeOut = 20000)
+    public void testSubscribeOnTerminatedTopic() throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+        /* MessageId msgId1 = */ producer.send("test-msg-1".getBytes());
+        MessageId msgId2 = producer.send("test-msg-2".getBytes());
+
+        MessageId lastMessageId = admin.persistentTopics().terminateTopicAsync(topicName).get();
+        assertEquals(lastMessageId, msgId2);
+
+        com.yahoo.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+
+        Thread.sleep(200);
+        assertTrue(consumer.hasReachedEndOfTopic());
+    }
+
+    @Test(timeOut = 20000)
+    public void testSubscribeOnTerminatedTopicWithNoMessages() throws Exception {
+        pulsarClient.createProducer(topicName);
+        admin.persistentTopics().terminateTopicAsync(topicName).get();
+
+        com.yahoo.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+
+        Thread.sleep(200);
+        assertTrue(consumer.hasReachedEndOfTopic());
+    }
+}

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PersistentTopics.java
@@ -29,6 +29,7 @@ import com.yahoo.pulsar.client.admin.PulsarAdminException.NotAuthorizedException
 import com.yahoo.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.api.MessageId;
 import com.yahoo.pulsar.common.partition.PartitionedTopicMetadata;
 import com.yahoo.pulsar.common.policies.data.AuthAction;
 import com.yahoo.pulsar.common.policies.data.PartitionedTopicStats;
@@ -307,6 +308,17 @@ public interface PersistentTopics {
      * @return a future that can be used to track when the topic is deleted
      */
     CompletableFuture<Void> deleteAsync(String destination);
+
+    /**
+     * Terminate the topic and prevent any more messages being published on it.
+     * <p>
+     * This
+     *
+     * @param destination
+     *            Destination name
+     * @return the message id of the last message that was published in the topic
+     */
+    CompletableFuture<MessageId> terminateTopicAsync(String destination);
 
     /**
      * Get the list of subscriptions.
@@ -673,7 +685,7 @@ public interface PersistentTopics {
 
     /**
      * Expire all messages older than given N (expireTimeInSeconds) seconds for a given subscription
-     * 
+     *
      * @param destination
      *            Destination name
      * @param subName
@@ -684,10 +696,10 @@ public interface PersistentTopics {
      *             Unexpected error
      */
     public void expireMessages(String destination, String subscriptionName, long expireTimeInSeconds) throws PulsarAdminException;
-    
+
     /**
      * Expire all messages older than given N (expireTimeInSeconds) seconds for a given subscription asynchronously
-     * 
+     *
      * @param destination
      *            Destination name
      * @param subName
@@ -701,7 +713,7 @@ public interface PersistentTopics {
     /**
      * Expire all messages older than given N (expireTimeInSeconds) seconds for all subscriptions of the
      * persistent-topic
-     * 
+     *
      * @param destination
      *            Destination name
      * @param expireTimeInSeconds
@@ -710,19 +722,19 @@ public interface PersistentTopics {
      *             Unexpected error
      */
     public void expireMessagesForAllSubscriptions(String destination, long expireTimeInSeconds) throws PulsarAdminException;
-    
+
 
     /**
      * Expire all messages older than given N (expireTimeInSeconds) seconds for all subscriptions of the
      * persistent-topic asynchronously
-     * 
+     *
      * @param destination
      *            Destination name
      * @param expireTimeInSeconds
      *            Expire messages older than time in seconds
      */
     public CompletableFuture<Void> expireMessagesForAllSubscriptionsAsync(String destination, long expireTimeInSeconds);
-    
+
     /**
      * Peek messages from a topic subscription
      *

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/PersistentTopicsImpl.java
@@ -37,6 +37,9 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -46,6 +49,8 @@ import com.yahoo.pulsar.client.admin.PulsarAdminException;
 import com.yahoo.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import com.yahoo.pulsar.client.api.Authentication;
 import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.api.MessageId;
+import com.yahoo.pulsar.client.impl.MessageIdImpl;
 import com.yahoo.pulsar.client.impl.MessageImpl;
 import com.yahoo.pulsar.common.naming.DestinationName;
 import com.yahoo.pulsar.common.naming.NamespaceName;
@@ -453,7 +458,7 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
             throw new PulsarAdminException(e.getCause());
         }
     }
-    
+
     @Override
     public CompletableFuture<Void> skipMessagesAsync(String destination, String subName, long numMessages) {
         DestinationName ds = validateTopic(destination);
@@ -463,7 +468,7 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
                         .path(encodedSubName).path("skip").path(String.valueOf(numMessages)),
                 Entity.entity("", MediaType.APPLICATION_JSON));
     }
-    
+
     @Override
     public void expireMessages(String destination, String subName, long expireTimeInSeconds) throws PulsarAdminException {
         try {
@@ -475,7 +480,7 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
             throw new PulsarAdminException(e.getCause());
         }
     }
-    
+
     @Override
     public CompletableFuture<Void> expireMessagesAsync(String destination, String subName, long expireTimeInSeconds) {
         DestinationName ds = validateTopic(destination);
@@ -485,7 +490,7 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
                         .path(encodedSubName).path("expireMessages").path(String.valueOf(expireTimeInSeconds)),
                 Entity.entity("", MediaType.APPLICATION_JSON));
     }
-    
+
     @Override
     public void expireMessagesForAllSubscriptions(String destination, long expireTimeInSeconds) throws PulsarAdminException {
         try {
@@ -497,7 +502,7 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
             throw new PulsarAdminException(e.getCause());
         }
     }
-    
+
     @Override
     public CompletableFuture<Void> expireMessagesForAllSubscriptionsAsync(String destination, long expireTimeInSeconds) {
         DestinationName ds = validateTopic(destination);
@@ -608,6 +613,37 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
                 Entity.entity("", MediaType.APPLICATION_JSON));
     }
 
+    @Override
+    public CompletableFuture<MessageId> terminateTopicAsync(String destination) {
+        DestinationName ds = validateTopic(destination);
+
+        final CompletableFuture<MessageId> future = new CompletableFuture<>();
+        try {
+            WebTarget target = persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName())
+                    .path("terminate");
+
+            request(target).async().post(Entity.entity("", MediaType.APPLICATION_JSON),
+                    new InvocationCallback<MessageIdImpl>() {
+
+                        @Override
+                        public void completed(MessageIdImpl messageId) {
+                            future.complete(messageId);
+                        }
+
+                        @Override
+                        public void failed(Throwable throwable) {
+                            log.warn("[{}] Failed to perform http post request: {}", target.getUri(),
+                                    throwable.getMessage());
+                            future.completeExceptionally(getApiException(throwable.getCause()));
+                        }
+                    });
+        } catch (PulsarAdminException cae) {
+            future.completeExceptionally(cae);
+        }
+
+        return future;
+    }
+
     /*
      * returns destination name with encoded Local Name
      */
@@ -656,4 +692,6 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
             }
         }
     }
+
+    private static final Logger log = LoggerFactory.getLogger(PersistentTopicsImpl.class);
 }

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdPersistentTopics.java
@@ -16,6 +16,7 @@
 package com.yahoo.pulsar.admin.cli;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import com.beust.jcommander.Parameter;
@@ -28,6 +29,7 @@ import com.yahoo.pulsar.client.admin.PersistentTopics;
 import com.yahoo.pulsar.client.admin.PulsarAdmin;
 import com.yahoo.pulsar.client.admin.PulsarAdminException;
 import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.api.MessageId;
 import com.yahoo.pulsar.client.impl.MessageIdImpl;
 
 import io.netty.buffer.ByteBuf;
@@ -65,6 +67,7 @@ public class CmdPersistentTopics extends CmdBase {
         jcommander.addCommand("delete-partitioned-topic", new DeletePartitionedCmd());
         jcommander.addCommand("peek-messages", new PeekMessages());
         jcommander.addCommand("reset-cursor", new ResetCursor());
+        jcommander.addCommand("terminate", new Terminate());
     }
 
     @Parameters(commandDescription = "Get the list of destinations under a namespace.")
@@ -347,7 +350,7 @@ public class CmdPersistentTopics extends CmdBase {
             persistentTopics.skipMessages(persistentTopic, subName, numMessages);
         }
     }
-    
+
     @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for the subscription")
     private class ExpireMessages extends CliCommand {
         @Parameter(description = "persistent://property/cluster/namespace/destination", required = true)
@@ -366,7 +369,7 @@ public class CmdPersistentTopics extends CmdBase {
             persistentTopics.expireMessages(persistentTopic, subName, expireTimeInSeconds);
         }
     }
-    
+
     @Parameters(commandDescription = "Expire messages that older than given expiry time (in seconds) for all subscriptions")
     private class ExpireMessagesForAllSubscriptions extends CliCommand {
         @Parameter(description = "persistent://property/cluster/namespace/destination", required = true)
@@ -403,6 +406,24 @@ public class CmdPersistentTopics extends CmdBase {
             // now - go back time
             long timestamp = System.currentTimeMillis() - resetTimeInMillis;
             persistentTopics.resetCursor(persistentTopic, subName, timestamp);
+        }
+    }
+
+    @Parameters(commandDescription = "Terminate a topic and don't allow any more messages to be published")
+    private class Terminate extends CliCommand {
+        @Parameter(description = "persistent://property/cluster/namespace/destination", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+
+            try {
+                MessageId lastMessageId = persistentTopics.terminateTopicAsync(persistentTopic).get();
+                System.out.println("Topic succesfully terminated at " + lastMessageId);
+            } catch (InterruptedException | ExecutionException e) {
+                throw new PulsarAdminException(e);
+            }
         }
     }
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/Consumer.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/Consumer.java
@@ -80,7 +80,7 @@ public interface Consumer extends Closeable {
      * {@code receiveAsync()} should be called subsequently once returned {@code CompletableFuture} gets complete with
      * received message. Else it creates <i> backlog of receive requests </i> in the application.
      * </p>
-     * 
+     *
      * @return {@link CompletableFuture}<{@link Message}> will be completed when message is available
      */
     CompletableFuture<Message> receiveAsync();
@@ -199,14 +199,14 @@ public interface Consumer extends Closeable {
 
     /**
      * Get statistics for the consumer
-     * 
+     *
      * numMsgsReceived : Number of messages received in the current interval numBytesReceived : Number of bytes received
      * in the current interval numReceiveFailed : Number of messages failed to receive in the current interval
      * numAcksSent : Number of acks sent in the current interval numAcksFailed : Number of acks failed to send in the
      * current interval totalMsgsReceived : Total number of messages received totalBytesReceived : Total number of bytes
      * received totalReceiveFailed : Total number of messages failed to receive totalAcksSent : Total number of acks
      * sent totalAcksFailed : Total number of acks failed to sent
-     * 
+     *
      * @return statistic for the consumer or null if ConsumerStats is disabled.
      */
     ConsumerStats getStats();
@@ -223,6 +223,11 @@ public interface Consumer extends Closeable {
      * @return a future that can be used to track the completion of the operation
      */
     CompletableFuture<Void> closeAsync();
+
+    /**
+     * Return true if the topic was terminated and this consumer has already consumed all the messages in the topic.
+     */
+    boolean hasReachedEndOfTopic();
 
     /**
      * Redelivers all the unacknowledged messages. In Failover mode, the request is ignored if the consumer is not

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/MessageListener.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/MessageListener.java
@@ -25,17 +25,27 @@ import java.io.Serializable;
 public interface MessageListener extends Serializable {
     /**
      * This method is called whenever a new message is received.
-     * 
+     *
      * Messages are guaranteed to be delivered in order and from the same thread for a single consumer
-     * 
+     *
      * This method will only be called once for each message, unless either application or broker crashes.
-     * 
+     *
      * Application is responsible of handling any exception that could be thrown while processing the message.
-     * 
+     *
      * @param consumer
      *            the consumer that received the message
      * @param msg
      *            the message object
      */
     void received(Consumer consumer, Message msg);
+
+    /**
+     * Get the notification when a topic is terminated
+     *
+     * @param consumer
+     *            the Consumer object associated with the terminated topic
+     */
+    default void reachedEndOfTopic(Consumer consumer) {
+        // By default ignore the notification
+    }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/PulsarClientException.java
@@ -78,6 +78,12 @@ public class PulsarClientException extends IOException {
         }
     }
 
+    public static class TopicTerminatedException extends PulsarClientException {
+        public TopicTerminatedException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class AuthenticationException extends PulsarClientException {
         public AuthenticationException(String msg) {
             super(msg);
@@ -169,7 +175,7 @@ public class PulsarClientException extends IOException {
             super(msg);
         }
     }
-    
+
     public static class ChecksumException extends PulsarClientException {
         public ChecksumException(String msg) {
             super(msg);

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/Reader.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/Reader.java
@@ -54,4 +54,9 @@ public interface Reader extends Closeable {
      * @return a future that can be used to track the completion of the operation
      */
     CompletableFuture<Void> closeAsync();
+
+    /**
+     * Return true if the topic was terminated and this reader has reached the end of the topic
+     */
+    boolean hasReachedEndOfTopic();
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ReaderListener.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ReaderListener.java
@@ -19,8 +19,6 @@ import java.io.Serializable;
 
 /**
  * A listener that will be called in order for every message received.
- *
- *
  */
 public interface ReaderListener extends Serializable {
     /**
@@ -38,4 +36,14 @@ public interface ReaderListener extends Serializable {
      *            the message object
      */
     void received(Reader reader, Message msg);
+
+    /**
+     * Get the notification when a topic is terminated
+     *
+     * @param reader
+     *            the Reader object associated with the terminated topic
+     */
+    default void reachedEndOfTopic(Reader reader) {
+        // By default ignore the notification
+    }
 }

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
@@ -99,6 +99,8 @@ public class ConsumerImpl extends ConsumerBase {
     private final SubscriptionMode subscriptionMode;
     private final MessageId startMessageId;
 
+    private volatile boolean hasReachedEndOfTopic;
+
     static enum SubscriptionMode {
         // Make the subscription to be backed by a durable cursor that will retain messages and persist the current
         // position
@@ -1082,6 +1084,20 @@ public class ConsumerImpl extends ConsumerBase {
             return null;
         }
         return stats;
+    }
+
+    void setTerminated() {
+        log.info("[{}] [{}] [{}] Consumer has reached the end of topic", subscription, topic, consumerName);
+        hasReachedEndOfTopic = true;
+        if (listener != null) {
+            // Propagate notification to listener
+            listener.reachedEndOfTopic(this);
+        }
+    }
+
+    @Override
+    public boolean hasReachedEndOfTopic() {
+        return hasReachedEndOfTopic;
     }
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerImpl.class);

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HandlerBase.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/HandlerBase.java
@@ -29,10 +29,12 @@ abstract class HandlerBase {
     protected final String topic;
     private static final AtomicReferenceFieldUpdater<HandlerBase, State> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(HandlerBase.class, State.class, "state");
+    @SuppressWarnings("unused")
     private volatile State state = null;
 
     private static final AtomicReferenceFieldUpdater<HandlerBase, ClientCnx> CLIENT_CNX_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(HandlerBase.class, ClientCnx.class, "clientCnx");
+    @SuppressWarnings("unused")
     private volatile ClientCnx clientCnx = null;
     protected final Backoff backoff;
 
@@ -42,6 +44,8 @@ abstract class HandlerBase {
         Ready, // Handler is being used
         Closing, // Close cmd has been sent to broker
         Closed, // Broker acked the close
+        Terminated, // Topic associated with this handler
+                    // has been terminated
         Failed // Handler is failed
     };
 
@@ -166,9 +170,11 @@ abstract class HandlerBase {
         case Ready:
             // Ok
             return true;
+
         case Closing:
         case Closed:
         case Failed:
+        case Terminated:
             return false;
         }
         return false;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/MessageIdImpl.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
 import com.google.protobuf.UninitializedMessageException;
 import com.yahoo.pulsar.client.api.MessageId;
@@ -35,6 +34,12 @@ public class MessageIdImpl implements MessageId, Comparable<MessageIdImpl> {
     protected final long ledgerId;
     protected final long entryId;
     protected final int partitionIndex;
+
+    // Private constructor used only for json deserialization
+    @SuppressWarnings("unused")
+    private MessageIdImpl() {
+        this(-1, -1, -1);
+    }
 
     public MessageIdImpl(long ledgerId, long entryId, int partitionIndex) {
         this.ledgerId = ledgerId;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -128,7 +128,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
             if (incomingMessages.size() >= maxReceiverQueueSize
                     || (incomingMessages.size() > sharedQueueResumeThreshold && !pausedConsumers.isEmpty())) {
-                // mark this consumer to be resumed later: if No more space left in shared queue, 
+                // mark this consumer to be resumed later: if No more space left in shared queue,
                 // or if any consumer is already paused (to create fair chance for already paused consumers)
                 pausedConsumers.add(consumer);
             } else {
@@ -429,6 +429,11 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     @Override
     public int getAvailablePermits() {
         return consumers.stream().mapToInt(ConsumerImpl::getAvailablePermits).sum();
+    }
+
+    @Override
+    public boolean hasReachedEndOfTopic() {
+        return consumers.stream().allMatch(Consumer::hasReachedEndOfTopic);
     }
 
     @Override

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerStats.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerStats.java
@@ -244,5 +244,12 @@ public class ProducerStats implements Serializable {
         return totalAcksReceived.longValue();
     }
 
+    public void cancelStatsTimeout() {
+        if (statTimeout != null) {
+            statTimeout.cancel();
+            statTimeout = null;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(ProducerStats.class);
 }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/Commands.java
@@ -21,7 +21,7 @@ import java.util.List;
 import com.google.protobuf.ByteString;
 import static com.yahoo.pulsar.checksum.utils.Crc32cChecksum.computeChecksum;
 import static com.yahoo.pulsar.checksum.utils.Crc32cChecksum.resumeChecksum;
-    
+
 import com.yahoo.pulsar.common.api.proto.PulsarApi;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.AuthMethod;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.BaseCommand;
@@ -46,6 +46,7 @@ import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandPing;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandPong;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandProducer;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSend;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSendError;
@@ -73,10 +74,10 @@ import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
 public class Commands {
-    
+
     public static final short magicCrc32c = 0x0e01;
     private static final int checksumSize = 4;
-    
+
     public static ByteBuf newConnect(String authMethodName, String authData, String libVersion) {
         return newConnect(authMethodName, authData, getCurrentProtocolVersion(), libVersion);
     }
@@ -85,7 +86,7 @@ public class Commands {
         CommandConnect.Builder connectBuilder = CommandConnect.newBuilder();
         connectBuilder.setClientVersion(libVersion != null ? libVersion : "Pulsar Client");
         connectBuilder.setAuthMethodName(authMethodName);
-        
+
         if ("ycav1".equals(authMethodName)) {
             // Handle the case of a client that gets updated before the broker and starts sending the string auth method
             // name. An example would be in broker-to-broker replication. We need to make sure the clients are still
@@ -200,10 +201,6 @@ public class Commands {
         return res;
     }
 
-    public static ByteBuf newSendError(long producerId, long sequenceId, Throwable t) {
-        return newSendError(producerId, sequenceId, ServerError.PersistenceError, t.getMessage());
-    }
-
     public static ByteBuf newSendError(long producerId, long sequenceId, ServerError error, String errorMsg) {
         CommandSendError.Builder sendErrorBuilder = CommandSendError.newBuilder();
         sendErrorBuilder.setProducerId(producerId);
@@ -216,12 +213,12 @@ public class Commands {
         sendError.recycle();
         return res;
     }
-    
+
 
     public static boolean hasChecksum(ByteBuf buffer) {
         return buffer.getShort(buffer.readerIndex()) == magicCrc32c;
     }
-    
+
     public static Long readChecksum(ByteBuf buffer) {
         if(hasChecksum(buffer)) {
             buffer.skipBytes(2); //skip magic bytes
@@ -284,7 +281,7 @@ public class Commands {
         sendBuilder.recycle();
         return res;
     }
-    
+
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
             SubType subType, int priorityLevel, String consumerName) {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
@@ -335,6 +332,17 @@ public class Commands {
         return res;
     }
 
+    public static ByteBuf newReachedEndOfTopic(long consumerId) {
+        CommandReachedEndOfTopic.Builder reachedEndOfTopicBuilder = CommandReachedEndOfTopic.newBuilder();
+        reachedEndOfTopicBuilder.setConsumerId(consumerId);
+        CommandReachedEndOfTopic reachedEndOfTopic = reachedEndOfTopicBuilder.build();
+        ByteBuf res = serializeWithSize(
+                BaseCommand.newBuilder().setType(Type.REACHED_END_OF_TOPIC).setReachedEndOfTopic(reachedEndOfTopic));
+        reachedEndOfTopicBuilder.recycle();
+        reachedEndOfTopic.recycle();
+        return res;
+    }
+
     public static ByteBuf newCloseProducer(long producerId, long requestId) {
         CommandCloseProducer.Builder closeProducerBuilder = CommandCloseProducer.newBuilder();
         closeProducerBuilder.setProducerId(producerId);
@@ -380,7 +388,7 @@ public class Commands {
         partitionMetadataResponse.recycle();
         return res;
     }
-    
+
     public static ByteBuf newPartitionMetadataRequest(String topic, long requestId) {
         CommandPartitionedTopicMetadata.Builder partitionMetadataBuilder = CommandPartitionedTopicMetadata.newBuilder();
         partitionMetadataBuilder.setTopic(topic);
@@ -408,7 +416,7 @@ public class Commands {
         partitionMetadataResponse.recycle();
         return res;
     }
-    
+
     public static ByteBuf newLookup(String topic, boolean authoritative, long requestId) {
         CommandLookupTopic.Builder lookupTopicBuilder = CommandLookupTopic.newBuilder();
         lookupTopicBuilder.setTopic(topic);
@@ -421,14 +429,14 @@ public class Commands {
         lookupBroker.recycle();
         return res;
     }
-    
-    
+
+
     public static ByteBuf newLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
             LookupType response, long requestId) {
         CommandLookupTopicResponse.Builder connectionBuilder = CommandLookupTopicResponse.newBuilder();
         connectionBuilder.setBrokerServiceUrl(brokerServiceUrl);
         if (brokerServiceUrlTls != null) {
-            connectionBuilder.setBrokerServiceUrlTls(brokerServiceUrlTls);    
+            connectionBuilder.setBrokerServiceUrlTls(brokerServiceUrlTls);
         }
         connectionBuilder.setResponse(response);
         connectionBuilder.setRequestId(requestId);
@@ -441,7 +449,7 @@ public class Commands {
         connectionLookupResponse.recycle();
         return res;
     }
-   
+
     public static ByteBuf newLookupResponse(ServerError error, String errorMsg, long requestId) {
         CommandLookupTopicResponse.Builder connectionBuilder = CommandLookupTopicResponse.newBuilder();
         connectionBuilder.setRequestId(requestId);
@@ -457,7 +465,7 @@ public class Commands {
         connectionBroker.recycle();
         return res;
     }
-    
+
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, AckType ackType,
             ValidationError validationError) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();
@@ -524,7 +532,7 @@ public class Commands {
         commandConsumerStatsResponseBuilder.setRequestId(requestId);
         commandConsumerStatsResponseBuilder.setErrorMessage(errMsg);
         commandConsumerStatsResponseBuilder.setErrorCode(serverError);
-        
+
         CommandConsumerStatsResponse commandConsumerStatsResponse = commandConsumerStatsResponseBuilder.build();
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.CONSUMER_STATS_RESPONSE)
                 .setConsumerStatsResponse(commandConsumerStatsResponseBuilder));
@@ -620,7 +628,7 @@ public class Commands {
         int totalSize = headerContentSize + payloadSize;
         int headersSize = 4 + headerContentSize; // totalSize + headerLength
         int checksumReaderIndex = -1;
-        
+
         ByteBuf headers = PooledByteBufAllocator.DEFAULT.buffer(headersSize, headersSize);
         headers.writeInt(totalSize); // External frame
 
@@ -632,7 +640,7 @@ public class Commands {
             cmd.writeTo(outStream);
             cmd.recycle();
             cmdBuilder.recycle();
-            
+
             //Create checksum placeholder
             if (includeChecksum) {
                 headers.writeShort(magicCrc32c);
@@ -650,7 +658,7 @@ public class Commands {
         }
 
         ByteBuf command = DoubleByteBuf.get(headers, payload);
-        
+
         // write checksum at created checksum-placeholder
         if (includeChecksum) {
             headers.markReaderIndex();

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/PulsarDecoder.java
@@ -39,6 +39,7 @@ import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandPing;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandPong;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandProducer;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSend;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSendError;
@@ -90,7 +91,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 handlePartitionMetadataRequest(cmd.getPartitionMetadata());
                 cmd.getPartitionMetadata().recycle();
                 break;
-                
+
             case PARTITIONED_METADATA_RESPONSE:
                 checkArgument(cmd.hasPartitionMetadataResponse());
                 handlePartitionResponse(cmd.getPartitionMetadataResponse());
@@ -102,13 +103,13 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 handleLookup(cmd.getLookupTopic());
                 cmd.getLookupTopic().recycle();
                 break;
-                
+
             case LOOKUP_RESPONSE:
                 checkArgument(cmd.hasLookupTopicResponse());
                 handleLookupResponse(cmd.getLookupTopicResponse());
                 cmd.getLookupTopicResponse().recycle();
-                break;  
-                
+                break;
+
             case ACK:
                 checkArgument(cmd.hasAck());
                 handleAck(cmd.getAck());
@@ -225,7 +226,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 handleRedeliverUnacknowledged(cmd.getRedeliverUnacknowledgedMessages());
                 cmd.getRedeliverUnacknowledgedMessages().recycle();
                 break;
-                
+
             case CONSUMER_STATS:
                 checkArgument(cmd.hasConsumerStats());
                 handleConsumerStats(cmd.getConsumerStats());
@@ -236,6 +237,12 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 checkArgument(cmd.hasConsumerStatsResponse());
                 handleConsumerStatsResponse(cmd.getConsumerStatsResponse());
                 cmd.getConsumerStatsResponse().recycle();
+                break;
+
+            case REACHED_END_OF_TOPIC:
+                checkArgument(cmd.hasReachedEndOfTopic());
+                handleReachedEndOfTopic(cmd.getReachedEndOfTopic());
+                cmd.getReachedEndOfTopic().recycle();
                 break;
             }
         } finally {
@@ -256,19 +263,19 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     protected void handlePartitionMetadataRequest(CommandPartitionedTopicMetadata response) {
         throw new UnsupportedOperationException();
     }
-    
+
     protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse response) {
         throw new UnsupportedOperationException();
     }
-    
+
     protected void handleLookup(CommandLookupTopic lookup) {
         throw new UnsupportedOperationException();
     }
-    
+
     protected void handleLookupResponse(CommandLookupTopicResponse connection) {
         throw new UnsupportedOperationException();
     }
-    
+
     protected void handleConnect(CommandConnect connect) {
         throw new UnsupportedOperationException();
     }
@@ -348,10 +355,14 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     protected void handleConsumerStats(CommandConsumerStats commandConsumerStats) {
     	throw new UnsupportedOperationException();
     }
-    
+
     protected void handleConsumerStatsResponse(CommandConsumerStatsResponse commandConsumerStatsResponse) {
     	throw new UnsupportedOperationException();
     }
-    
+
+    protected void handleReachedEndOfTopic(CommandReachedEndOfTopic commandReachedEndOfTopic) {
+        throw new UnsupportedOperationException();
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PulsarDecoder.class);
 }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/proto/PulsarApi.java
@@ -69,6 +69,7 @@ public final class PulsarApi {
     SubscriptionNotFound(12, 12),
     ConsumerNotFound(13, 13),
     TooManyRequests(14, 14),
+    TopicTerminatedError(15, 15),
     ;
     
     public static final int UnknownError_VALUE = 0;
@@ -86,6 +87,7 @@ public final class PulsarApi {
     public static final int SubscriptionNotFound_VALUE = 12;
     public static final int ConsumerNotFound_VALUE = 13;
     public static final int TooManyRequests_VALUE = 14;
+    public static final int TopicTerminatedError_VALUE = 15;
     
     
     public final int getNumber() { return value; }
@@ -107,6 +109,7 @@ public final class PulsarApi {
         case 12: return SubscriptionNotFound;
         case 13: return ConsumerNotFound;
         case 14: return TooManyRequests;
+        case 15: return TopicTerminatedError;
         default: return null;
       }
     }
@@ -187,6 +190,7 @@ public final class PulsarApi {
     v6(6, 6),
     v7(7, 7),
     v8(8, 8),
+    v9(9, 9),
     ;
     
     public static final int v0_VALUE = 0;
@@ -198,6 +202,7 @@ public final class PulsarApi {
     public static final int v6_VALUE = 6;
     public static final int v7_VALUE = 7;
     public static final int v8_VALUE = 8;
+    public static final int v9_VALUE = 9;
     
     
     public final int getNumber() { return value; }
@@ -213,6 +218,7 @@ public final class PulsarApi {
         case 6: return v6;
         case 7: return v7;
         case 8: return v8;
+        case 9: return v9;
         default: return null;
       }
     }
@@ -11368,6 +11374,334 @@ public final class PulsarApi {
     // @@protoc_insertion_point(class_scope:pulsar.proto.CommandUnsubscribe)
   }
   
+  public interface CommandReachedEndOfTopicOrBuilder
+      extends com.google.protobuf.MessageLiteOrBuilder {
+    
+    // required uint64 consumer_id = 1;
+    boolean hasConsumerId();
+    long getConsumerId();
+  }
+  public static final class CommandReachedEndOfTopic extends
+      com.google.protobuf.GeneratedMessageLite
+      implements CommandReachedEndOfTopicOrBuilder, com.yahoo.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
+    // Use CommandReachedEndOfTopic.newBuilder() to construct.
+    private io.netty.util.Recycler.Handle handle;
+    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle handle) {
+      this.handle = handle;
+    }
+    
+     private static final io.netty.util.Recycler<CommandReachedEndOfTopic> RECYCLER = new io.netty.util.Recycler<CommandReachedEndOfTopic>() {
+            protected CommandReachedEndOfTopic newObject(Handle handle) {
+              return new CommandReachedEndOfTopic(handle);
+            }
+          };
+        
+        public void recycle() {
+            this.initFields();
+            this.memoizedIsInitialized = -1;
+            this.bitField0_ = 0;
+            this.memoizedSerializedSize = -1;
+            if (handle != null) { RECYCLER.recycle(this, handle); }
+        }
+         
+    private CommandReachedEndOfTopic(boolean noInit) {}
+    
+    private static final CommandReachedEndOfTopic defaultInstance;
+    public static CommandReachedEndOfTopic getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public CommandReachedEndOfTopic getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    private int bitField0_;
+    // required uint64 consumer_id = 1;
+    public static final int CONSUMER_ID_FIELD_NUMBER = 1;
+    private long consumerId_;
+    public boolean hasConsumerId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public long getConsumerId() {
+      return consumerId_;
+    }
+    
+    private void initFields() {
+      consumerId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasConsumerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+        throw new RuntimeException("Cannot use CodedOutputStream");
+    }
+    
+    public void writeTo(com.yahoo.pulsar.common.util.protobuf.ByteBufCodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeUInt64(1, consumerId_);
+      }
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(1, consumerId_);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic, Builder>
+        implements com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopicOrBuilder, com.yahoo.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
+      // Construct using com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.newBuilder()
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
+        this.handle = handle;
+        maybeForceBuilderInitialization();
+      }
+      private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+               return new Builder(handle);
+             }
+            };
+      
+       public void recycle() {
+                clear();
+                if (handle != null) {RECYCLER.recycle(this, handle);}
+            }
+      
+      private void maybeForceBuilderInitialization() {
+      }
+      private static Builder create() {
+        return RECYCLER.get();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        consumerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic getDefaultInstanceForType() {
+        return com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
+      }
+      
+      public com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic build() {
+        com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic buildPartial() {
+        com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic result = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.RECYCLER.get();
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.consumerId_ = consumerId_;
+        result.bitField0_ = to_bitField0_;
+        return result;
+      }
+      
+      public Builder mergeFrom(com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic other) {
+        if (other == com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance()) return this;
+        if (other.hasConsumerId()) {
+          setConsumerId(other.getConsumerId());
+        }
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasConsumerId()) {
+          
+          return false;
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
+                              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                              throws java.io.IOException {
+         throw new java.io.IOException("Merge from CodedInputStream is disabled");
+                              }
+      public Builder mergeFrom(
+          com.yahoo.pulsar.common.util.protobuf.ByteBufCodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              
+              return this;
+            default: {
+              if (!input.skipField(tag)) {
+                
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              consumerId_ = input.readUInt64();
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required uint64 consumer_id = 1;
+      private long consumerId_ ;
+      public boolean hasConsumerId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public long getConsumerId() {
+        return consumerId_;
+      }
+      public Builder setConsumerId(long value) {
+        bitField0_ |= 0x00000001;
+        consumerId_ = value;
+        
+        return this;
+      }
+      public Builder clearConsumerId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        consumerId_ = 0L;
+        
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandReachedEndOfTopic)
+    }
+    
+    static {
+      defaultInstance = new CommandReachedEndOfTopic(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:pulsar.proto.CommandReachedEndOfTopic)
+  }
+  
   public interface CommandCloseProducerOrBuilder
       extends com.google.protobuf.MessageLiteOrBuilder {
     
@@ -16232,6 +16566,10 @@ public final class PulsarApi {
     // optional .pulsar.proto.CommandConsumerStatsResponse consumerStatsResponse = 26;
     boolean hasConsumerStatsResponse();
     com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse getConsumerStatsResponse();
+    
+    // optional .pulsar.proto.CommandReachedEndOfTopic reachedEndOfTopic = 27;
+    boolean hasReachedEndOfTopic();
+    com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic getReachedEndOfTopic();
   }
   public static final class BaseCommand extends
       com.google.protobuf.GeneratedMessageLite
@@ -16294,6 +16632,7 @@ public final class PulsarApi {
       LOOKUP_RESPONSE(22, 24),
       CONSUMER_STATS(23, 25),
       CONSUMER_STATS_RESPONSE(24, 26),
+      REACHED_END_OF_TOPIC(25, 27),
       ;
       
       public static final int CONNECT_VALUE = 2;
@@ -16321,6 +16660,7 @@ public final class PulsarApi {
       public static final int LOOKUP_RESPONSE_VALUE = 24;
       public static final int CONSUMER_STATS_VALUE = 25;
       public static final int CONSUMER_STATS_RESPONSE_VALUE = 26;
+      public static final int REACHED_END_OF_TOPIC_VALUE = 27;
       
       
       public final int getNumber() { return value; }
@@ -16352,6 +16692,7 @@ public final class PulsarApi {
           case 24: return LOOKUP_RESPONSE;
           case 25: return CONSUMER_STATS;
           case 26: return CONSUMER_STATS_RESPONSE;
+          case 27: return REACHED_END_OF_TOPIC;
           default: return null;
         }
       }
@@ -16638,6 +16979,16 @@ public final class PulsarApi {
       return consumerStatsResponse_;
     }
     
+    // optional .pulsar.proto.CommandReachedEndOfTopic reachedEndOfTopic = 27;
+    public static final int REACHEDENDOFTOPIC_FIELD_NUMBER = 27;
+    private com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic reachedEndOfTopic_;
+    public boolean hasReachedEndOfTopic() {
+      return ((bitField0_ & 0x04000000) == 0x04000000);
+    }
+    public com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic getReachedEndOfTopic() {
+      return reachedEndOfTopic_;
+    }
+    
     private void initFields() {
       type_ = com.yahoo.pulsar.common.api.proto.PulsarApi.BaseCommand.Type.CONNECT;
       connect_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConnect.getDefaultInstance();
@@ -16665,6 +17016,7 @@ public final class PulsarApi {
       lookupTopicResponse_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.getDefaultInstance();
       consumerStats_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConsumerStats.getDefaultInstance();
       consumerStatsResponse_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.getDefaultInstance();
+      reachedEndOfTopic_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -16813,6 +17165,12 @@ public final class PulsarApi {
           return false;
         }
       }
+      if (hasReachedEndOfTopic()) {
+        if (!getReachedEndOfTopic().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -16902,6 +17260,9 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x02000000) == 0x02000000)) {
         output.writeMessage(26, consumerStatsResponse_);
+      }
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+        output.writeMessage(27, reachedEndOfTopic_);
       }
     }
     
@@ -17014,6 +17375,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x02000000) == 0x02000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(26, consumerStatsResponse_);
+      }
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(27, reachedEndOfTopic_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -17180,6 +17545,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x01000000);
         consumerStatsResponse_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.getDefaultInstance();
         bitField0_ = (bitField0_ & ~0x02000000);
+        reachedEndOfTopic_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
+        bitField0_ = (bitField0_ & ~0x04000000);
         return this;
       }
       
@@ -17317,6 +17684,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x02000000;
         }
         result.consumerStatsResponse_ = consumerStatsResponse_;
+        if (((from_bitField0_ & 0x04000000) == 0x04000000)) {
+          to_bitField0_ |= 0x04000000;
+        }
+        result.reachedEndOfTopic_ = reachedEndOfTopic_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -17400,6 +17771,9 @@ public final class PulsarApi {
         }
         if (other.hasConsumerStatsResponse()) {
           mergeConsumerStatsResponse(other.getConsumerStatsResponse());
+        }
+        if (other.hasReachedEndOfTopic()) {
+          mergeReachedEndOfTopic(other.getReachedEndOfTopic());
         }
         return this;
       }
@@ -17543,6 +17917,12 @@ public final class PulsarApi {
         }
         if (hasConsumerStatsResponse()) {
           if (!getConsumerStatsResponse().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasReachedEndOfTopic()) {
+          if (!getReachedEndOfTopic().isInitialized()) {
             
             return false;
           }
@@ -17828,6 +18208,16 @@ public final class PulsarApi {
               }
               input.readMessage(subBuilder, extensionRegistry);
               setConsumerStatsResponse(subBuilder.buildPartial());
+              subBuilder.recycle();
+              break;
+            }
+            case 218: {
+              com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.Builder subBuilder = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.newBuilder();
+              if (hasReachedEndOfTopic()) {
+                subBuilder.mergeFrom(getReachedEndOfTopic());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setReachedEndOfTopic(subBuilder.buildPartial());
               subBuilder.recycle();
               break;
             }
@@ -18933,6 +19323,49 @@ public final class PulsarApi {
         consumerStatsResponse_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.getDefaultInstance();
         
         bitField0_ = (bitField0_ & ~0x02000000);
+        return this;
+      }
+      
+      // optional .pulsar.proto.CommandReachedEndOfTopic reachedEndOfTopic = 27;
+      private com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic reachedEndOfTopic_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
+      public boolean hasReachedEndOfTopic() {
+        return ((bitField0_ & 0x04000000) == 0x04000000);
+      }
+      public com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic getReachedEndOfTopic() {
+        return reachedEndOfTopic_;
+      }
+      public Builder setReachedEndOfTopic(com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        reachedEndOfTopic_ = value;
+        
+        bitField0_ |= 0x04000000;
+        return this;
+      }
+      public Builder setReachedEndOfTopic(
+          com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.Builder builderForValue) {
+        reachedEndOfTopic_ = builderForValue.build();
+        
+        bitField0_ |= 0x04000000;
+        return this;
+      }
+      public Builder mergeReachedEndOfTopic(com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic value) {
+        if (((bitField0_ & 0x04000000) == 0x04000000) &&
+            reachedEndOfTopic_ != com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance()) {
+          reachedEndOfTopic_ =
+            com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.newBuilder(reachedEndOfTopic_).mergeFrom(value).buildPartial();
+        } else {
+          reachedEndOfTopic_ = value;
+        }
+        
+        bitField0_ |= 0x04000000;
+        return this;
+      }
+      public Builder clearReachedEndOfTopic() {
+        reachedEndOfTopic_ = com.yahoo.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
+        
+        bitField0_ = (bitField0_ & ~0x04000000);
         return this;
       }
       

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -84,6 +84,7 @@ enum ServerError {
     SubscriptionNotFound = 12; // Subscription not found
     ConsumerNotFound = 13; // Consumer not found
     TooManyRequests = 14; // Error with too many simultaneously request 
+    TopicTerminatedError = 15; // The topic has been terminated
 }
 
 enum AuthMethod {
@@ -104,6 +105,7 @@ enum ProtocolVersion {
 	v6 = 6;  // Added checksum computation for metadata + payload
 	v7 = 7;  // Added CommandLookupTopic - Binary Lookup 
 	v8 = 8;  // Added CommandConsumerStats - Client fetches broker side consumer stats
+	v9 = 9;  // Added end of topic notification
 }
 
 message CommandConnect {
@@ -257,6 +259,13 @@ message CommandUnsubscribe {
 	required uint64 request_id  = 2;
 }
 
+// Message sent by broker to client when a topic
+// has been forcefully terminated and there are no more
+// messages left to consume
+message CommandReachedEndOfTopic {
+	required uint64 consumer_id = 1;
+}
+
 message CommandCloseProducer {
 	required uint64 producer_id = 1;
 	required uint64 request_id = 2;
@@ -385,6 +394,8 @@ message BaseCommand {
 		CONSUMER_STATS		= 25;
 		CONSUMER_STATS_RESPONSE	= 26;
 
+		REACHED_END_OF_TOPIC = 27;
+
 	}
 
 	required Type type = 1;
@@ -421,4 +432,6 @@ message BaseCommand {
 
 	optional CommandConsumerStats consumerStats                         = 25;
 	optional CommandConsumerStatsResponse consumerStatsResponse         = 26;
+
+	optional CommandReachedEndOfTopic reachedEndOfTopic  = 27;
 }


### PR DESCRIPTION
### Motivation

Introduce new "topic termination" feature. 

Through the admin API, a topic can be terminated. Once that happens, no more
messages are allowed to be published on the topic. Application will receive 
`TopicTerminatedException` when publishing or creating producer and can 
react accordingly, if desired.

Consumers will be notified that they reached the end of topic once all the messages
have been acknowledged. Application can check the current consumer status (`Consumer.hasReachedEndOfTopic()`) or get notified through the `MessageListener`.

### Modifications
 
 * Introduced topic termination state in ManagedLedger to persist the information
 * Added admin API for topic termination
 * Extended client library to properly react to topic terminated messages from broker.
