### PR TITLE
Avoid taking mutex while calling callback on executor-thread

### DIFF
--- a/managed-ledger/src/test/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/managed-ledger/src/test/java/org/apache/zookeeper/MockZooKeeper.java
@@ -173,24 +173,23 @@ public class MockZooKeeper extends ZooKeeper {
         executor.execute(() -> {
             String parent = path.substring(0, path.lastIndexOf("/"));
 
-            synchronized (MockZooKeeper.this) {
-                if (getProgrammedFailStatus()) {
-                    cb.processResult(failReturnCode.intValue(), path, ctx, null);
-                } else if (stopped) {
-                    cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
-                } else if (tree.containsKey(path)) {
-                    cb.processResult(KeeperException.Code.NODEEXISTS.intValue(), path, ctx, null);
-                } else if (!parent.isEmpty() && !tree.containsKey(parent)) {
-                    cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
-                } else {
-                    tree.put(path, Pair.create(new String(data), 0));
-                    cb.processResult(0, path, ctx, null);
-                    if (!parent.isEmpty()) {
-                        watchers.get(parent).forEach(watcher -> watcher.process(
-                                new WatchedEvent(EventType.NodeChildrenChanged, KeeperState.SyncConnected, parent)));
-                    }
+            if (getProgrammedFailStatus()) {
+                cb.processResult(failReturnCode.intValue(), path, ctx, null);
+            } else if (stopped) {
+                cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
+            } else if (tree.containsKey(path)) {
+                cb.processResult(KeeperException.Code.NODEEXISTS.intValue(), path, ctx, null);
+            } else if (!parent.isEmpty() && !tree.containsKey(parent)) {
+                cb.processResult(KeeperException.Code.NONODE.intValue(), path, ctx, null);
+            } else {
+                tree.put(path, Pair.create(new String(data), 0));
+                cb.processResult(0, path, ctx, null);
+                if (!parent.isEmpty()) {
+                    watchers.get(parent).forEach(watcher -> watcher.process(
+                            new WatchedEvent(EventType.NodeChildrenChanged, KeeperState.SyncConnected, parent)));
                 }
             }
+            
         });
     }
 

--- a/managed-ledger/src/test/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/managed-ledger/src/test/java/org/apache/zookeeper/MockZooKeeper.java
@@ -665,7 +665,7 @@ public class MockZooKeeper extends ZooKeeper {
         tree.clear();
         watchers.clear();
         executor.shutdownNow();
-        callbackExecutor.shutdown();
+        callbackExecutor.shutdownNow();
     }
 
     void checkProgrammedFail() throws KeeperException {

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -257,7 +257,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
 
         NamespaceBundle bundle = bundles.getBundles().get(0);
-        assertNotNull(ownershipCache.tryAcquiringOwnership(bundle));
+        assertNotNull(ownershipCache.tryAcquiringOwnership(bundle).get());
         assertNotNull(ownershipCache.getOwnedBundle(bundle));
         ownershipCache.removeOwnership(bundles).get();
         assertNull(ownershipCache.getOwnedBundle(bundle));


### PR DESCRIPTION
### Motivation

As discussed in #434 it should help to fix #434, #404 and hopefully #237 

### Modifications

Fix possible dead-lock between MockZooKeeper and `Caffeine.ConcurrentHashMap (from ZKCache)` where 1 thread first takes mutex on MockZk and same thread process callback which eventually hits Caffeine.ConcurrentHashMap and other end 2nd thread first hits Caffeine.ConcurrentHashMap and it tries to get data from MockZk. So, we need to break this deadlock. I will create a PR for MockZk.
