### PR TITLE
Look at the absolute difference in maximum usage percentage.

### DIFF
--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -206,6 +206,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // load placement strategy
     private String loadBalancerPlacementStrategy = "weightedRandomSelection"; // weighted random selection
     // Percentage of change to trigger load report update
+    @FieldContext(dynamic = true)
     private int loadBalancerReportUpdateThresholdPercentage = 10;
     // maximum interval to update load report
     @FieldContext(dynamic = true)

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -208,6 +208,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Percentage of change to trigger load report update
     private int loadBalancerReportUpdateThresholdPercentage = 10;
     // maximum interval to update load report
+    @FieldContext(dynamic = true)
     private int loadBalancerReportUpdateMaxIntervalMinutes = 15;
     // Frequency of report to collect
     private int loadBalancerHostUsageCheckIntervalMinutes = 1;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -322,14 +322,15 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     private boolean needBrokerDataUpdate() {
         final long updateMaxIntervalMillis = TimeUnit.MINUTES
                 .toMillis(conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
-        if (System.currentTimeMillis() - localData.getLastUpdate() > updateMaxIntervalMillis) {
+        long timeSinceLastReportWrittenToZooKeeper = System.currentTimeMillis() - localData.getLastUpdate();
+        if (timeSinceLastReportWrittenToZooKeeper > updateMaxIntervalMillis) {
             log.info("Writing local data to ZooKeeper because time since last update exceeded threshold of {} minutes",
                     conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
             // Always update after surpassing the maximum interval.
             return true;
         }
         final double maxChange = Math
-                .max(percentChange(lastData.getMaxResourceUsage(), localData.getMaxResourceUsage()),
+                .max(100.0 * (Math.abs(lastData.getMaxResourceUsage() - localData.getMaxResourceUsage())),
                         Math.max(percentChange(lastData.getMsgRateIn() + lastData.getMsgRateOut(),
                                 localData.getMsgRateIn() + localData.getMsgRateOut()),
                                 Math.max(
@@ -337,8 +338,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                                                 localData.getMsgThroughputIn() + localData.getMsgThroughputOut()),
                                         percentChange(lastData.getNumBundles(), localData.getNumBundles()))));
         if (maxChange > conf.getLoadBalancerReportUpdateThresholdPercentage()) {
-            log.info("Writing local data to ZooKeeper because maximum change {}% exceeded threshold {}%", maxChange,
-                    conf.getLoadBalancerReportUpdateThresholdPercentage());
+            log.info("Writing local data to ZooKeeper because maximum change {}% exceeded threshold {}%; " +
+                    "time since last report written is {} seconds", maxChange,
+                    conf.getLoadBalancerReportUpdateThresholdPercentage(), timeSinceLastReportWrittenToZooKeeper/1000.0);
             return true;
         }
         return false;


### PR DESCRIPTION


### Motivation

When determining whether to publish a new load report to ZooKeeper, the `usage%` is compared with the `usage%` in ZooKeeper. If the percentage differs by a configurable percentage, the load report is published. Change this comparison to use the _absolute percentage difference_ for `usage%` rather than _percentage of a percentage_.

For example, if `usage%` fluctuates between 10% and 15% and back again, that amounts to a 50%
increase (and 33% decrease) which triggers ZK updates (both times) although the utilization really only changed by 5% which should not be significant enough to update ZooKeeper.

### Modifications

Write a load report to ZooKeeper only when the _absolute_  usage% changes by a configurable amount.

### Result

Load report will not get published when the load fluctuation are small (in absolute) but large (as a percentage).
