### PR TITLE
C++ Client - fix for seeing correct msg rate in broker stats

### DIFF
--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -76,6 +76,9 @@ PairSharedBuffer Commands::newSend(SharedBuffer& headers, BaseCommand& cmd,
     CommandSend* send = cmd.mutable_send();
     send->set_producer_id(producerId);
     send->set_sequence_id(sequenceId);
+    if (metadata.has_num_messages_in_batch()) {
+        send->set_num_messages(metadata.num_messages_in_batch());
+    }
 
     // / Wire format
     // [TOTAL_SIZE] [CMD_SIZE][CMD] [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA] [PAYLOAD]


### PR DESCRIPTION
### Motivation

Fix for #456

### Modifications

Populated the num_messages field in CommandSend.

### Result

No functional change - just the stats will start showing the correct message rate.