### PR TITLE
Use maven-3.5.0 in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,9 @@ install:
   - sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR dep
 
 script:
-    # Java build
-    - mvn license:check test
-
-    # C++ build
-    - sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
+    # Build Java and C++
+    - mvn license:check test && \
+      sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
 
 deploy:
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,28 @@ cache:
   directories:
   - $HOME/.m2
   - $HOME/pulsar-dep
+  - "$HOME/apache-maven-3.5.0"
 
 # Reconstruct the gpg keys to sign the artifacts
 before_deploy:
   - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch || true
   - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch || true
 
+# Upgrade to maven 3.5.0
+before_install:
+  - export M2_HOME=$HOME/apache-maven-3.5.0
+  - if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz | tar zxf - -C $HOME; fi
+  - export PATH=$M2_HOME/bin:$PATH
+
 install:
   - sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR dep
 
-after_success:
-  - sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
+script:
+    # Java build
+    - mvn license:check test
+
+    # C++ build
+    - sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
 
 deploy:
   -


### PR DESCRIPTION
### Motivation

Use latest version of maven in Travis builds, which along with multiple fixes, introduces colored output for builds.