### PR TITLE
Fix DoubleByteBuf to send large size messages in TLS mode

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -165,7 +165,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
      * @throws Exception
      */
     @Test
-    public void testAuthemticationFilterNegative() throws Exception {
+    public void testAuthenticationFilterNegative() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
         Map<String, String> authParams = new HashMap<>();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/TlsProducerConsumerTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.client.api;
+
+import static org.mockito.Mockito.spy;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.yahoo.pulsar.client.admin.PulsarAdmin;
+import com.yahoo.pulsar.common.policies.data.ClusterData;
+import com.yahoo.pulsar.common.policies.data.PropertyAdmin;
+
+public class TlsProducerConsumerTest extends ProducerConsumerBase {
+    private static final Logger log = LoggerFactory.getLogger(AuthenticatedProducerConsumerTest.class);
+
+    private final String TLS_TRUST_CERT_FILE_PATH = "./src/test/resources/authentication/tls/cacert.pem";
+    private final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/authentication/tls/broker-cert.pem";
+    private final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/authentication/tls/broker-key.pem";
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+
+        conf.setTlsEnabled(true);
+        conf.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
+        conf.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
+
+        conf.setClusterName("use");
+
+        super.init();
+    }
+
+    protected final void internalSetupForTls() throws Exception {
+
+        com.yahoo.pulsar.client.api.ClientConfiguration clientConf = new com.yahoo.pulsar.client.api.ClientConfiguration();
+        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
+        clientConf.setUseTls(true);
+
+        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        String lookupUrl = new URI("pulsar+ssl://localhost:" + BROKER_PORT_TLS).toString();
+        pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    /**
+     * verifies that messages whose size is larger than 2^14 bytes (max size of single TLS chunk) can be
+     * produced/consumed
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testTlsLargeSizeMessage() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final int MESSAGE_SIZE = 16 * 1024 + 1;
+        log.info("-- message size --", MESSAGE_SIZE);
+
+        internalSetupForTls();
+
+        admin.clusters().createCluster("use", new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(),
+                "pulsar://localhost:" + BROKER_PORT, "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
+        admin.properties().createProperty("my-property",
+                new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
+        admin.namespaces().createNamespace("my-property/use/my-ns");
+
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        for (int i = 0; i < 10; i++) {
+            byte[] message = new byte[MESSAGE_SIZE];
+            Arrays.fill(message, (byte) i);
+            producer.send(message);
+        }
+
+        Message msg = null;
+        for (int i = 0; i < 10; i++) {
+            msg = consumer.receive(5, TimeUnit.SECONDS);
+            byte[] expected = new byte[MESSAGE_SIZE];
+            Arrays.fill(expected, (byte) i);
+            Assert.assertArrayEquals(expected, msg.getData());
+        }
+        // Acknowledge the consumption of all messages at once
+        consumer.acknowledgeCumulative(msg);
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
+    }
+}

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/DoubleByteBuf.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/DoubleByteBuf.java
@@ -135,11 +135,6 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public int readableBytes() {
-        return b1.readableBytes() + b2.readableBytes();
-    }
-
-    @Override
     public int writableBytes() {
         return 0;
     }

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/api/DoubleByteBufTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/api/DoubleByteBufTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.common.api;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+
+public class DoubleByteBufTest {
+
+    /**
+     * Verify that readableBytes() returns writerIndex - readerIndex. In this case writerIndex is the end of the buffer
+     * and readerIndex is increased by 64.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testReadableBytes() throws Exception {
+
+        ByteBuf b1 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
+        b1.writerIndex(b1.capacity());
+        ByteBuf b2 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
+        b2.writerIndex(b2.capacity());
+        ByteBuf buf = DoubleByteBuf.get(b1, b2);
+
+        assertEquals(buf.readerIndex(), 0);
+        assertEquals(buf.writerIndex(), 256);
+        assertEquals(buf.readableBytes(), 256);
+
+        for (int i = 0; i < 4; ++i) {
+            buf.skipBytes(64);
+            assertEquals(buf.readableBytes(), 256 - 64 * (i + 1));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

#### Issue

When TLS is enabled, messages whose size is larger than 2^14(16384) bytes can not be sent by the following error:
```
java.lang.IndexOutOfBoundsException: index: 16384, length: 1000057 (expected: range(0, 1000057))
    at io.netty.buffer.AbstractByteBuf.checkIndex0(AbstractByteBuf.java:1143) ~[netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.buffer.AbstractByteBuf.checkIndex(AbstractByteBuf.java:1138) ~[netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.buffer.AbstractByteBuf.checkDstIndex(AbstractByteBuf.java:1157) ~[netty-all-4.0.40.Final.jar:4.0.40.Final]
    at com.yahoo.pulsar.common.api.DoubleByteBuf.getBytes(DoubleByteBuf.java:206) ~[pulsar-common-1.17.1-SNAPSHOT.jar:na]
    at com.yahoo.pulsar.common.api.DoubleByteBuf.getBytes(DoubleByteBuf.java:60) ~[pulsar-common-1.17.1-SNAPSHOT.jar:na]
    at io.netty.buffer.AbstractByteBuf.getBytes(AbstractByteBuf.java:452) ~[netty-all-4.0.40.Final.jar:4.0.40.Final]
    at com.yahoo.pulsar.common.api.DoubleByteBuf.nioBuffer(DoubleByteBuf.java:333) ~[pulsar-common-1.17.1-SNAPSHOT.jar:na]
    at com.yahoo.pulsar.common.api.DoubleByteBuf.nioBuffers(DoubleByteBuf.java:339) ~[pulsar-common-1.17.1-SNAPSHOT.jar:na]
    at com.yahoo.pulsar.common.api.DoubleByteBuf.nioBuffers(DoubleByteBuf.java:356) ~[pulsar-common-1.17.1-SNAPSHOT.jar:na]
    at io.netty.buffer.WrappedByteBuf.nioBuffers(WrappedByteBuf.java:739) ~[netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.handler.ssl.SslHandler.wrap(SslHandler.java:682) ~[netty-all-4.0.40.Final.jar:na]
    at io.netty.handler.ssl.SslHandler.wrap(SslHandler.java:522) ~[netty-all-4.0.40.Final.jar:na]
    at io.netty.handler.ssl.SslHandler.flush(SslHandler.java:497) ~[netty-all-4.0.40.Final.jar:na]
    at io.netty.channel.AbstractChannelHandlerContext.invokeFlush0(AbstractChannelHandlerContext.java:780) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:806) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:817) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:798) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at com.yahoo.pulsar.client.impl.ProducerImpl$WriteInEventLoopCallback.run(ProducerImpl.java:358) [pulsar-client-1.17.1-SNAPSHOT.jar:na]
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:408) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:309) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:140) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) [netty-all-4.0.40.Final.jar:4.0.40.Final]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_112]
```

#### Cause

[DoubleByteBuf#readableBytes](https://github.com/yahoo/pulsar/blob/master/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/DoubleByteBuf.java#L137-L140) returns wrong value. 

#### Detail

`DoubleByteBuf` has 2 buffers (`b1`, `b2`) internally.
`DoubleByteBuf#readableBytes` returns `b1.readableBytes() + b2.readableBytes()`, where [readableBytes](https://github.com/netty/netty/blob/netty-4.0.40.Final/buffer/src/main/java/io/netty/buffer/ByteBuf.java#L373-L377) is defined as `writerIndex`(default: end of the buffer) - `readerIndex`(default: 0).

However, since `b1.readerIndex` and `b2.readerIndex` are not updated through any methods of `DoubleByteBuf`, it always returns the sum of the length of `b1` and `b2`.

In TLS, messages whose size is larger than 2^14 bytes are divided into several chunks (c.f. 6.2.1.  Fragmentation on https://www.ietf.org/rfc/rfc5246.txt).

When sending the second chunk, `DoubleByteBuf#readerIndex` is 16384 while `DoubleByteBuf#readableBytes` returns the length of buffer, `IndexOutOfBoundsException` occurs in [DoubleByteBuf#nioBuffers](https://github.com/yahoo/pulsar/blob/master/pulsar-common/src/main/java/com/yahoo/pulsar/common/api/DoubleByteBuf.java#L356-L359) which attempts to read the buffer from 16384 to 16384 + length.

### Modifications

* Delete `DoubleByteBuf#readableBytes` in order to use [AbstractByteBuf#readableBytes](https://github.com/netty/netty/blob/netty-4.0.40.Final/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java#L149-L152) instead
* Added `TlsProducerConsumerTest` to verify that messages whose size is larger than 2^14 bytes can be sent.
* Fixed typo in `AuthenticatedProducerConsumerTest`

Note:
In this PR I just deleted `DoubleByteBuf#readableBytes`.
Another approach is to update `b1.readerIndex` and `b2.readerIndex` when `DoubleByteBuf#readerIndex` is updated, but it seems unnecessary for now.
Should we do so?

### Result

Messages whose size is larger than 2^14 bytes can be sent when TLS is enabled.