### PR TITLE
Shutdown zk cache executor on service shutdown

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/PulsarService.java
@@ -204,6 +204,7 @@ public class PulsarService implements AutoCloseable {
             }
 
             orderedExecutor.shutdown();
+            cacheExecutor.shutdown();
             state = State.Closed;
 
         } catch (Exception e) {


### PR DESCRIPTION
### Motivation

ZK cache executor is not being shutdown on pulsar service close. This causes a big number of threads being leaked in the unit tests execution.