### PR TITLE
Refactor HttpLookupService to take ownership of HttpClient

### DIFF
--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/BinaryProtoLookupService.java
@@ -50,26 +50,26 @@ class BinaryProtoLookupService implements LookupService {
             throw new PulsarClientException.InvalidServiceURL(e);
         }
     }
-    
+
     /**
      * Calls broker binaryProto-lookup api to find broker-service address which can serve a given topic.
-     * 
+     *
      * @param destination: topic-name
      * @return broker-socket-address that serves given topic
      */
     public CompletableFuture<InetSocketAddress> getBroker(DestinationName destination) {
         return findBroker(serviceAddress, false, destination);
     }
-    
+
     /**
      * calls broker binaryProto-lookup api to get metadata of partitioned-topic.
-     * 
+     *
      */
     public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(DestinationName destination) {
         return getPartitionedTopicMetadata(serviceAddress, destination);
     }
-    
-    
+
+
     private CompletableFuture<InetSocketAddress> findBroker(InetSocketAddress socketAddress, boolean authoritative,
             DestinationName destination) {
         CompletableFuture<InetSocketAddress> addressFuture = new CompletableFuture<InetSocketAddress>();
@@ -125,8 +125,8 @@ class BinaryProtoLookupService implements LookupService {
         });
         return addressFuture;
     }
-    
-    
+
+
     private CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(InetSocketAddress socketAddress,
             DestinationName destination) {
 
@@ -156,9 +156,14 @@ class BinaryProtoLookupService implements LookupService {
 
         return partitionFuture;
     }
-    
+
     public String getServiceUrl() {
     	return serviceAddress.toString();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // no-op
     }
 
     static class LookupDataResult {
@@ -176,7 +181,7 @@ class BinaryProtoLookupService implements LookupService {
             this.authoritative = authoritative;
             this.redirect = redirect;
         }
-        
+
         public LookupDataResult(int partitions) {
             super();
             this.partitions = partitions;

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/LookupService.java
@@ -30,31 +30,31 @@ import com.yahoo.pulsar.common.partition.PartitionedTopicMetadata;
  * <li><b>Partitioned-topic-Metadata-lookup:</b> lookup to find
  * PartitionedMetadata for a given topic</li>
  * </ul>
- * 
+ *
  */
-interface LookupService {
+interface LookupService extends AutoCloseable {
 
 	/**
 	 * Calls broker lookup-api to get broker {@link InetSocketAddress} which serves namespacebundle that
 	 * contains given topic.
-	 * 
+	 *
 	 * @param destination:
 	 *            topic-name
 	 * @return broker-socket-address that serves given topic
 	 */
 	public CompletableFuture<InetSocketAddress> getBroker(DestinationName topic);
-    
+
 	/**
 	 * Returns {@link PartitionedTopicMetadata} for a given topic.
-	 * 
+	 *
 	 * @param destination : topic-name
 	 * @return
 	 */
 	public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(DestinationName destination);
-	
+
 	/**
 	 * Returns broker-service lookup api url.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getServiceUrl();

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/PulsarClientImpl.java
@@ -58,7 +58,6 @@ public class PulsarClientImpl implements PulsarClient {
     private static final Logger log = LoggerFactory.getLogger(PulsarClientImpl.class);
 
     private final ClientConfiguration conf;
-    private HttpClient httpClient;
     private final LookupService lookup;
     private final ConnectionPool cnxPool;
     private final Timer timer;
@@ -92,9 +91,7 @@ public class PulsarClientImpl implements PulsarClient {
         conf.getAuthentication().start();
         cnxPool = new ConnectionPool(this, eventLoopGroup);
         if (serviceUrl.startsWith("http")) {
-            httpClient = new HttpClient(serviceUrl, conf.getAuthentication(), eventLoopGroup,
-                    conf.isTlsAllowInsecureConnection(), conf.getTlsTrustCertsFilePath());
-            lookup = new HttpLookupService(httpClient, conf.isUseTls());
+            lookup = new HttpLookupService(serviceUrl, conf, eventLoopGroup);
         } else {
             lookup = new BinaryProtoLookupService(this, serviceUrl, conf.isUseTls());
         }
@@ -405,9 +402,7 @@ public class PulsarClientImpl implements PulsarClient {
     @Override
     public void shutdown() throws PulsarClientException {
         try {
-            if (httpClient != null) {
-                httpClient.close();
-            }
+            lookup.close();
             cnxPool.close();
             timer.stop();
             externalExecutorProvider.shutdownNow();


### PR DESCRIPTION
### Motivation

Small refactoring to have `HttpClient` managed by the `HttpLookupService` which is the only user of it.