### PR TITLE
Fix test: testNeedBrokerDataUpdate loadReport considers absolute perc…

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -363,10 +363,17 @@ public class ModularLoadManagerImplTest {
         lastData.setMsgRateIn(0);
         assert (!needUpdate.get());
 
-        // Minimally test other values to ensure they are included.
+        // Minimally test other absolute values to ensure they are included.
         lastData.getCpu().usage = 100;
         lastData.getCpu().limit = 1000;
         currentData.getCpu().usage = 106;
+        currentData.getCpu().limit = 1000;
+        assert (!needUpdate.get());
+        
+        // Minimally test other absolute values to ensure they are included.
+        lastData.getCpu().usage = 100;
+        lastData.getCpu().limit = 1000;
+        currentData.getCpu().usage = 206;
         currentData.getCpu().limit = 1000;
         assert (needUpdate.get());
 


### PR DESCRIPTION
…entage change only

Fix test which started failing due to #454 where load-manager considers absolute difference in maximum usage percentage. 