### PR TITLE
Fix shared reference between the two load reports

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/LocalBrokerData.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/LocalBrokerData.java
@@ -136,11 +136,11 @@ public class LocalBrokerData extends JSONWritable implements ServiceLookupData {
     // Update resource usage given each individual usage.
     private void updateSystemResourceUsage(final ResourceUsage cpu, final ResourceUsage memory,
             final ResourceUsage directMemory, final ResourceUsage bandwidthIn, final ResourceUsage bandwidthOut) {
-        this.cpu = cpu;
-        this.memory = memory;
-        this.directMemory = directMemory;
-        this.bandwidthIn = bandwidthIn;
-        this.bandwidthOut = bandwidthOut;
+        this.cpu = new ResourceUsage(cpu);
+        this.memory = new ResourceUsage(memory);
+        this.directMemory = new ResourceUsage(directMemory);
+        this.bandwidthIn = new ResourceUsage(bandwidthIn);
+        this.bandwidthOut = new ResourceUsage(bandwidthOut);
     }
 
     // Aggregate all message, throughput, topic count, bundle count, consumer

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/loadbalancer/ResourceUsage.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/loadbalancer/ResourceUsage.java
@@ -28,8 +28,12 @@ public class ResourceUsage {
         this.limit = limit;
     }
 
-    public ResourceUsage() {
+    public ResourceUsage(ResourceUsage that) {
+        this.usage = that.usage;
+        this.limit = that.limit;
+    }
 
+    public ResourceUsage() {
     }
 
     public void reset() {


### PR DESCRIPTION
### Motivation

There is a bug which causes the load report to only get written to ZooKeeper once per 15 minutes (or whatever `loadBalancerReportUpdateMaxIntervalMinutes` was set to) when the `ModularLoadManagerImpl` is being used, regardless of any short-term change in the broker's utilization (cpu, memory, etc.).

The problem is with a shared reference with the `ResourceUsage` members between two `LocalBrokerData` objects. One of these objects is intended to reflect the latest load report _written to ZooKeeper_ (which may be 15 minutes old) and the other one is frequently updated with current usage data (it is less than 5 seconds old).

ZooKeeper is only updated when a nontrivial load report item changed (e.g., when system usage changes more than a configurable percentage). However, the shared reference causes both `ResourceUsage` members to get updated so the diff always looks like zero percent and thus the preemptive load report publish to ZooKeeper never happens and we must wait for 15 minutes to get an update.

### Modifications

A deep copy is made whenever the current system usage is calculated, so the longer term usage (in the load report) is not accidentally "overwritten". 

### Result

During a period of rapid load change on a broker, load reports will get published more frequently than once per 15 minutes. This is by design and how the old load manager worked.
