### PR TITLE
Fixed travis build script spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ install:
 
 script:
     # Build Java and C++
-    - mvn license:check test && \
-      sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
+    - mvn license:check test && sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
 
 deploy:
   -


### PR DESCRIPTION
### Motivation

In the last commit I grouped the java and c++ build, to avoid compiling and running C++ tests when java fails (since the broker won't be running and the c++ tests will fail anyway).

Apparently, travis is trying to execute `" sudo"`, with a heading space and not finding it.