### PR TITLE
WebSocket proxy should not make a consumer/producer when authorization is failed

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -87,9 +87,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     }
 
     @Override
-    public void onWebSocketConnect(Session session) {
-        super.onWebSocketConnect(session);
-
+    protected void createClient(Session session) {
         try {
             this.consumer = service.getPulsarClient().subscribe(topic, subscription, conf);
             this.service.addConsumer(this);

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -245,8 +245,8 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     }
 
     @Override
-    protected CompletableFuture<Boolean> isAuthorized(String authRole) {
-        return service.getAuthorizationManager().canConsumeAsync(DestinationName.get(topic), authRole);
+    protected Boolean isAuthorized(String authRole) throws Exception {
+        return service.getAuthorizationManager().canConsume(DestinationName.get(topic), authRole);
     }
 
     private static String extractSubscription(HttpServletRequest request) {

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
@@ -88,14 +88,14 @@ public class ProducerHandler extends AbstractWebSocketHandler {
     }
 
     @Override
-    public void onWebSocketConnect(Session session) {
-        super.onWebSocketConnect(session);
-
+    protected void createClient(Session session) {
         try {
             ProducerConfiguration conf = getProducerConfiguration();
             this.producer = service.getPulsarClient().createProducer(topic, conf);
             this.service.addProducer(this);
         } catch (Exception e) {
+            log.warn("[{}] Failed in creating producer on topic {}", session.getRemoteAddress(),
+                    topic, e);
             close(FailedToCreateProducer, e.getMessage());
         }
     }
@@ -176,6 +176,7 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         return MSG_PUBLISHED_COUNTER_UPDATER.get(this);
     }
 
+    @Override
     protected CompletableFuture<Boolean> isAuthorized(String authRole) {
         return service.getAuthorizationManager().canProduceAsync(DestinationName.get(topic), authRole);
     }

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
@@ -177,8 +177,8 @@ public class ProducerHandler extends AbstractWebSocketHandler {
     }
 
     @Override
-    protected CompletableFuture<Boolean> isAuthorized(String authRole) {
-        return service.getAuthorizationManager().canProduceAsync(DestinationName.get(topic), authRole);
+    protected Boolean isAuthorized(String authRole) throws Exception {
+        return service.getAuthorizationManager().canProduce(DestinationName.get(topic), authRole);
     }
 
     private void sendAckResponse(ProducerAck response) {


### PR DESCRIPTION
### Motivation

Now, websocket proxy make an internal consumer/producer by using a super user role even if authorization is failed. (Although websocket connection is closed.)
It causes some problems.

### Modifications

- Changed `isAuthorized()` to synchronized
- Made producer/consumer creation abstract

### Result

Websocket proxy no longer make consumers/producers for unauthorized users.