### PR TITLE
Add debug statement for redelivery message for troubleshoot

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -43,7 +43,6 @@ import com.yahoo.pulsar.client.impl.Backoff;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import com.yahoo.pulsar.common.util.Codec;
 import com.yahoo.pulsar.common.util.collections.ConcurrentLongPairSet;
-import com.yahoo.pulsar.common.util.collections.ConcurrentLongPairSet.LongPair;
 import com.yahoo.pulsar.utils.CopyOnWriteArrayList;
 
 /**
@@ -570,7 +569,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
             messagesToReplay.add(ledgerId, entryId);
         });
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Redelivering unacknowledged messages for consumer ", consumer);
+            log.debug("[{}] Redelivering unacknowledged messages for consumer {}", consumer, messagesToReplay);
         }
         readMoreEntries();
     }
@@ -579,7 +578,7 @@ public class PersistentDispatcherMultipleConsumers implements Dispatcher, ReadEn
     public synchronized void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions) {
         positions.forEach(position -> messagesToReplay.add(position.getLedgerId(), position.getEntryId()));
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Redelivering unacknowledged messages for consumer ", consumer);
+            log.debug("[{}] Redelivering unacknowledged messages for consumer {}", consumer, positions);
         }
         readMoreEntries();
     }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Predicate;
 
@@ -527,5 +528,24 @@ public class ConcurrentLongPairSet {
                 return Long.compare(second, o.second);
             }
         }
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        final AtomicBoolean first = new AtomicBoolean(true);
+        forEach((item1, item2) -> {
+            if (!first.getAndSet(false)) {
+                sb.append(", ");
+            }
+            sb.append('[');
+            sb.append(item1);
+            sb.append(':');
+            sb.append(item2);
+            sb.append(']');
+        });
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentLongPairSetTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/ConcurrentLongPairSetTest.java
@@ -390,5 +390,17 @@ public class ConcurrentLongPairSetTest {
         assertFalse(set.contains(t1, t1));
         assertFalse(set.contains(t1_b, t1_b));
     }
+    
+    @Test
+    public void testToString() {
+
+        ConcurrentLongPairSet set = new ConcurrentLongPairSet();
+
+        set.add(0, 0);
+        set.add(1, 1);
+        set.add(3, 3);
+        final String toString = "{[3:3], [0:0], [1:1]}";
+        assertEquals(set.toString(), toString);
+    }
 
 }


### PR DESCRIPTION
### Motivation

Sometimes client complains about message-redelivery and in order to troubleshoot or verify message-redelivery of messages at broker we need some mechanism to check which messages are sent as part of redelivery. So, for now, adding redelivery messages as part of debug logs.

### Modifications

print redeliver-message in debug logs at broker.

### Result

no functional change.
