### PR TITLE
Add connectionsPerBroker setting to WebSocket proxy

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -34,9 +34,6 @@ webServicePort=8080
 # Port to use to server HTTPS request
 webServicePortTls=8443
 
-# Enable the WebSocket API service in broker
-webSocketServiceEnabled=false
-
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0
 
@@ -320,3 +317,14 @@ brokerServicePurgeInactiveFrequencyInSeconds=60
 
 # Name of load manager to use
 loadManagerClassName=com.yahoo.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl
+
+### --- WebSocket --- ###
+
+# Enable the WebSocket API service in broker
+webSocketServiceEnabled=false
+
+# Number of IO threads in Pulsar Client used in WebSocket proxy
+webSocketNumIoThreads=8
+
+# Number of connections per Broker in Pulsar Client used in WebSocket proxy
+webSocketConnectionsPerBroker=8

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -268,3 +268,14 @@ keepAliveIntervalSeconds=30
 
 # How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected)
 brokerServicePurgeInactiveFrequencyInSeconds=60
+
+### --- WebSocket --- ###
+
+# Enable the WebSocket API service in broker
+webSocketServiceEnabled=true
+
+# Number of IO threads in Pulsar Client used in WebSocket proxy
+webSocketNumIoThreads=8
+
+# Number of connections per Broker in Pulsar Client used in WebSocket proxy
+webSocketConnectionsPerBroker=8

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -39,6 +39,12 @@ bindAddress=0.0.0.0
 # Name of the pulsar cluster to connect to
 clusterName=
 
+# Number of IO threads in Pulsar Client used in WebSocket proxy
+numIoThreads=8
+
+# Number of connections per Broker in Pulsar Client used in WebSocket proxy
+connectionsPerBroker=8
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -280,6 +280,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(dynamic = true)
     private boolean preferLaterVersions = false;
 
+    /**** --- WebSocket --- ****/
+    // Number of IO threads in Pulsar Client used in WebSocket proxy
+    private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
+    // Number of connections per Broker in Pulsar Client used in WebSocket proxy
+    private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
+
     public String getZookeeperServers() {
         return zookeeperServers;
     }
@@ -1019,4 +1025,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     public void setPreferLaterVersions(boolean preferLaterVersions) {
         this.preferLaterVersions = preferLaterVersions;
     }
+
+    public int getWebSocketNumIoThreads() { return webSocketNumIoThreads; }
+
+    public void setWebSocketNumIoThreads(int webSocketNumIoThreads) { this.webSocketNumIoThreads = webSocketNumIoThreads; }
+
+    public int getWebSocketConnectionsPerBroker() { return webSocketConnectionsPerBroker; }
+
+    public void setWebSocketConnectionsPerBroker(int webSocketConnectionsPerBroker) { this.webSocketConnectionsPerBroker = webSocketConnectionsPerBroker; }
 }

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
@@ -177,6 +177,8 @@ public class WebSocketService implements Closeable {
         clientConf.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
         clientConf.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
         clientConf.setIoThreads(WebSocketProxyConfiguration.PULSAR_CLIENT_IO_THREADS);
+        clientConf.setConnectionsPerBroker(WebSocketProxyConfiguration.PULSAR_CLIENT_CONNECTIONS_PER_BROKER);
+
         if (config.isAuthenticationEnabled()) {
             clientConf.setAuthentication(config.getBrokerClientAuthenticationPlugin(),
                     config.getBrokerClientAuthenticationParameters());

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
@@ -176,8 +176,8 @@ public class WebSocketService implements Closeable {
         clientConf.setUseTls(config.isTlsEnabled());
         clientConf.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
         clientConf.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
-        clientConf.setIoThreads(WebSocketProxyConfiguration.PULSAR_CLIENT_IO_THREADS);
-        clientConf.setConnectionsPerBroker(WebSocketProxyConfiguration.PULSAR_CLIENT_CONNECTIONS_PER_BROKER);
+        clientConf.setIoThreads(config.getWebSocketNumIoThreads());
+        clientConf.setConnectionsPerBroker(config.getWebSocketConnectionsPerBroker());
 
         if (config.isAuthenticationEnabled()) {
             clientConf.setAuthentication(config.getBrokerClientAuthenticationPlugin(),
@@ -225,6 +225,8 @@ public class WebSocketService implements Closeable {
         serviceConfig.setTlsCertificateFilePath(config.getTlsCertificateFilePath());
         serviceConfig.setTlsKeyFilePath(config.getTlsKeyFilePath());
         serviceConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
+        serviceConfig.setWebSocketNumIoThreads(config.getNumIoThreads());
+        serviceConfig.setWebSocketConnectionsPerBroker(config.getConnectionsPerBroker());
         return serviceConfig;
     }
 

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -32,6 +32,8 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     public static final int GLOBAL_ZK_THREADS = 8;
     // Number of IO threads in Pulsar Client
     public static final int PULSAR_CLIENT_IO_THREADS = Runtime.getRuntime().availableProcessors();
+    // Number of connections per Broker in Pulsar Client
+    public static final int PULSAR_CLIENT_CONNECTIONS_PER_BROKER = Runtime.getRuntime().availableProcessors();
 
     // Name of the cluster to which this broker belongs to
     @FieldContext(required = true)

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -30,10 +30,6 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     public static final int WEBSOCKET_SERVICE_THREADS = 20;
     // Number of threads used by Global ZK
     public static final int GLOBAL_ZK_THREADS = 8;
-    // Number of IO threads in Pulsar Client
-    public static final int PULSAR_CLIENT_IO_THREADS = Runtime.getRuntime().availableProcessors();
-    // Number of connections per Broker in Pulsar Client
-    public static final int PULSAR_CLIENT_CONNECTIONS_PER_BROKER = Runtime.getRuntime().availableProcessors();
 
     // Name of the cluster to which this broker belongs to
     @FieldContext(required = true)
@@ -70,6 +66,11 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     // Authentication settings of the proxy itself. Used to connect to brokers
     private String brokerClientAuthenticationPlugin;
     private String brokerClientAuthenticationParameters;
+
+    // Number of IO threads in Pulsar Client used in WebSocket proxy
+    private int numIoThreads = Runtime.getRuntime().availableProcessors();
+    // Number of connections per Broker in Pulsar Client used in WebSocket proxy
+    private int connectionsPerBroker = Runtime.getRuntime().availableProcessors();
 
     /***** --- TLS --- ****/
     // Enable TLS
@@ -212,6 +213,14 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     public void setBrokerClientAuthenticationParameters(String brokerClientAuthenticationParameters) {
         this.brokerClientAuthenticationParameters = brokerClientAuthenticationParameters;
     }
+
+    public int getNumIoThreads() { return numIoThreads; }
+
+    public void setNumIoThreads(int numIoThreads) { this.numIoThreads = numIoThreads; }
+
+    public int getConnectionsPerBroker() { return connectionsPerBroker; }
+
+    public void setConnectionsPerBroker(int connectionsPerBroker) { this.connectionsPerBroker = connectionsPerBroker; }
 
     public boolean isTlsEnabled() {
         return tlsEnabled;


### PR DESCRIPTION
### Motivation

Increase `connectionsPerBroker` (default: 1) of WebSocket Proxy for more performance.

### Modification

Added `connectionsPerBroker` setting to WebSocket Proxy.

Note:
For now I naively set `connectionsPerBroker` to `WebSocketProxyConfiguration.PULSAR_CLIENT_IO_THREADS`.
Should I enable to set arbitrary value through `websocket.conf` (or `broker.conf` if WebSocketProxy is running within the same  HTTP server in the broker) ?