### PR TITLE
Changed default maxPendingMessages to 30000

### DIFF
--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -36,7 +36,7 @@ struct ProducerConfigurationImpl {
     ProducerConfigurationImpl()
             : sendTimeoutMs(30000),
               compressionType(CompressionNone),
-              maxPendingMessages(1000),
+              maxPendingMessages(30000),
               routingMode(ProducerConfiguration::UseSinglePartition),
               blockIfQueueFull(true),
               batchingEnabled(false),

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ProducerConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ProducerConfiguration.java
@@ -36,7 +36,7 @@ public class ProducerConfiguration implements Serializable {
      */
     private static final long serialVersionUID = 1L;
     private long sendTimeoutMs = 30000;
-    private int maxPendingMessages = 1000;
+    private int maxPendingMessages = 30000;
     private boolean blockIfQueueFull = true;
     private MessageRoutingMode messageRouteMode = MessageRoutingMode.SinglePartition;
     private MessageRouter customMessageRouter = null;


### PR DESCRIPTION
### Motivation

Fix for #422

### Modifications

Changed default options in CPP and Java Client ProducerConfigurations

### Result

sendAsync doesn't fail before 30K messages

### Do not merge this