### PR TITLE
update shaded async-http-client property file with 2.0.31 version

### DIFF
--- a/pulsar-client/src/main/resources/ahc.properties
+++ b/pulsar-client/src/main/resources/ahc.properties
@@ -45,3 +45,4 @@ com.yahoo.pulsar.shade.org.asynchttpclient.keepEncodingHeader=false
 com.yahoo.pulsar.shade.org.asynchttpclient.shutdownQuietPeriod=2000
 com.yahoo.pulsar.shade.org.asynchttpclient.shutdownTimeout=15000
 com.yahoo.pulsar.shade.org.asynchttpclient.useNativeTransport=false
+com.yahoo.pulsar.shade.org.asynchttpclient.ioThreadsCount=0


### PR DESCRIPTION
### Motivation

async-http-client-2.0.31 has additional property which should be included into shaded `pulsar-client's ahc.properties` file else async-http-client init fails to parse newly added property `org.asynchttpclient.ioThreadsCount=0`.
```
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:542)
	at java.lang.Integer.parseInt(Integer.java:615)
	at com.yahoo.pulsar.shade.org.asynchttpclient.config.AsyncHttpClientConfigHelper$Config.getInt(AsyncHttpClientConfigHelper.java:105)
```

### Modifications

add newly added property in [async-http-client-2.0.31](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.0.31/client/src/main/resources/ahc-default.properties)

### Result

`pulsar-client` shaded will be able to init async-http-client and can use it for `HttpLookupService`
