### PR TITLE
Fixed race condition with NPE on Producer.closeAsync()

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ProducerImpl.java
@@ -406,7 +406,8 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
 
         stats.cancelStatsTimeout();
 
-        if (getClientCnx() == null || currentState != State.Ready) {
+        ClientCnx cnx = cnx();
+        if (cnx == null || currentState != State.Ready) {
             log.info("[{}] [{}] Closed Producer (not connected)", topic, producerName);
             synchronized (this) {
                 setState(State.Closed);
@@ -428,7 +429,6 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         ByteBuf cmd = Commands.newCloseProducer(producerId, requestId);
 
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
-        ClientCnx cnx = cnx();
         cnx.sendRequestWithId(cmd, requestId).handle((v, exception) -> {
             cnx.removeProducer(producerId);
             if (exception == null || !cnx.ctx().channel().isActive()) {


### PR DESCRIPTION
### Motivation

As seen sometimes during unit tests, there is a potential NPE in `ProducerImpl.closeAsync()` when the connection is being closed at the same time.

```
2017-06-17 18:08:32,968 - ERROR - [main:TestListener@41] - ------------ Test Failed - com.yahoo.pulsar.client.impl.BrokerClientIntegrationTest / testCloseConnectionOnInternalServerError -- attrs: []
java.lang.NullPointerException
        at com.yahoo.pulsar.client.impl.ProducerImpl.closeAsync(ProducerImpl.java:432)
        at com.yahoo.pulsar.client.impl.PulsarClientImpl.lambda$6(PulsarClientImpl.java:380)
        at java.util.ArrayList.forEach(ArrayList.java:1249)
        at com.yahoo.pulsar.client.impl.PulsarClientImpl.closeAsync(PulsarClientImpl.java:380)
        at com.yahoo.pulsar.client.impl.PulsarClientImpl.close(PulsarClientImpl.java:353)
        at com.yahoo.pulsar.client.impl.BrokerClientIntegrationTest.testCloseConnectionOnInternalServerError(BrokerClientIntegrationTest.java:640)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
        at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:46)
        at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:37)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

### Modifications

Read the `cnx` variable just once. If the connection is being closed in parallel, then `cnx.sendRequestWithId()` will fail with in the future and will be handled in the right way.