### PR TITLE
add log and cleanup failed non-durable subscription

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1595,9 +1595,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             PositionImpl newReadPosition = ledger.getNextValidPosition(markDeletePosition);
             PositionImpl oldReadPosition = readPosition;
 
-            if (log.isDebugEnabled()) {
-                log.debug("Rewind from {} to {}", oldReadPosition, newReadPosition);
-            }
+            log.info("[{}] Rewind from {} to {}", name, oldReadPosition, newReadPosition);
 
             readPosition = newReadPosition;
         } finally {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentTopic.java
@@ -446,6 +446,9 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
         if (!subscriptionFuture.isDone()) {
             subscriptionFuture.complete(subscription);
+        } else {
+            // failed to initialize managed-cursor: clean up created subscription
+            subscriptions.remove(subscriptionName);
         }
 
         return subscriptionFuture;


### PR DESCRIPTION
### Motivation

- add info log for cursor rewind because it is a critical operation and it should be logged to debug any bug that lead to rewind cursor.
- clean up subscription for non-durable subscription if cursor init failed while creating subscription

### Modifications

- add rewind info log
- clean up failed subscription

### Result

- NonDurableSubscription should be failed if it failed to initialize managed-cursor.
