### PR TITLE
Enable PulsarAdmin to trust multiple certificates

### DIFF
--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/SecurityUtility.java
@@ -93,7 +93,9 @@ public class SecurityUtility {
             if (trustCertficates == null || trustCertficates.length == 0) {
                 tmf.init((KeyStore) null);
             } else {
-                ksh.setCertificate("trust", trustCertficates[0]);
+                for (int i = 0; i < trustCertficates.length; i++) {
+                    ksh.setCertificate("trust" + i, trustCertficates[i]);
+                }
                 tmf.init(ksh.getKeyStore());
             }
 


### PR DESCRIPTION
### Motivation

Even when a trusted certificate file includes multiple certificates, PulsarAdmin trusts only the first one.

### Modifications

Modify `SecurityUtility#createSslContext()` to import all certificates loaded from a CRT file.

### Result

We can make PulsarAdmin to trust multiple certificates.
