### PR TITLE
add timeout for websocket testcase

### DIFF
--- a/pulsar-websocket/src/test/java/com/yahoo/pulsar/proxy/authentication/AuthenticationServiceTest.java
+++ b/pulsar-websocket/src/test/java/com/yahoo/pulsar/proxy/authentication/AuthenticationServiceTest.java
@@ -37,7 +37,7 @@ import com.yahoo.pulsar.broker.authentication.AuthenticationService;
 public class AuthenticationServiceTest {
     private static final String s_authentication_success = "authenticated";
 
-    @Test
+    @Test(timeOut = 10000)
     public void testAuthentication() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();
         Set<String> providersClassNames = Sets.newHashSet(MockAuthenticationProvider.class.getName());
@@ -49,7 +49,7 @@ public class AuthenticationServiceTest {
         service.close();
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void testAuthenticationHttp() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();
         Set<String> providersClassNames = Sets.newHashSet(MockAuthenticationProvider.class.getName());

--- a/pulsar-websocket/src/test/java/com/yahoo/pulsar/websocket/LookupProtocolTest.java
+++ b/pulsar-websocket/src/test/java/com/yahoo/pulsar/websocket/LookupProtocolTest.java
@@ -24,7 +24,7 @@ import com.yahoo.pulsar.websocket.service.WebSocketProxyConfiguration;
 import com.yahoo.pulsar.client.impl.PulsarClientImpl;
 
 public class LookupProtocolTest {
-    @Test
+    @Test(timeOut = 10000)
     public void httpLookupTest() throws Exception{
         WebSocketProxyConfiguration conf = new WebSocketProxyConfiguration();
         conf.setServiceUrl("http://localhost:8080");
@@ -38,7 +38,7 @@ public class LookupProtocolTest {
         service.close();
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void httpsLookupTest() throws Exception{
         WebSocketProxyConfiguration conf = new WebSocketProxyConfiguration();
         conf.setServiceUrl("http://localhost:8080");
@@ -54,7 +54,7 @@ public class LookupProtocolTest {
         service.close();
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void binaryLookupTest() throws Exception{
         WebSocketProxyConfiguration conf = new WebSocketProxyConfiguration();
         conf.setServiceUrl("http://localhost:8080");
@@ -70,7 +70,7 @@ public class LookupProtocolTest {
         service.close();
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void binaryTlsLookupTest() throws Exception{
         WebSocketProxyConfiguration conf = new WebSocketProxyConfiguration();
         conf.setServiceUrl("http://localhost:8080");


### PR DESCRIPTION
### Motivation

At internal build sometimes, build stuck at one of the testcase which doesn't time and build couldn't stop. So, adding timeout for these testcases.

### Modifications

add timeout to testcase.

### Result

No changes.
