### PR TITLE
Fix intermittent LoadBalancerTest due to unpredictable host usage

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -202,8 +202,6 @@ public class LoadBalancerTest {
 
                 LoadReport loadReport = objectMapper.readValue(loadReportData, LoadReport.class);
                 assert (loadReport.getName().equals(lookupAddresses[i]));
-                assertTrue(loadReport.isUnderLoaded());
-                assertFalse(loadReport.isOverLoaded());
 
                 // Check Initial Ranking is populated in both the brokers
                 Field ranking = ((SimpleLoadManagerImpl) pulsarServices[i].getLoadManager().get()).getClass()


### PR DESCRIPTION
### Motivation

`LoadBalancerTest` intermittently fails due to unpredictable host usage. when given test runs on a host which is having other process running may consume resources which can affect unit-test and test can fail intermittently.
```
01:36:10 Tests run: 497, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 970.607 sec <<< FAILURE! - in TestSuite
01:36:10 testLoadReportsWrittenOnZK(com.yahoo.pulsar.broker.loadbalance.LoadBalancerTest)  Time elapsed: 0.035 sec  <<< FAILURE!
01:36:10 java.lang.AssertionError: expected [true] but found [false]
01:36:10 	at com.yahoo.pulsar.broker.loadbalance.LoadBalancerTest.testLoadReportsWrittenOnZK(LoadBalancerTest.java:205)
01:36:10 
01:36:10 
01:36:10 Results :
01:36:10 
01:36:10 Failed tests: 
01:36:10   LoadBalancerTest.testLoadReportsWrittenOnZK:205 expected [true] but found [false]
01:36:10 
01:36:10 Tests run: 497, Failures: 1, Errors: 0, Skipped: 0
```

### Modifications

remove host load assertion.


