### PR TITLE
add wagon-ssh-external extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -684,6 +684,13 @@ flexible messaging model and an intuitive client API.</description>
         </plugin>
       </plugins>
     </pluginManagement>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>2.10</version>
+      </extension>
+    </extensions>
   </build>
 
   <profiles>


### PR DESCRIPTION
### Motivation

Adding `wagon-ssh-external` maven plugin in case if any org/user wants to build custom build and deploy artifact to maven-repo using ssh.

### Modifications

add `wagon-ssh-external` maven plugin to parent `pom.xml`.

### Result

No change for build or deployment.
