### PR TITLE
Remove bundle from the ephemeral preallocated map once it is loaded

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -182,6 +182,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                 if (log.isDebugEnabled()) {
                     log.debug("Update Received for path {}", path);
                 }
+                reapDeadBrokerPreallocations(data);
                 scheduler.submit(ModularLoadManagerImpl.this::updateAll);
             }
         });
@@ -240,6 +241,30 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                         CreateMode.PERSISTENT);
             } catch (KeeperException.NodeExistsException e) {
                 // Ignore if already exists.
+            }
+        }
+    }
+
+    // For each broker that we have a recent load report, see if they are still alive
+    private void reapDeadBrokerPreallocations(Set<String> aliveBrokers) {
+        for ( String broker : loadData.getBrokerData().keySet() ) {
+            if ( !aliveBrokers.contains(broker)) {
+                if ( log.isDebugEnabled() ) {
+                    log.debug("Broker {} appears to have stopped; now reclaiming any preallocations", broker);
+                }
+                final Iterator<Map.Entry<String, String>> iterator = preallocatedBundleToBroker.entrySet().iterator();
+                while ( iterator.hasNext() ) {
+                    Map.Entry<String, String> entry = iterator.next();
+                    final String preallocatedBundle = entry.getKey();
+                    final String preallocatedBroker = entry.getValue();
+                    if ( broker.equals(preallocatedBroker) ) {
+                        if ( log.isDebugEnabled() ) {
+                            log.debug("Removing old preallocation on dead broker {} for bundle {}",
+                                    preallocatedBroker, preallocatedBundle);
+                        }
+                        iterator.remove();
+                    }
+                }
             }
         }
     }
@@ -415,11 +440,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             // Remove all loaded bundles from the preallocated maps.
             final Map<String, BundleData> preallocatedBundleData = brokerData.getPreallocatedBundleData();
             synchronized (preallocatedBundleData) {
-                for (String bundleName : brokerData.getLocalData().getBundles()) {
-                    if (preallocatedBundleData.containsKey(bundleName)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Preallocated bundle {[]} is now loaded on broker [{}]", bundleName, broker);
-                        }
+                for (String preallocatedBundleName : brokerData.getPreallocatedBundleData().keySet()) {
+                    if (brokerData.getLocalData().getBundles().contains(preallocatedBundleName)) {
                         final Iterator<Map.Entry<String, BundleData>> preallocatedIterator = preallocatedBundleData.entrySet()
                                 .iterator();
                         while (preallocatedIterator.hasNext()) {
@@ -431,10 +453,12 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                             }
                         }
                     }
+
+                    // This is needed too in case a broker which was assigned a bundle dies and comes back up.
+                    if ( preallocatedBundleToBroker.containsKey(preallocatedBundleName) ) {
+                        preallocatedBundleToBroker.remove(preallocatedBundleName);
+                    }
                 }
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("Number of preallocated bundles remaining: {}", preallocatedBundleToBroker.size());
             }
 
             // Using the newest data, update the aggregated time-average data for the current broker.

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -414,17 +414,27 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
 
             // Remove all loaded bundles from the preallocated maps.
             final Map<String, BundleData> preallocatedBundleData = brokerData.getPreallocatedBundleData();
-            // Should not iterate with more than one thread at a time.
             synchronized (preallocatedBundleData) {
-                final Iterator<Map.Entry<String, BundleData>> preallocatedIterator = preallocatedBundleData.entrySet()
-                        .iterator();
-                while (preallocatedIterator.hasNext()) {
-                    final String bundle = preallocatedIterator.next().getKey();
-                    if (bundleData.containsKey(bundle)) {
-                        preallocatedIterator.remove();
-                        preallocatedBundleToBroker.remove(bundle);
+                for (String bundleName : brokerData.getLocalData().getBundles()) {
+                    if (preallocatedBundleData.containsKey(bundleName)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Preallocated bundle {[]} is now loaded on broker [{}]", bundleName, broker);
+                        }
+                        final Iterator<Map.Entry<String, BundleData>> preallocatedIterator = preallocatedBundleData.entrySet()
+                                .iterator();
+                        while (preallocatedIterator.hasNext()) {
+                            final String bundle = preallocatedIterator.next().getKey();
+
+                            if (bundleData.containsKey(bundle)) {
+                                preallocatedIterator.remove();
+                                preallocatedBundleToBroker.remove(bundle);
+                            }
+                        }
                     }
                 }
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Number of preallocated bundles remaining: {}", preallocatedBundleToBroker.size());
             }
 
             // Using the newest data, update the aggregated time-average data for the current broker.


### PR DESCRIPTION
### Motivation

When `ModularLoadManagerImpl` is enabled, all lookup requests get forwarded to a single lead broker for placement. After an assignment is made for the bundle, the result is temporarily saved in an ephemeral _preallocation_ map, the key of which is the bundle name. After the bundle is successfully loaded (usually by a different broker than the lead broker) _and a new load report is written_ (which could several minutes later), the lead broker _should_ remove this map entry. If the bundle is subsequently unloaded or the assigned broker dies, it should go through the same flow and get assigned to a different broker.

There is a bug where these bundles are not being removed from the ephemeral map, even after they show up in the load reports for the target broker. This has two negative side effects:

1. The load manager has incomplete information regarding bundle activity on the brokers, potentially leading to hot brokers (double counting some message rates), but more dangerous:
2. Once a bundle is assigned to a broker, if that broker permanently dies (or is shut down), the load manager keeps assigning the bundle that broker _which is not up_

### Modifications

Remove the ephemeral map entry once a load report is processed indicating the bundle has been loaded.

### Result

Brokers which have recently been shut down will not get assignments, plus better (more even) load balancing of bundles across brokers.
