### PR TITLE
pulsar-client should use the log4j.shell.properties conf

### DIFF
--- a/bin/pulsar-client
+++ b/bin/pulsar-client
@@ -19,7 +19,7 @@ BINDIR=$(dirname "$0")
 PULSAR_HOME=`cd $BINDIR/..;pwd`
 
 DEFAULT_CLIENT_CONF=$PULSAR_HOME/conf/client.conf
-DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j.properties
+DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j.shell.properties
 
 if [ -f "$PULSAR_HOME/conf/pulsar_tools_env.sh" ]
 then


### PR DESCRIPTION
### Motivation

All CLI tools should use the `log4j.shell.properties` conf file.