### PR TITLE
Internal Producer/Consumer in WebSocketProxy should be closed asynchronously

### DIFF
--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -137,7 +137,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
                             @Override
                             public void writeSuccess() {
                                 if (log.isDebugEnabled()) {
-                                    log.info("[{}/{}] message is delivered successfully to {} ", consumer.getTopic(),
+                                    log.debug("[{}/{}] message is delivered successfully to {} ", consumer.getTopic(),
                                             subscription, getRemote().getInetSocketAddress().toString());
                                 }
                                 updateDeliverMsgStat(msgSize);
@@ -186,9 +186,14 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     public void close() throws IOException {
         if (consumer != null) {
             this.service.removeConsumer(this);
-            consumer.closeAsync().thenAccept(x ->
-                log.debug("[{}] Closed consumer asynchronously", consumer.getTopic())
-            );
+            consumer.closeAsync().thenAccept(x -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Closed consumer asynchronously", consumer.getTopic());
+                }
+            }).exceptionally(exception -> {
+                log.warn("[{}] Failed to close consumer", consumer.getTopic(), exception);
+                return null;
+            });
         }
     }
 

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ConsumerHandler.java
@@ -186,7 +186,9 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     public void close() throws IOException {
         if (consumer != null) {
             this.service.removeConsumer(this);
-            consumer.close();
+            consumer.closeAsync().thenAccept(x ->
+                log.debug("[{}] Closed consumer asynchronously", consumer.getTopic())
+            );
         }
     }
 

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
@@ -83,9 +83,14 @@ public class ProducerHandler extends AbstractWebSocketHandler {
     public void close() throws IOException {
         if (producer != null) {
             this.service.removeProducer(this);
-            producer.closeAsync().thenAccept(x ->
-                log.debug("[{}] Closed producer asynchronously", producer.getTopic())
-            );
+            producer.closeAsync().thenAccept(x -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Closed producer asynchronously", producer.getTopic());
+                }
+            }).exceptionally(exception -> {
+                log.warn("[{}] Failed to close producer", producer.getTopic(), exception);
+                return null;
+            });
         }
     }
 

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/ProducerHandler.java
@@ -83,7 +83,9 @@ public class ProducerHandler extends AbstractWebSocketHandler {
     public void close() throws IOException {
         if (producer != null) {
             this.service.removeProducer(this);
-            producer.close();
+            producer.closeAsync().thenAccept(x ->
+                log.debug("[{}] Closed producer asynchronously", producer.getTopic())
+            );
         }
     }
 


### PR DESCRIPTION
This PR fixes #458.

### Motivation

- PulsarClient uses one "pulsar-client-io-*" thread in WebSocketProxy.
- onWebSocketError method is occasionally called in PulsarClient using "pulsar-client-io-\*".
- onWebSocketError calls producer/consumer close method synchronously, which uses "pulsar-client-io-\*".
- Then, the latter "pulsar-client-io-\*" thread waits and the former "pulsar-client-io-\*" will not end.

### Modifications
- Made producer/consumer closing asynchronously.

### Result
- onWebSocketError doesn't cause thread waiting.